### PR TITLE
ESP32 support for solid (analog) RGB(W) stripes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -197,7 +197,7 @@ build_flags =
   ${common.build_flags}
   ${common:esp8266_1M.build_flags}
   -D WLED_DISABLE_HUESYNC
-  -D WLED_ENABLE_ANALOG_LEDS
+  -D WLED_USE_ANALOG_LEDS
 lib_deps =
   ${common.lib_deps_external}
 
@@ -211,7 +211,7 @@ build_flags =
   ${common.build_flags}
   ${common:esp8266_1M.build_flags}
   -D WLED_DISABLE_HUESYNC
-  -D WLED_ENABLE_ANALOG_LEDS
+  -D WLED_USE_ANALOG_LEDS
   -D WLED_USE_H801
 lib_deps =
   ${common.lib_deps_external}
@@ -226,7 +226,7 @@ build_flags =
   ${common.build_flags}
   ${common:esp8266_1M.build_flags}
   -D WLED_DISABLE_HUESYNC
-  -D WLED_ENABLE_ANALOG_LEDS
+  -D WLED_USE_ANALOG_LEDS
   -D WLED_USE_H801
   -D WLED_ENABLE_5CH_LEDS 
 lib_deps =


### PR DESCRIPTION
Uses ledc funtion to drive analog RGB(W) stripes with 3, 4 or 5 channels.

...this time only this single change :-)

Also important for the last PR:
the define in platformio.ini needs to be "WLED_USE_ANALOG_LEDS" - I changed this in the PR, too.