### PR TITLE
non-required HUE settings

### DIFF
--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -234,13 +234,13 @@ Group Topic: <input name="MG" maxlength="32"><br>
 <i>Reboot required to apply changes. </i><a href="https://github.com/Aircoookie/WLED/wiki/MQTT" target="_blank">MQTT info</a>
 <h3>Philips Hue</h3>
 <i>You can find the bridge IP and the light number in the 'About' section of the hue app.</i><br>
-Poll Hue light <input name="HL" type="number" min="1" max="99" required> every <input name="HI" type="number" min="100" max="65000" required> ms: <input type="checkbox" name="HP"><br>
+Poll Hue light <input name="HL" type="number" min="1" max="99" > every <input name="HI" type="number" min="100" max="65000"> ms: <input type="checkbox" name="HP"><br>
 Then, receive <input type="checkbox" name="HO"> On/Off, <input type="checkbox" name="HB"> Brightness, and <input type="checkbox" name="HC"> Color<br>
 Hue Bridge IP:<br>
-<input name="H0" type="number" min="0" max="255" required> .
-<input name="H1" type="number" min="0" max="255" required> .
-<input name="H2" type="number" min="0" max="255" required> .
-<input name="H3" type="number" min="0" max="255" required><br>
+<input name="H0" type="number" min="0" max="255" > .
+<input name="H1" type="number" min="0" max="255" > .
+<input name="H2" type="number" min="0" max="255" > .
+<input name="H3" type="number" min="0" max="255" ><br>
 <b>Press the pushlink button on the bridge, after that save this page!</b><br>
 (when first connecting)<br>
 Hue status: <span class="hms"> Internal ESP Error! </span><hr>


### PR DESCRIPTION
Remove the "required" from the HUE settings forms. This gets rid of the error message requiring something to be in those fields (see #533, #613). 