### PR TITLE
Added Arduino Core 2.6.1 and 2.6.2 and made 2.6.2 default

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,8 +58,10 @@ arduino_core_2_4_1 = espressif8266@1.7.3
 arduino_core_2_4_2 = espressif8266@1.8.0
 arduino_core_2_5_0 = espressif8266@2.0.4
 arduino_core_2_5_2 = espressif8266@2.2.3
+arduino_core_2_6_1 = espressif8266@2.3.0
+arduino_core_2_6_2 = espressif8266@2.3.1
 arduino_core_stage = https://github.com/platformio/platform-espressif8266.git#feature/stage
-platform = ${common:esp8266.arduino_core_2_5_2}
+platform = ${common:esp8266.arduino_core_2_6_2}
 build_flags =
   -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
   -Wl,-Teagle.flash.4m1m.ld  ;;;; Required for core > v2.5.0 or staging version 4MB Flash 3MB SPIFFs


### PR DESCRIPTION
2.4.2 was default for NodeMCU and caused a boot loop for me. Even erasing and re-flashing didn't solve the problem. With core 2.6.2 it seems to be fine.