### PR TITLE
Fix include filename for WiFiUdp.h

### DIFF
--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -51,7 +51,7 @@
 #endif
 
 #include <EEPROM.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <DNSServer.h>
 #ifndef WLED_DISABLE_OTA
  #include <ArduinoOTA.h>


### PR DESCRIPTION
I didn't find a WiFiUDP.h, but WiFiUdp.h (with lowercase "dp") exists ;-)

Note: I'm new to Arduino and WLED, so please double-check before merging ;-)