### PR TITLE
ESP32 support for IR remotes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ data_dir = ./wled00/data
 ;lib_extra_dirs = ./wled00/src
 lib_dir = ./wled00/src
 ; Please uncomment one of the 5 lines below to select your board
-; env_default = nodemcuv2
+env_default = nodemcuv2
 ; env_default = esp01
 ; env_default = esp01_1m
 ; env_default = esp07
@@ -39,7 +39,7 @@ lib_deps_external =
   AsyncTCP@1.0.3
   Esp Async WebServer@1.2.0
   #ArduinoJson@5.13.5
-  IRremoteESP8266@2.5.5
+  IRremoteESP8266@2.7.2
   #Time@1.5
   #Timezone@1.2.1
   #For use SSD1306 0.91" OLED display uncomment following
@@ -105,7 +105,6 @@ platform = espressif32@1.11.1
 build_flags =
   -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
   -D ARDUINO_ARCH_ESP32
-  -D WLED_DISABLE_INFRARED 
 
 # see: http://docs.platformio.org/en/latest/platforms/espressif8266.html
 [env:nodemcuv2]
@@ -184,7 +183,6 @@ build_flags =
 lib_deps =
   ${common.lib_deps_external}
 lib_ignore =
-  IRremoteESP8266
   ESPAsyncUDP
 
 [env:esp8285_4CH_MagicHome]

--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -83,16 +83,11 @@
  #endif
 #endif
 
-#ifdef ARDUINO_ARCH_ESP32
-  #undef WLED_USE_ANALOG_LEDS  // Solid RGBW not implemented for ESP32 yet
-#else
  #ifndef WLED_DISABLE_INFRARED
   #include <IRremoteESP8266.h>
   #include <IRrecv.h>
   #include <IRutils.h>
  #endif
-#endif
-
 
 //version code in format yymmddb (b = daily build)
 #define VERSION 2001071


### PR DESCRIPTION
uses library v2.7.2 in platformio.ini 

...and the #defines in WLED00.ino needed some changes (by the way I corrected the exclusion of analogLEDs for ESP32 as this is possible now).