### PR TITLE
OLED contrast set to 10

### DIFF
--- a/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
+++ b/usermods/ssd1306_i2c_oled_u8g2/wled06_usermod.ino
@@ -19,6 +19,7 @@ U8X8_SSD1306_128X32_UNIVISION_HW_I2C u8x8(U8X8_PIN_NONE, U8X8_PIN_SCL,
 void userSetup() {
   u8x8.begin();
   u8x8.setPowerSave(0);
+    u8x8.setContrast(10); //Contrast setup will help to preserve OLED lifetime. In case OLED need to be brighter increase number up to 255
   u8x8.setFont(u8x8_font_chroma48medium8_r);
   u8x8.drawString(0, 0, "Loading...");
 }


### PR DESCRIPTION
Another OLED lifetime saving feature. With set to 10 is bright enough to see all labels, even more readable on cheap OLEDs.