### PR TITLE
modify /usermods/ssd1306_i2c_oled_u8g2/ to be slightly more robust. 

### DIFF
--- a/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
+++ b/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
@@ -80,9 +80,9 @@ void userLoop() {
 
   // First row with Wifi name
   u8x8.setCursor(1, 0);
-  u8x8.print(ssid.substring(0, u8x8.getCols() > 1 ? u8x8.getCols() - 2 : 0));
+  u8x8.print(knownSsid.substring(0, u8x8.getCols() > 1 ? u8x8.getCols() - 2 : 0));
   // Print `~` char to indicate that SSID is longer, than owr dicplay
-  if (ssid.length() > u8x8.getCols())
+  if (knownSsid.length() > u8x8.getCols())
     u8x8.print("~");
 
   // Second row with IP or Psssword
@@ -91,7 +91,7 @@ void userLoop() {
   if (apActive && bri == 0)
     u8x8.print(apPass);
   else
-    u8x8.print(ip);
+    u8x8.print(knownIp);
 
   // Third row with mode name
   u8x8.setCursor(2, 2);

--- a/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
+++ b/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
@@ -69,7 +69,7 @@ void userLoop() {
   needRedraw = false;
 
   // Update last known values.
-  #ifdef(ESP8266)
+  #if defined(ESP8266)
   knownSsid = apActive ? WiFi.softAPSSID() : WiFi.SSID();
   #else
   knownSsid = WiFi.SSID();

--- a/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
+++ b/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
@@ -1,12 +1,18 @@
 #include <U8x8lib.h> // from https://github.com/olikraus/u8g2/
 
+//The SCL and SDA pins are defined here. 
+//Lolin32 boards use SCL=4 SDA=5 
+#define U8X8_PIN_SCL 5
+#define U8X8_PIN_SDA 4
+
+
 // If display does not work or looks corrupted check the
 // constructor reference:
 // https://github.com/olikraus/u8g2/wiki/u8x8setupcpp
 // or check the gallery:
 // https://github.com/olikraus/u8g2/wiki/gallery
-U8X8_SSD1306_128X32_UNIVISION_HW_I2C u8x8(U8X8_PIN_NONE, 5,
-                                          4); // Pins are Reset, SCL, SDA
+U8X8_SSD1306_128X32_UNIVISION_HW_I2C u8x8(U8X8_PIN_NONE, U8X8_PIN_SCL,
+                                          U8X8_PIN_SDA); // Pins are Reset, SCL, SDA
 
 // gets called once at boot. Do all initialization that doesn't depend on
 // network here

--- a/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
+++ b/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
@@ -69,7 +69,11 @@ void userLoop() {
   needRedraw = false;
 
   // Update last known values.
+  #ifdef(ESP8266)
   knownSsid = apActive ? WiFi.softAPSSID() : WiFi.SSID();
+  #else
+  knownSsid = WiFi.SSID();
+  #endif
   knownIp = apActive ? IPAddress(4, 3, 2, 1) : WiFi.localIP();
   knownBrightness = bri;
   knownMode = strip.getMode();


### PR DESCRIPTION
I made a few small modifications to make this usermod work with esp32 boards and make it slightly easier to redefine the SCL and SDA pins to make them work with other boards like the lolin32 boards with built in OLEDs. 