### PR TITLE
More IR remotes (24/40/44-keys) and select them in the settings

### DIFF
--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -187,7 +187,7 @@ const char PAGE_settings_sync[] PROGMEM = R"=====(<!DOCTYPE html>
 <h2>Sync setup</h2>
 <h3>Button setup</h3>
 On/Off button enabled: <input type="checkbox" name="BT"><br>
-Infrared receiver enabled: <input type="checkbox" name="IR"><br>
+Infrared receiver type (0 = disabled): <input name="IR" type="number" min="0" max="4" required><br>
 <a href="https://github.com/Aircoookie/WLED/wiki/Infrared-Control" target="_blank">IR info</a>
 <h3>WLED Broadcast</h3>
 UDP Port: <input name="UP" type="number" min="1" max="65535" required><br>

--- a/wled00/ir_codes.h
+++ b/wled00/ir_codes.h
@@ -30,52 +30,145 @@
 #define IR24_FADE      0xF7C837 
 #define IR24_SMOOTH    0xF7E817 
 
-/* 44-key defs, to be done later
-#define IR44_BPlus  0xFF3AC5  // 
-#define IR44_BMinus 0xFFBA45  // 
-#define IR44_ON     0xFF827D  // 
-#define IR44_OFF    0xFF02FD  // 
-#define IR44_R      0xFF1AE5  // 
-#define IR44_G      0xFF9A65  // 
-#define IR44_B      0xFFA25D  // 
-#define IR44_W      0xFF22DD  // 
-#define IR44_B1     0xFF2AD5  // 
-#define IR44_B2     0xFFAA55  // 
-#define IR44_B3     0xFF926D  // 
-#define IR44_B4     0xFF12ED  // 
-#define IR44_B5     0xFF0AF5  // 
-#define IR44_B6     0xFF8A75  // 
-#define IR44_B7     0xFFB24D  // 
-#define IR44_B8     0xFF32CD  // 
-#define IR44_B9     0xFF38C7  // 
-#define IR44_B10    0xFFB847  // 
-#define IR44_B11    0xFF7887  // 
-#define IR44_B12    0xFFF807  // 
-#define IR44_B13    0xFF18E7  // 
-#define IR44_B14    0xFF9867  // 
-#define IR44_B15    0xFF58A7  // 
-#define IR44_B16    0xFFD827  // 
-#define IR44_UPR    0xFF28D7  // 
-#define IR44_UPG    0xFFA857  // 
-#define IR44_UPB    0xFF6897  // 
-#define IR44_QUICK  0xFFE817  // 
-#define IR44_DOWNR  0xFF08F7  // 
-#define IR44_DOWNG  0xFF8877  // 
-#define IR44_DOWNB  0xFF48B7  // 
-#define IR44_SLOW   0xFFC837  // 
-#define IR44_DIY1   0xFF30CF  // 
-#define IR44_DIY2   0xFFB04F  // 
-#define IR44_DIY3   0xFF708F  // 
-#define IR44_AUTO   0xFFF00F  // 
-#define IR44_DIY4   0xFF10EF  // 
-#define IR44_DIY5   0xFF906F  // 
-#define IR44_DIY6   0xFF50AF  // 
-#define IR44_FLASH  0xFFD02F  // 
-#define IR44_JUMP3  0xFF20DF  // 
-#define IR44_JUMP7  0xFFA05F  // 
-#define IR44_FADE3  0xFF609F  // 
-#define IR44_FADE7  0xFFE01F  // 
-*/
+// 24-key defs for white remote control with CW / WW / CT+ and CT- keys (from ALDI LED pillar lamp)
+#define IR24_CT_BRIGHTER   0xF700FF // BRI +
+#define IR24_CT_DARKER     0xF7807F // BRI -
+#define IR24_CT_OFF        0xF740BF // OFF
+#define IR24_CT_ON         0xF7C03F // ON
+#define IR24_CT_RED        0xF720DF // RED
+#define IR24_CT_REDDISH    0xF710EF // REDDISH
+#define IR24_CT_ORANGE     0xF730CF // ORANGE
+#define IR24_CT_YELLOWISH  0xF708F7 // YELLOWISH
+#define IR24_CT_YELLOW     0xF728D7 // YELLOW
+#define IR24_CT_GREEN      0xF7A05F // GREEN
+#define IR24_CT_GREENISH   0xF7906F // GREENISH
+#define IR24_CT_TURQUOISE  0xF7B04F // TURQUOISE
+#define IR24_CT_CYAN       0xF78877 // CYAN
+#define IR24_CT_AQUA       0xF7A857 // AQUA
+#define IR24_CT_BLUE       0xF7609F // BLUE
+#define IR24_CT_DEEPBLUE   0xF750AF // DEEPBLUE
+#define IR24_CT_PURPLE     0xF7708F // PURPLE
+#define IR24_CT_MAGENTA    0xF748B7 // MAGENTA
+#define IR24_CT_PINK       0xF76897 // PINK
+#define IR24_CT_COLDWHITE  0xF7E01F // CW
+#define IR24_CT_WARMWHITE  0xF7D02F // WW
+#define IR24_CT_CTPLUS     0xF7F00F // CT+
+#define IR24_CT_CTMINUS    0xF7C837 // CT-
+#define IR24_CT_MEMORY     0xF7E817 // MEMORY
+
+// 24-key defs for old remote control 
+#define IR24_OLD_BRIGHTER  0xFF906F // Brightness Up     
+#define IR24_OLD_DARKER    0xFFB847 // Brightness Down   
+#define IR24_OLD_OFF       0xFFF807 // Power OFF         
+#define IR24_OLD_ON        0xFFB04F // Power On          
+#define IR24_OLD_RED       0xFF9867 // RED               
+#define IR24_OLD_REDDISH   0xFFE817 // Light RED		
+#define IR24_OLD_ORANGE    0xFF02FD // Orange            
+#define IR24_OLD_YELLOWISH 0xFF50AF // Light Orange		
+#define IR24_OLD_YELLOW    0xFF38C7 // YELLOW            
+#define IR24_OLD_GREEN     0xFFD827 // GREEN             
+#define IR24_OLD_GREENISH  0xFF48B7 // Light GREEN		
+#define IR24_OLD_TURQUOISE 0xFF32CD // TURQUOISE         
+#define IR24_OLD_CYAN      0xFF7887 // CYAN
+#define IR24_OLD_AQUA      0xFF28D7 // AQUA	
+#define IR24_OLD_BLUE      0xFF8877 // BLUE              
+#define IR24_OLD_DEEPBLUE  0xFF6897 // Dark BLUE
+#define IR24_OLD_PURPLE    0xFF20DF // PURPLE		
+#define IR24_OLD_MAGENTA   0xFF708F // MAGENTA           
+#define IR24_OLD_PINK      0xFFF00F // PINK              
+#define IR24_OLD_WHITE     0xFFA857 // WHITE             
+#define IR24_OLD_FLASH     0xFFB24D // FLASH Mode       
+#define IR24_OLD_STROBE    0xFF00FF // STROBE Mode       
+#define IR24_OLD_FADE      0xFF58A7 // FADE Mode         
+#define IR24_OLD_SMOOTH    0xFF30CF // SMOOTH Mode       
+
+// 40-key defs for blue remote control 
+#define IR40_BPLUS         0xFF3AC5  // 
+#define IR40_BMINUS        0xFFBA45  // 
+#define IR40_OFF           0xFF827D  // 
+#define IR40_ON            0xFF02FD  // 
+#define IR40_RED           0xFF1AE5  // 
+#define IR40_GREEN         0xFF9A65  // 
+#define IR40_BLUE          0xFFA25D  // 
+#define IR40_WHITE         0xFF22DD  // natural white
+#define IR40_REDDISH       0xFF2AD5  // 
+#define IR40_GREENISH      0xFFAA55  // 
+#define IR40_DEEPBLUE      0xFF926D  // 
+#define IR40_WARMWHITE2    0xFF12ED  // warmest white
+#define IR40_ORANGE        0xFF0AF5  // 
+#define IR40_TURQUOISE     0xFF8A75  // 
+#define IR40_PURPLE        0xFFB24D  // 
+#define IR40_WARMWHITE     0xFF32CD  // warm white
+#define IR40_YELLOWISH     0xFF38C7  // 
+#define IR40_CYAN          0xFFB847  // 
+#define IR40_MAGENTA       0xFF7887  // 
+#define IR40_COLDWHITE     0xFFF807  // cold white
+#define IR40_YELLOW        0xFF18E7  // 
+#define IR40_AQUA          0xFF9867  // 
+#define IR40_PINK          0xFF58A7  // 
+#define IR40_COLDWHITE2    0xFFD827  // coldest white
+#define IR40_WPLUS         0xFF28D7  // white chanel bright plus
+#define IR40_WMINUS        0xFFA857  // white chanel bright minus
+#define IR40_WOFF          0xFF6897  // white chanel on
+#define IR40_WON           0xFFE817  // white chanel off
+#define IR40_W25           0xFF08F7  // white chanel 25%
+#define IR40_W50           0xFF8877  // white chanel 50%
+#define IR40_W75           0xFF48B7  // white chanel 75%
+#define IR40_W100          0xFFC837  // white chanel 100%
+#define IR40_JUMP3         0xFF30CF  // JUMP3
+#define IR40_FADE3         0xFFB04F  // FADE3
+#define IR40_JUMP7         0xFF708F  // JUMP7
+#define IR40_QUICK         0xFFF00F  // QUICK
+#define IR40_FADE7         0xFF10EF  // FADE7
+#define IR40_FLASH         0xFF906F  // FLASH
+#define IR40_AUTO          0xFF50AF  // AUTO
+#define IR40_SLOW          0xFFD02F  // SLOW
+
+// 44-key defs, to be done later
+#define IR44_BPLUS         0xFF3AC5  // 
+#define IR44_BMINUS        0xFFBA45  // 
+#define IR44_OFF           0xFF827D  // 
+#define IR44_ON            0xFF02FD  // 
+#define IR44_RED           0xFF1AE5  // 
+#define IR44_GREEN         0xFF9A65  // 
+#define IR44_BLUE          0xFFA25D  // 
+#define IR44_WHITE         0xFF22DD  // natural white
+#define IR44_REDDISH       0xFF2AD5  // 
+#define IR44_GREENISH      0xFFAA55  // 
+#define IR44_DEEPBLUE      0xFF926D  // 
+#define IR44_WARMWHITE2    0xFF12ED  // warmest white
+#define IR44_ORANGE        0xFF0AF5  // 
+#define IR44_TURQUOISE     0xFF8A75  // 
+#define IR44_PURPLE        0xFFB24D  // 
+#define IR44_WARMWHITE     0xFF32CD  // warm white
+#define IR44_YELLOWISH     0xFF38C7  // 
+#define IR44_CYAN          0xFFB847  // 
+#define IR44_MAGENTA       0xFF7887  // 
+#define IR44_COLDWHITE     0xFFF807  // cold white
+#define IR44_YELLOW        0xFF18E7  // 
+#define IR44_AQUA          0xFF9867  // 
+#define IR44_PINK          0xFF58A7  // 
+#define IR44_COLDWHITE2    0xFFD827  // coldest white
+#define IR44_REDPLUS       0xFF28D7  // 
+#define IR44_GREENPLUS     0xFFA857  // 
+#define IR44_BLUEPLUS      0xFF6897  // 
+#define IR44_QUICK         0xFFE817  // 
+#define IR44_REDMINUS      0xFF08F7  // 
+#define IR44_GREENMINUS    0xFF8877  // 
+#define IR44_BLUEMINUS     0xFF48B7  // 
+#define IR44_SLOW          0xFFC837  // 
+#define IR44_DIY1          0xFF30CF  // 
+#define IR44_DIY2          0xFFB04F  // 
+#define IR44_DIY3          0xFF708F  // 
+#define IR44_AUTO          0xFFF00F  // 
+#define IR44_DIY4          0xFF10EF  // 
+#define IR44_DIY5          0xFF906F  // 
+#define IR44_DIY6          0xFF50AF  // 
+#define IR44_FLASH         0xFFD02F  // 
+#define IR44_JUMP3         0xFF20DF  // 
+#define IR44_JUMP7         0xFFA05F  // 
+#define IR44_FADE3         0xFF609F  // 
+#define IR44_FADE7         0xFFE01F  // 
 
 #define COLOR_RED       0xFF0000
 #define COLOR_REDDISH   0xFF7800
@@ -93,3 +186,13 @@
 #define COLOR_MAGENTA   0xFF00DC
 #define COLOR_PINK      0xFF00A0
 #define COLOR_WHITE     0xFFFFDC
+#define COLOR_WARMWHITE2     0xFFAA69
+#define COLOR_WARMWHITE      0xFFBF8E 
+#define COLOR_NEUTRALWHITE   0xFFD4B4
+#define COLOR_COLDWHITE      0xFFE9D9
+#define COLOR_COLDWHITE2     0xFFFFFF
+#define COLOR2_WARMWHITE2    0xFFFF9900
+#define COLOR2_WARMWHITE     0xFF825A00 
+#define COLOR2_NEUTRALWHITE  0xFF000000
+#define COLOR2_COLDWHITE     0xFF7F7F7F
+#define COLOR2_COLDWHITE2    0xFFFFFFFF

--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -85,9 +85,6 @@
 
 #ifdef ARDUINO_ARCH_ESP32
   #undef WLED_USE_ANALOG_LEDS  // Solid RGBW not implemented for ESP32 yet
- /*#ifndef WLED_DISABLE_INFRARED
-  #include <IRremote.h>
- #endif*/ //there are issues with ESP32 infrared, so it is disabled for now
 #else
  #ifndef WLED_DISABLE_INFRARED
   #include <IRremoteESP8266.h>
@@ -160,7 +157,7 @@ bool syncToggleReceive = false;               //UIs which only have a single but
 
 //Sync CONFIG
 bool buttonEnabled =  true;
-bool irEnabled     = false;                   //Infrared receiver
+byte irEnabled     =  0;                      //Infrared receiver
 
 uint16_t udpPort    = 21324;                  //WLED notifier default port
 uint16_t udpRgbPort = 19446;                  //Hyperion port
@@ -288,6 +285,7 @@ byte briOld = 0;
 byte briT = 0;
 byte briIT = 0;
 byte briLast = 128;                           //brightness before turned off. Used for toggle function
+byte whiteLast = 128;                         //white channel before turned off. Used for toggle function
 
 //button
 bool buttonPressedBefore = false;
@@ -507,6 +505,7 @@ void setup() {
 
 //main program loop
 void loop() {
+  handleIR();          //2nd call to function needed for ESP32 to return valid results -- should be good for ESP8266, too
   handleConnection();
   handleSerial();
   handleNotifications();

--- a/wled00/wled02_xml.ino
+++ b/wled00/wled02_xml.ino
@@ -249,7 +249,7 @@ void getSettingsJS(byte subPage, char* dest)
   if (subPage == 4)
   {
     sappend('c',"BT",buttonEnabled);
-    sappend('c',"IR",irEnabled);
+    sappend('v',"IR",irEnabled);
     sappend('v',"UP",udpPort);
     sappend('c',"RB",receiveNotificationBrightness);
     sappend('c',"RC",receiveNotificationColor);

--- a/wled00/wled03_set.ino
+++ b/wled00/wled03_set.ino
@@ -120,7 +120,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
   if (subPage == 4)
   {
     buttonEnabled = request->hasArg("BT");
-    irEnabled = request->hasArg("IR");
+    irEnabled = request->arg("IR").toInt();
     int t = request->arg("UP").toInt();
     if (t > 0) udpPort = t;
     receiveNotificationBrightness = request->hasArg("RB");

--- a/wled00/wled14_colors.ino
+++ b/wled00/wled14_colors.ino
@@ -17,6 +17,29 @@ void colorFromUint32(uint32_t in, bool secondary)
   }
 }
 
+//load a color without affecting the white channel
+void colorFromUint24(uint32_t in, bool secondary = false)
+{
+  if (secondary) {
+    colSec[0] = in >> 16 & 0xFF;
+    colSec[1] = in >> 8  & 0xFF;
+    colSec[2] = in       & 0xFF;
+  } else {
+    col[0] = in >> 16 & 0xFF;
+    col[1] = in >> 8  & 0xFF;
+    col[2] = in       & 0xFF;
+  }
+}
+
+//relatively change white brightness, minumum A=5
+void relativeChangeWhite(int8_t amount, byte lowerBoundary =0)
+{
+  int16_t new_val = (int16_t) col[3] + amount;
+  if (new_val > 0xFF) new_val = 0xFF;
+  else if (new_val < lowerBoundary) new_val = lowerBoundary;
+  col[3] = new_val;
+}
+
 void colorHStoRGB(uint16_t hue, byte sat, byte* rgb) //hue, sat to rgb
 {
   float h = ((float)hue)/65535.0;

--- a/wled00/wled20_ir.ino
+++ b/wled00/wled20_ir.ino
@@ -48,11 +48,11 @@ void decodeIR(uint32_t code)
   if (code == 0xFFFFFFFF) //repeated code, continue brightness up/down
   {
     irTimesRepeated++;
-    if (lastValidCode == IR24_BRIGHTER | lastValidCode == IR40_BPLUS )
+    if (lastValidCode == IR24_BRIGHTER || lastValidCode == IR40_BPLUS )
     { 
       relativeChange(&bri, 10); colorUpdated(2);
     }
-    else if (lastValidCode == IR24_DARKER | lastValidCode == IR40_BMINUS )
+    else if (lastValidCode == IR24_DARKER || lastValidCode == IR40_BMINUS )
     {
       relativeChange(&bri, -10, 5); colorUpdated(2);
     }
@@ -64,7 +64,7 @@ void decodeIR(uint32_t code)
     {
       relativeChangeWhite(-10, 5); colorUpdated(2);
     }
-    else if ((lastValidCode == IR24_ON | lastValidCode == IR40_ON) && irTimesRepeated > 7 )
+    else if ((lastValidCode == IR24_ON || lastValidCode == IR40_ON) && irTimesRepeated > 7 )
     {
       nightlightActive = true;
       nightlightStartTime = millis();

--- a/wled00/wled20_ir.ino
+++ b/wled00/wled20_ir.ino
@@ -1,8 +1,8 @@
 /*
- * Infrared sensor support for generic 24 key RGB remote
+ * Infrared sensor support for generic 24/40/44 key RGB remotes
  */
 
-#if defined(WLED_DISABLE_INFRARED) || defined(ARDUINO_ARCH_ESP32)
+#if defined(WLED_DISABLE_INFRARED)
 void handleIR(){}
 #else
 
@@ -48,15 +48,23 @@ void decodeIR(uint32_t code)
   if (code == 0xFFFFFFFF) //repeated code, continue brightness up/down
   {
     irTimesRepeated++;
-    if (lastValidCode == IR24_BRIGHTER)
+    if (lastValidCode == IR24_BRIGHTER | lastValidCode == IR40_BPLUS )
     { 
       relativeChange(&bri, 10); colorUpdated(2);
     }
-    else if (lastValidCode == IR24_DARKER)
+    else if (lastValidCode == IR24_DARKER | lastValidCode == IR40_BMINUS )
     {
       relativeChange(&bri, -10, 5); colorUpdated(2);
     }
-    else if (lastValidCode == IR24_ON && irTimesRepeated > 7)
+    if (lastValidCode == IR40_WPLUS)
+    { 
+      relativeChangeWhite(10); colorUpdated(2);
+    }
+    else if (lastValidCode == IR40_WMINUS)
+    {
+      relativeChangeWhite(-10, 5); colorUpdated(2);
+    }
+    else if ((lastValidCode == IR24_ON | lastValidCode == IR40_ON) && irTimesRepeated > 7 )
     {
       nightlightActive = true;
       nightlightStartTime = millis();
@@ -68,8 +76,16 @@ void decodeIR(uint32_t code)
 
   if (decodeIRCustom(code)) return;
   if      (code > 0xFFFFFF) return; //invalid code
-  else if (code > 0xFF0000) decodeIR44(code); //is in 44-key remote range
   else if (code > 0xF70000 && code < 0xF80000) decodeIR24(code); //is in 24-key remote range
+  else if (code > 0xFF0000) {
+    switch (irEnabled) {
+      case 1: decodeIR24OLD(code); break;  // white 24-key remote (old) - it sends 0xFF0000 values
+      case 2: decodeIR24CT(code);  break;  // white 24-key remote with CW, WW, CT+ and CT- keys
+      case 3: decodeIR40(code);    break;  // blue  40-key remote with 25%, 50%, 75% and 100% keys
+      case 4: decodeIR44(code);    break;  // white 44-key remote with color-up/down keys and DIY1 to 6 keys 
+      default: return;
+    }
+  }
   //code <= 0xF70000 also invalid
 }
 
@@ -107,16 +123,202 @@ void decodeIR24(uint32_t code)
   colorUpdated(2); //for notifier, IR is considered a button input
 }
 
+void decodeIR24OLD(uint32_t code)
+{
+  switch (code) {
+    case IR24_OLD_BRIGHTER  : relativeChange(&bri, 10);            break;
+    case IR24_OLD_DARKER    : relativeChange(&bri, -10, 5);        break;
+    case IR24_OLD_OFF       : briLast = bri; bri = 0;              break;
+    case IR24_OLD_ON        : bri = briLast;                       break;
+    case IR24_OLD_RED       : colorFromUint32(COLOR_RED);          break;
+    case IR24_OLD_REDDISH   : colorFromUint32(COLOR_REDDISH);      break;
+    case IR24_OLD_ORANGE    : colorFromUint32(COLOR_ORANGE);       break;
+    case IR24_OLD_YELLOWISH : colorFromUint32(COLOR_YELLOWISH);    break;
+    case IR24_OLD_YELLOW    : colorFromUint32(COLOR_YELLOW);       break;
+    case IR24_OLD_GREEN     : colorFromUint32(COLOR_GREEN);        break;
+    case IR24_OLD_GREENISH  : colorFromUint32(COLOR_GREENISH);     break;
+    case IR24_OLD_TURQUOISE : colorFromUint32(COLOR_TURQUOISE);    break;
+    case IR24_OLD_CYAN      : colorFromUint32(COLOR_CYAN);         break;
+    case IR24_OLD_AQUA      : colorFromUint32(COLOR_AQUA);         break;
+    case IR24_OLD_BLUE      : colorFromUint32(COLOR_BLUE);         break;
+    case IR24_OLD_DEEPBLUE  : colorFromUint32(COLOR_DEEPBLUE);     break;
+    case IR24_OLD_PURPLE    : colorFromUint32(COLOR_PURPLE);       break;
+    case IR24_OLD_MAGENTA   : colorFromUint32(COLOR_MAGENTA);      break;
+    case IR24_OLD_PINK      : colorFromUint32(COLOR_PINK);         break;
+    case IR24_OLD_WHITE     : colorFromUint32(COLOR_WHITE);        effectCurrent = 0;     break;
+    case IR24_OLD_FLASH     : if (!applyPreset(1)) effectCurrent = FX_MODE_COLORTWINKLE;  effectPalette = 0; break;
+    case IR24_OLD_STROBE    : if (!applyPreset(2)) effectCurrent = FX_MODE_RAINBOW_CYCLE; effectPalette = 0; break;
+    case IR24_OLD_FADE      : if (!applyPreset(3)) effectCurrent = FX_MODE_BREATH;        effectPalette = 0; break;
+    case IR24_OLD_SMOOTH    : if (!applyPreset(4)) effectCurrent = FX_MODE_RAINBOW;       effectPalette = 0; break;
+    default: return;
+  }
+  lastValidCode = code;
+  colorUpdated(2); //for notifier, IR is considered a button input
+}
+
+
+void decodeIR24CT(uint32_t code)
+{
+  switch (code) {
+    case IR24_CT_BRIGHTER   : relativeChange(&bri, 10);            break;
+    case IR24_CT_DARKER     : relativeChange(&bri, -10, 5);        break;
+    case IR24_CT_OFF        : briLast = bri; bri = 0;              break;
+    case IR24_CT_ON         : bri = briLast;                       break;
+    case IR24_CT_RED        : colorFromUint32(COLOR_RED);          break;
+    case IR24_CT_REDDISH    : colorFromUint32(COLOR_REDDISH);      break;
+    case IR24_CT_ORANGE     : colorFromUint32(COLOR_ORANGE);       break;
+    case IR24_CT_YELLOWISH  : colorFromUint32(COLOR_YELLOWISH);    break;
+    case IR24_CT_YELLOW     : colorFromUint32(COLOR_YELLOW);       break;
+    case IR24_CT_GREEN      : colorFromUint32(COLOR_GREEN);        break;
+    case IR24_CT_GREENISH   : colorFromUint32(COLOR_GREENISH);     break;
+    case IR24_CT_TURQUOISE  : colorFromUint32(COLOR_TURQUOISE);    break;
+    case IR24_CT_CYAN       : colorFromUint32(COLOR_CYAN);         break;
+    case IR24_CT_AQUA       : colorFromUint32(COLOR_AQUA);         break;
+    case IR24_CT_BLUE       : colorFromUint32(COLOR_BLUE);         break;
+    case IR24_CT_DEEPBLUE   : colorFromUint32(COLOR_DEEPBLUE);     break;
+    case IR24_CT_PURPLE     : colorFromUint32(COLOR_PURPLE);       break;
+    case IR24_CT_MAGENTA    : colorFromUint32(COLOR_MAGENTA);      break;
+    case IR24_CT_PINK       : colorFromUint32(COLOR_PINK);         break;
+    case IR24_CT_COLDWHITE  : colorFromUint32(COLOR_COLDWHITE);    effectCurrent = 0;  break;
+    case IR24_CT_WARMWHITE  : colorFromUint32(COLOR_WARMWHITE);    effectCurrent = 0;  break;
+    case IR24_CT_CTPLUS     : colorFromUint32(COLOR_COLDWHITE2);   effectCurrent = 0;  break;
+    case IR24_CT_CTMINUS    : colorFromUint32(COLOR_WARMWHITE2);   effectCurrent = 0;  break;
+    case IR24_CT_MEMORY   : {
+      if (col[3] > 0) col[3] = 0; 
+      else colorFromUint32(COLOR_NEUTRALWHITE); effectCurrent = 0; }                    break;
+    default: return; 
+  }
+  lastValidCode = code;
+  colorUpdated(2); //for notifier, IR is considered a button input
+}
+
+
+void decodeIR40(uint32_t code)
+{
+  switch (code) {
+    case IR40_BPLUS        : relativeChange(&bri, 10);                                   break;
+    case IR40_BMINUS       : relativeChange(&bri, -10, 5);                               break;
+    case IR40_OFF          : briLast = bri; bri = 0;                                     break;
+    case IR40_ON           : bri = briLast;                                              break;
+    case IR40_RED          : colorFromUint24(COLOR_RED);                                 break;
+    case IR40_REDDISH      : colorFromUint24(COLOR_REDDISH);                             break;
+    case IR40_ORANGE       : colorFromUint24(COLOR_ORANGE);                              break;
+    case IR40_YELLOWISH    : colorFromUint24(COLOR_YELLOWISH);                           break;
+    case IR40_YELLOW       : colorFromUint24(COLOR_YELLOW);                              break;
+    case IR40_GREEN        : colorFromUint24(COLOR_GREEN);                               break;
+    case IR40_GREENISH     : colorFromUint24(COLOR_GREENISH);                            break;
+    case IR40_TURQUOISE    : colorFromUint24(COLOR_TURQUOISE);                           break;
+    case IR40_CYAN         : colorFromUint24(COLOR_CYAN);                                break;
+    case IR40_AQUA         : colorFromUint24(COLOR_AQUA);                                break;
+    case IR40_BLUE         : colorFromUint24(COLOR_BLUE);                                break;
+    case IR40_DEEPBLUE     : colorFromUint24(COLOR_DEEPBLUE);                            break;
+    case IR40_PURPLE       : colorFromUint24(COLOR_PURPLE);                              break;
+    case IR40_MAGENTA      : colorFromUint24(COLOR_MAGENTA);                             break;
+    case IR40_PINK         : colorFromUint24(COLOR_PINK);                                break;
+    case IR40_WARMWHITE2   : {
+      if (useRGBW) {        colorFromUint32(COLOR2_WARMWHITE2);   effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_WARMWHITE2);                       }   break;
+    case IR40_WARMWHITE    : {
+      if (useRGBW) {        colorFromUint32(COLOR2_WARMWHITE);    effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_WARMWHITE);                        }   break;
+    case IR40_WHITE        : {
+      if (useRGBW) {        colorFromUint32(COLOR2_NEUTRALWHITE); effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_NEUTRALWHITE);                     }   break;
+    case IR40_COLDWHITE    : {
+      if (useRGBW) {        colorFromUint32(COLOR2_COLDWHITE);    effectCurrent = 0; }   
+      else                  colorFromUint24(COLOR_COLDWHITE);                        }   break;
+    case IR40_COLDWHITE2    : {
+      if (useRGBW) {        colorFromUint32(COLOR2_COLDWHITE2);   effectCurrent = 0; }   
+      else                  colorFromUint24(COLOR_COLDWHITE2);                       }   break;
+    case IR40_WPLUS        : relativeChangeWhite(10);                                    break;
+    case IR40_WMINUS       : relativeChangeWhite(-10, 5);                                break;
+    case IR40_WOFF         : whiteLast = col[3]; col[3] = 0;                             break;
+    case IR40_WON          : col[3] = whiteLast;                                         break;
+    case IR40_W25          : bri = 63;                                                   break;
+    case IR40_W50          : bri = 127;                                                  break;
+    case IR40_W75          : bri = 191;                                                  break;
+    case IR40_W100         : bri = 255;                                                  break;
+    case IR40_QUICK        : relativeChange(&effectSpeed, 10);                           break;
+    case IR40_SLOW         : relativeChange(&effectSpeed, -10, 5);                       break;
+    case IR40_JUMP7        : relativeChange(&effectIntensity, 10);                       break;
+    case IR40_AUTO         : relativeChange(&effectIntensity, -10, 5);                   break;
+    case IR40_JUMP3        : if (!applyPreset(1)) effectCurrent = FX_MODE_STATIC;        effectPalette = 0; break;
+    case IR40_FADE3        : if (!applyPreset(2)) effectCurrent = FX_MODE_BREATH;        effectPalette = 0; break;
+    case IR40_FADE7        : if (!applyPreset(3)) effectCurrent = FX_MODE_FIRE_FLICKER;  effectPalette = 0; break;
+    case IR40_FLASH        : if (!applyPreset(4)) effectCurrent = FX_MODE_RAINBOW;       effectPalette = 0; break;
+  }
+  lastValidCode = code;
+  colorUpdated(2); //for notifier, IR is considered a button input 
+}
 
 void decodeIR44(uint32_t code)
 {
-  //not implemented for now
+  switch (code) {
+    case IR44_BPLUS       : relativeChange(&bri, 10);                                   break;
+    case IR44_BMINUS      : relativeChange(&bri, -10, 5);                               break;
+    case IR44_OFF         : briLast = bri; bri = 0;                                     break;
+    case IR44_ON          : bri = briLast;                                              break;
+    case IR44_RED         : colorFromUint24(COLOR_RED);                                 break;
+    case IR44_REDDISH     : colorFromUint24(COLOR_REDDISH);                             break;
+    case IR44_ORANGE      : colorFromUint24(COLOR_ORANGE);                              break;
+    case IR44_YELLOWISH   : colorFromUint24(COLOR_YELLOWISH);                           break;
+    case IR44_YELLOW      : colorFromUint24(COLOR_YELLOW);                              break;
+    case IR44_GREEN       : colorFromUint24(COLOR_GREEN);                               break;
+    case IR44_GREENISH    : colorFromUint24(COLOR_GREENISH);                            break;
+    case IR44_TURQUOISE   : colorFromUint24(COLOR_TURQUOISE);                           break;
+    case IR44_CYAN        : colorFromUint24(COLOR_CYAN);                                break;
+    case IR44_AQUA        : colorFromUint24(COLOR_AQUA);                                break;
+    case IR44_BLUE        : colorFromUint24(COLOR_BLUE);                                break;
+    case IR44_DEEPBLUE    : colorFromUint24(COLOR_DEEPBLUE);                            break;
+    case IR44_PURPLE      : colorFromUint24(COLOR_PURPLE);                              break;
+    case IR44_MAGENTA     : colorFromUint24(COLOR_MAGENTA);                             break;
+    case IR44_PINK        : colorFromUint24(COLOR_PINK);                                break;
+    case IR44_WHITE       : {
+      if (useRGBW) {
+        if (col[3] > 0) col[3] = 0; 
+        else {              colorFromUint32(COLOR2_NEUTRALWHITE); effectCurrent = 0; }
+      } else                colorFromUint24(COLOR_NEUTRALWHITE);                     }  break;
+    case IR44_WARMWHITE2  : {
+      if (useRGBW) {        colorFromUint32(COLOR2_WARMWHITE2);   effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_WARMWHITE2);                       }  break;
+    case IR44_WARMWHITE   : {
+      if (useRGBW) {        colorFromUint32(COLOR2_WARMWHITE);    effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_WARMWHITE);                        }  break;
+    case IR44_COLDWHITE   : {
+      if (useRGBW) {        colorFromUint32(COLOR2_COLDWHITE);    effectCurrent = 0; }   
+      else                  colorFromUint24(COLOR_COLDWHITE);                        }  break;
+    case IR44_COLDWHITE2  : {
+      if (useRGBW) {        colorFromUint32(COLOR2_COLDWHITE2);   effectCurrent = 0; }    
+      else                  colorFromUint24(COLOR_COLDWHITE2);                       }  break;
+    case IR44_REDPLUS     : relativeChange(&effectCurrent, 1);                          break;
+    case IR44_REDMINUS    : relativeChange(&effectCurrent, -1, 0);                      break;
+    case IR44_GREENPLUS   : relativeChange(&effectPalette, 1);                          break;
+    case IR44_GREENMINUS  : relativeChange(&effectPalette, -1, 0);                      break;
+    case IR44_BLUEPLUS    : relativeChange(&effectIntensity, 10);                       break;
+    case IR44_BLUEMINUS   : relativeChange(&effectIntensity, -10, 5);                   break;
+    case IR44_QUICK       : relativeChange(&effectSpeed, 10);                           break;
+    case IR44_SLOW        : relativeChange(&effectSpeed, -10, 5);                       break;
+    case IR44_DIY1        : if (!applyPreset(1)) effectCurrent = FX_MODE_STATIC;        effectPalette = 0; break;
+    case IR44_DIY2        : if (!applyPreset(2)) effectCurrent = FX_MODE_BREATH;        effectPalette = 0; break;
+    case IR44_DIY3        : if (!applyPreset(3)) effectCurrent = FX_MODE_FIRE_FLICKER;  effectPalette = 0; break;
+    case IR44_DIY4        : if (!applyPreset(4)) effectCurrent = FX_MODE_RAINBOW;       effectPalette = 0; break;
+    case IR44_DIY5        : if (!applyPreset(5)) effectCurrent = FX_MODE_METEOR_SMOOTH; effectPalette = 0; break;
+    case IR44_DIY6        : if (!applyPreset(6)) effectCurrent = FX_MODE_RAIN;          effectPalette = 0; break;
+    case IR44_AUTO        : effectCurrent = FX_MODE_STATIC;                             break;
+    case IR44_FLASH       : effectCurrent = FX_MODE_PALETTE;                            break;
+    case IR44_JUMP3       : bri = 63;                                                   break;
+    case IR44_JUMP7       : bri = 127;                                                  break;
+    case IR44_FADE3       : bri = 191;                                                  break;
+    case IR44_FADE7       : bri = 255;                                                  break;
+  }
+  lastValidCode = code;
+  colorUpdated(2); //for notifier, IR is considered a button input 
 }
 
 
 void initIR()
 {
-  if (irEnabled)
+  if (irEnabled > 0)
   {
     irrecv = new IRrecv(IR_PIN);
     irrecv->enableIRIn();
@@ -126,10 +328,10 @@ void initIR()
 
 void handleIR()
 {
-  if (irEnabled && millis() - irCheckedTime > 120)
+  if (irEnabled > 0 && millis() - irCheckedTime > 120)
   {
     irCheckedTime = millis();
-    if (irEnabled)
+    if (irEnabled > 0)
     {
       if (irrecv == NULL)
       { 
@@ -138,9 +340,12 @@ void handleIR()
       
       if (irrecv->decode(&results))
       {
-        Serial.print("IR recv\r\n0x");
-        Serial.println((uint32_t)results.value, HEX);
-        Serial.println();
+        if (results.value != 0) // only print results if anything is received ( != 0 )
+        {
+          Serial.print("IR recv\r\n0x");
+          Serial.println((uint32_t)results.value, HEX);
+          Serial.println();
+        }
         decodeIR(results.value);
         irrecv->resume();
       }


### PR DESCRIPTION
Hi @Aircoookie ,

I added the logic for three more IR remotes that can be bought for small money at AliExpress (less than 2 EUR) and changed the settings so that the actual remote type can be selected instead of just turning all ON/OFF.

If you like I can add pictures of the remotes and a link to AliExpress to the wiki:

24-key:
![image](https://user-images.githubusercontent.com/33399267/71938667-70852300-31b0-11ea-8409-12a1a77d6b2f.png)


40-key:
![image](https://user-images.githubusercontent.com/33399267/71938681-7975f480-31b0-11ea-97e3-8b09a20a0fd9.png)


44-key:
![image](https://user-images.githubusercontent.com/33399267/71938687-8266c600-31b0-11ea-8260-2a8e357f2c87.png)
