### PR TITLE
Add support for Saskatchewan Timezone

### DIFF
--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -308,15 +308,16 @@ Time zone:
 <option value="3">EET/EEST</option>
 <option value="4">US-EST/EDT</option>
 <option value="5">US-CST/CDT</option>
-<option value="6">US-MST/MDT</option>
-<option value="7">US-AZ</option>
-<option value="8">US-PST/PDT</option>
-<option value="9">CST(AWST)</option>
-<option value="10">JST(KST)</option>
-<option value="11">AEST/AEDT</option>
-<option value="12">NZST/NZDT</option>
-<option value="13">North Korea</option>
-<option value="14">IST (India)</option>
+<option value="6">Saskatchewan</option>
+<option value="7">US-MST/MDT</option>
+<option value="8">US-AZ</option>
+<option value="9">US-PST/PDT</option>
+<option value="10">CST(AWST)</option>
+<option value="11">JST(KST)</option>
+<option value="12">AEST/AEDT</option>
+<option value="13">NZST/NZDT</option>
+<option value="14">North Korea</option>
+<option value="15">IST (India)</option>
 </select><br>
 UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 Current local time is <span class="times">unknown</span>.

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -308,16 +308,16 @@ Time zone:
 <option value="3">EET/EEST</option>
 <option value="4">US-EST/EDT</option>
 <option value="5">US-CST/CDT</option>
-<option value="6">Saskatchewan</option>
-<option value="7">US-MST/MDT</option>
-<option value="8">US-AZ</option>
-<option value="9">US-PST/PDT</option>
-<option value="10">CST(AWST)</option>
-<option value="11">JST(KST)</option>
-<option value="12">AEST/AEDT</option>
-<option value="13">NZST/NZDT</option>
-<option value="14">North Korea</option>
-<option value="15">IST (India)</option>
+<option value="6">US-MST/MDT</option>
+<option value="7">US-AZ</option>
+<option value="8">US-PST/PDT</option>
+<option value="9">CST(AWST)</option>
+<option value="10">JST(KST)</option>
+<option value="11">AEST/AEDT</option>
+<option value="12">NZST/NZDT</option>
+<option value="13">North Korea</option>
+<option value="14">IST (India)</option>
+<option value="15">CA-Saskatchewan</option>
 </select><br>
 UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 Current local time is <span class="times">unknown</span>.

--- a/wled00/wled10_ntp.ino
+++ b/wled00/wled10_ntp.ino
@@ -57,7 +57,7 @@ Timezone tzNK(NKST, NKST);
 TimeChangeRule IST = {Last, Sun, Mar, 1, 330};     // India Standard Time = UTC + 5.5 hours
 Timezone tzIndia(IST, IST);
 
-Timezone* timezones[] = {&tzUTC, &tzUK, &tzEUCentral, &tzEUEastern, &tzUSEastern, &tzUSCentral, &tzCASaskatchewan, &tzUSMountain, &tzUSArizona, &tzUSPacific, &tzChina, &tzJapan, &tzAUEastern, &tzNZ, &tzNK, &tzIndia};  
+Timezone* timezones[] = {&tzUTC, &tzUK, &tzEUCentral, &tzEUEastern, &tzUSEastern, &tzUSCentral, &tzUSMountain, &tzUSArizona, &tzUSPacific, &tzChina, &tzJapan, &tzAUEastern, &tzNZ, &tzNK, &tzIndia, &tzCASaskatchewan};  
 
 void handleNetworkTime()
 {

--- a/wled00/wled10_ntp.ino
+++ b/wled00/wled10_ntp.ino
@@ -25,6 +25,8 @@ TimeChangeRule CDT = {Second, Sun, Mar, 2, -300 };    //Daylight time = UTC - 5 
 TimeChangeRule CST = {First, Sun, Nov, 2, -360 };     //Standard time = UTC - 6 hours
 Timezone tzUSCentral(CDT, CST);
 
+Timezone tzCASaskatchewan(CST, CST); //Central without DST
+
 TimeChangeRule MDT = {Second, Sun, Mar, 2, -360 };    //Daylight time = UTC - 6 hours
 TimeChangeRule MST = {First, Sun, Nov, 2, -420 };     //Standard time = UTC - 7 hours
 Timezone tzUSMountain(MDT, MST);
@@ -55,7 +57,7 @@ Timezone tzNK(NKST, NKST);
 TimeChangeRule IST = {Last, Sun, Mar, 1, 330};     // India Standard Time = UTC + 5.5 hours
 Timezone tzIndia(IST, IST);
 
-Timezone* timezones[] = {&tzUTC, &tzUK, &tzEUCentral, &tzEUEastern, &tzUSEastern, &tzUSCentral, &tzUSMountain, &tzUSArizona, &tzUSPacific, &tzChina, &tzJapan, &tzAUEastern, &tzNZ, &tzNK, &tzIndia};  
+Timezone* timezones[] = {&tzUTC, &tzUK, &tzEUCentral, &tzEUEastern, &tzUSEastern, &tzUSCentral, &tzCASaskatchewan, &tzUSMountain, &tzUSArizona, &tzUSPacific, &tzChina, &tzJapan, &tzAUEastern, &tzNZ, &tzNK, &tzIndia};  
 
 void handleNetworkTime()
 {


### PR DESCRIPTION
This PR adds support for the Saskatchewan Timezone (America/Regina) UTC-6 (CST no DST).