### PR TITLE
Added support for APA102 LEDs.

### DIFF
--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -3,13 +3,16 @@
 #define NpbWrapper_h
 
 //PIN CONFIGURATION
+#define BTNPIN 0  //button pin. Needs to have pullup (gpio0 recommended)
 //#define USE_APA102 // Uncomment for using APA102 LEDs.
 #ifdef USE_APA102
  #define CLKPIN 0
  #define DATAPIN 2
-#else
- #define BTNPIN 0  //button pin. Needs to have pullup (gpio0 recommended)
+ #if BTNPIN == CLKPIN || BTNPIN == DATAPIN
+  #undef BTNPIN   // Deactivate button pin if it conflicts with one of the APA102 pins.
+ #endif
 #endif
+
 #define LEDPIN 2  //strip pin. Any for ESP32, gpio2 or 3 is recommended for ESP8266 (gpio2/3 are labeled D4/RX on NodeMCU and Wemos)
 #define IR_PIN 4  //infrared pin (-1 to disable)
 #define RLYPIN 12 //pin for relay, will be set HIGH if LEDs are on (-1 to disable). Also usable for standby leds, triggers,...

--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -3,8 +3,14 @@
 #define NpbWrapper_h
 
 //PIN CONFIGURATION
+//#define USE_APA102 // Uncomment for using APA102 LEDs.
+#ifdef USE_APA102
+ #define CLKPIN 0
+ #define DATAPIN 2
+#else
+ #define BTNPIN 0  //button pin. Needs to have pullup (gpio0 recommended)
+#endif
 #define LEDPIN 2  //strip pin. Any for ESP32, gpio2 or 3 is recommended for ESP8266 (gpio2/3 are labeled D4/RX on NodeMCU and Wemos)
-#define BTNPIN 0  //button pin. Needs to have pullup (gpio0 recommended)
 #define IR_PIN 4  //infrared pin (-1 to disable)
 #define RLYPIN 12 //pin for relay, will be set HIGH if LEDs are on (-1 to disable). Also usable for standby leds, triggers,...
 #define AUXPIN -1 //debug auxiliary output pin (-1 to disable)
@@ -17,7 +23,9 @@
  #define PIXELMETHOD NeoWs2813Method
 #else //esp8266
  //autoselect the right method depending on strip pin
- #if LEDPIN == 2
+ #ifdef USE_APA102
+  #define PIXELMETHOD DotStarMethod
+ #elif LEDPIN == 2
   #define PIXELMETHOD NeoEsp8266Uart1Ws2813Method //if you get an error here, try to change to NeoEsp8266UartWs2813Method or update Neopixelbus
  #elif LEDPIN == 3
   #define PIXELMETHOD NeoEsp8266Dma800KbpsMethod
@@ -29,8 +37,13 @@
 
 
 //you can now change the color order in the web settings
-#define PIXELFEATURE3 NeoGrbFeature
-#define PIXELFEATURE4 NeoGrbwFeature
+#ifdef USE_APA102
+ #define PIXELFEATURE3 DotStarBgrFeature
+ #define PIXELFEATURE4 DotStarLbgrFeature
+#else
+ #define PIXELFEATURE3 NeoGrbFeature
+ #define PIXELFEATURE4 NeoGrbwFeature
+#endif
 
 
 #include <NeoPixelBrightnessBus.h>
@@ -68,12 +81,20 @@ public:
     switch (_type)
     {
       case NeoPixelType_Grb:
+      #ifdef USE_APA102
+        _pGrb = new NeoPixelBrightnessBus<PIXELFEATURE3,PIXELMETHOD>(countPixels, CLKPIN, DATAPIN);
+      #else
         _pGrb = new NeoPixelBrightnessBus<PIXELFEATURE3,PIXELMETHOD>(countPixels, LEDPIN);
+      #endif
         _pGrb->Begin();
       break;
 
       case NeoPixelType_Grbw:
+      #ifdef USE_APA102
+        _pGrbw = new NeoPixelBrightnessBus<PIXELFEATURE4,PIXELMETHOD>(countPixels, CLKPIN, DATAPIN);
+      #else
         _pGrbw = new NeoPixelBrightnessBus<PIXELFEATURE4,PIXELMETHOD>(countPixels, LEDPIN);
+      #endif
         _pGrbw->Begin();
       break;
     }

--- a/wled00/wled05_init.ino
+++ b/wled00/wled05_init.ino
@@ -154,7 +154,9 @@ void beginStrip()
   strip.setColor(0);
   strip.setBrightness(255);
 
+#ifdef BTNPIN
   pinMode(BTNPIN, INPUT_PULLUP);
+#endif
 
   if (bootPreset>0) applyPreset(bootPreset, turnOnAtBoot, true, true);
   colorUpdated(0);
@@ -170,7 +172,11 @@ void beginStrip()
   #endif
 
   //disable button if it is "pressed" unintentionally
+#ifdef BTNPIN
   if(digitalRead(BTNPIN) == LOW) buttonEnabled = false;
+#else
+  buttonEnabled = false;
+#endif
 }
 
 

--- a/wled00/wled09_button.ino
+++ b/wled00/wled09_button.ino
@@ -16,6 +16,7 @@ void shortPressAction()
 
 void handleButton()
 {
+#ifdef BTNPIN
   if (!buttonEnabled) return;
   
   if (digitalRead(BTNPIN) == LOW && !buttonPressedBefore) //pressed
@@ -51,6 +52,7 @@ void handleButton()
     buttonWaitTime = 0;
     shortPressAction();
   }
+#endif
 }
 
 void handleIO()


### PR DESCRIPTION
Uncomment "#define USE_APA102" in NbpWrapper.h.
Connect clock to GPIO 0 and data to GPIO 2.
Choose color order "GRB" in the settings, do not check RGBW.
Tested on ESP-01 with 301 LEDs.