### PR TITLE
SunRise using NightLight Fade

### DIFF
--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -141,6 +141,7 @@ byte briS = 128;                              //default brightness
 byte nightlightTargetBri = 0;                 //brightness after nightlight is over
 byte nightlightDelayMins = 60;
 bool nightlightFade = true;                   //if enabled, light will gradually dim towards the target bri. Otherwise, it will instantly set after delay over
+bool nightlightColorFade = false;             //if enabled, light will gradually fade color from primary to secondary color.
 bool fadeTransition = true;                   //enable crossfading color transition
 bool enableSecTransition = true;              //also enable transition for secondary color
 uint16_t transitionDelay = 750;               //default crossfade duration in ms
@@ -276,6 +277,7 @@ uint32_t nightlightDelayMs = 10;
 uint8_t nightlightDelayMinsDefault = nightlightDelayMins;
 unsigned long nightlightStartTime;
 byte briNlT = 0;                              //current nightlight brightness
+byte colNlT[]{0, 0, 0, 0};                    //current nightlight color
 
 //brightness
 unsigned long lastOnTime = 0;

--- a/wled00/wled03_set.ino
+++ b/wled00/wled03_set.ino
@@ -511,6 +511,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req)
   if (pos > 0)
   {
     nightlightFade = (req.charAt(pos+3) != '0');
+    nightlightColorFade = (req.charAt(pos+3) == '2');  //NighLightColorFade can only be enabled via API or Macro with "NF=2"
     nightlightActiveOld = false; //re-init
   }
 

--- a/wled00/wled08_led.ino
+++ b/wled00/wled08_led.ino
@@ -217,11 +217,16 @@ void handleNightlight()
       nightlightDelayMs = (int)(nightlightDelayMins*60000);
       nightlightActiveOld = true;
       briNlT = bri;
+      for (byte i=0; i<4; i++) colNlT[i] = col[i];                                    // remember starting color
     }
     float nper = (millis() - nightlightStartTime)/((float)nightlightDelayMs);
     if (nightlightFade)
     {
       bri = briNlT + ((nightlightTargetBri - briNlT)*nper);
+      if (nightlightColorFade)                                                        // color fading only is enabled with "NF=2"
+      {
+        for (byte i=0; i<4; i++) col[i] = colNlT[i]+ ((colSec[i] - colNlT[i])*nper);  // fading from actual color to secondary color
+      }
       colorUpdated(5);
     }
     if (nper >= 1)


### PR DESCRIPTION
Hi @Aircoookie , some weeks before someone wished to have a sunrise effect and I used something similar already (Nightlight with target brightness of 128). The only thing that missing was that in a "real" sunrise the color does change, too.

This PR does implement exactly this (without changing any of the old capabilities).

I changed WLED08_led.ino to fade from current color to the secondary color. This can be used without effecting the current logic with setting "NF=2" in a macro or through the API.

If a red color tone is chosen as primary and a yellow/white tone as secondary color, 
the actual brightness is set to 5 and the target brightness to 255,
the duration is set to 10 minutes,

This will create a smooth fade from darkest red to a bright warm light (like in a real SunRise)