### PR TITLE
Added percent display effect.

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2976,3 +2976,31 @@ uint16_t WS2812FX::mode_plasma(void) {
 
   return FRAMETIME;
 } 
+
+/*
+ * Percentage display
+ * Intesity values from 0-100 turn on the leds.
+ */
+uint16_t WS2812FX::mode_percent(void) {
+
+	uint8_t percent = max(0, min(100, SEGMENT.intensity));
+
+	float active_float = SEGLEN * percent / 100.0;
+	uint16_t active_leds = active_float;
+	uint16_t active_part = (active_float - active_leds) * 255;
+	CRGB color;
+
+	for (uint16_t i = 0; i < SEGLEN; i++) {
+		if (i < active_leds) {
+			setPixelColor(i, color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
+		}
+		else if (i == active_leds) {
+			setPixelColor(i, color_from_palette(i, true, PALETTE_SOLID_WRAP, 0, active_part));
+		}
+		else {
+			setPixelColor(i, SEGCOLOR(1));
+		}
+	}
+
+	return FRAMETIME;
+}

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -91,7 +91,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE )     == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED)     == SELECTED    )
 
-#define MODE_COUNT  98
+#define MODE_COUNT  99
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -191,7 +191,7 @@
 #define FX_MODE_POPCORN                 95
 #define FX_MODE_DRIP                    96
 #define FX_MODE_PLASMA                  97
-
+#define FX_MODE_PERCENT                 98
 
 class WS2812FX {
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
@@ -378,6 +378,7 @@ class WS2812FX {
       _mode[FX_MODE_POPCORN]                 = &WS2812FX::mode_popcorn;
       _mode[FX_MODE_DRIP]                    = &WS2812FX::mode_drip;
       _mode[FX_MODE_PLASMA]                  = &WS2812FX::mode_plasma;
+      _mode[FX_MODE_PERCENT]                 = &WS2812FX::mode_percent;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -560,7 +561,8 @@ class WS2812FX {
       mode_sinelon_rainbow(void),
       mode_popcorn(void),
       mode_drip(void),
-      mode_plasma(void);
+      mode_plasma(void),
+      mode_percent(void);
       
 
   private:
@@ -640,7 +642,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Scanner Dual","Stream 2","Oscillate","Pride 2015","Juggle","Palette","Fire 2012","Colorwaves","Bpm","Fill Noise",
 "Noise 1","Noise 2","Noise 3","Noise 4","Colortwinkles","Lake","Meteor","Meteor Smooth","Railway","Ripple",
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
-"Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma"
+"Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent"
 ])=====";
 
 


### PR DESCRIPTION
This is not really an effect but usefull for status displays of any kind.
Intensity values from 0 - 100 represent the pertentage amount of LED that light up.
It uses col0/palette for on and col1 for off.

PS: I'm not very familiar with pull requests so things might go sideways.. :/