### PR TITLE
Fix compiling on a case sensitive filesystems

### DIFF
--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -51,7 +51,7 @@
 #endif
 
 #include <EEPROM.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <DNSServer.h>
 #ifndef WLED_DISABLE_OTA
  #include <ArduinoOTA.h>


### PR DESCRIPTION
Fixed:
`fatal error: WiFiUDP.h: No such file or directory`
on a case sensitive filesystems (ext4, btrfs, etc.).
The header from the ESP8266 core library is called [WifiUdp.h](https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/src/WiFiUdp.h).
