### PR TITLE
Pin ESPAsyncUDP version to avoid unexpected behavior

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ lib_deps_external =
   FastLED@3.3.2
   NeoPixelBus@2.5.1
   ESPAsyncTCP@1.2.0
-  ESPAsyncUDP
+  ESPAsyncUDP@697c75a025
   AsyncTCP@1.0.3
   Esp Async WebServer@1.2.0
   #ArduinoJson@5.13.5


### PR DESCRIPTION
Fix ESPAsyncUDP version, to avoid unexpected behavior if the library is updated with braking changes