### PR TITLE
try pio workaround for pio4.2.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -127,6 +127,8 @@ build_flags =
   ${common:esp8266.build_flags}
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:d1_mini]
 board = d1_mini

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,12 +7,12 @@ data_dir = ./wled00/data
 ;lib_extra_dirs = ./wled00/src
 lib_dir = ./wled00/src
 ; Please uncomment one of the 5 lines below to select your board
-default_envs = nodemcuv2
+; default_envs = nodemcuv2
 ; default_envs = esp01
 ; default_envs = esp01_1m
 ; default_envs = esp07
 ; default_envs = d1_mini
-; default_envs = esp32dev
+default_envs = esp32dev
 ; default_envs = esp8285_4CH_MagicHome
 ; default_envs = esp8285_4CH_H801
 ; default_envs = esp8285_5CH_H801
@@ -203,6 +203,7 @@ lib_deps =
   ${common.lib_deps_external}
 lib_ignore =
   ESPAsyncUDP
+lib_compat_mode = strict
 
 [env:esp8285_4CH_MagicHome]
 board = esp8285

--- a/platformio.ini
+++ b/platformio.ini
@@ -141,6 +141,8 @@ build_flags =
   ${common:esp8266.build_flags}
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:esp01_1m]
 board = esp01_1m
@@ -155,6 +157,8 @@ build_flags =
   -D WLED_DISABLE_INFRARED
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:esp01]
 board = esp01
@@ -168,6 +172,8 @@ build_flags =
   -D WLED_DISABLE_INFRARED
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:esp07]
 board = esp07
@@ -180,6 +186,8 @@ build_flags =
   ${common:esp8266.build_flags}
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 # see: http://docs.platformio.org/en/latest/platforms/espressif32.html
 [env:esp32dev]
@@ -209,6 +217,8 @@ build_flags =
   -D WLED_USE_ANALOG_LEDS
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:esp8285_4CH_H801]
 board = esp8285
@@ -224,6 +234,8 @@ build_flags =
   -D WLED_USE_H801
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
 
 [env:esp8285_5CH_H801]
 board = esp8285
@@ -240,4 +252,6 @@ build_flags =
   -D WLED_ENABLE_5CH_LEDS 
 lib_deps =
   ${common.lib_deps_external}
+lib_compat_mode = strict
+lib_ignore = AsynTCP
   

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,12 +7,12 @@ data_dir = ./wled00/data
 ;lib_extra_dirs = ./wled00/src
 lib_dir = ./wled00/src
 ; Please uncomment one of the 5 lines below to select your board
-; default_envs = nodemcuv2
+default_envs = nodemcuv2
 ; default_envs = esp01
 ; default_envs = esp01_1m
 ; default_envs = esp07
 ; default_envs = d1_mini
-default_envs = esp32dev
+; default_envs = esp32dev
 ; default_envs = esp8285_4CH_MagicHome
 ; default_envs = esp8285_4CH_H801
 ; default_envs = esp8285_5CH_H801


### PR DESCRIPTION
From the link:
https://community.platformio.org/t/pio-4-2-0-complile-error-for-asynctcp-id1826/12025/4

"Sorry, this is our bug and has been fixed in https://github.com/platformio/platformio-core/commit/5cc9a328ab4d64c42f3cda714f65e150eca31128 4

We plan to publish bug fix release of PIO Core 4.2.1 next week, A temporary solution is to use lib_ignore = AsynTCP or lib_compat_mode = strict in platformio.ini."