### PR TITLE
fixes #742

### DIFF
--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -85,6 +85,7 @@
 		<h3>Realtime</h3>
 		Receive UDP realtime: <input type="checkbox" name="RD"><br><br>
 		E1.31 (sACN)<br>
+		Skip out-of-sequence packets (freeze instead of flicker): <input type="checkbox" name="ES"><br>
 		Multicast mode: <input type="checkbox" name="EM"><br>
 		E1.31 start universe: <input name="EU" type="number" min="1" max="63999" required><br>
 		<i>Reboot required.</i> Check out <a href="https://github.com/ahodges9/LedFx" target="_blank">LedFx</a>!<br><br>

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -284,6 +284,7 @@ Send notifications twice: <input type="checkbox" name="S2">
 <h3>Realtime</h3>
 Receive UDP realtime: <input type="checkbox" name="RD"><br><br>
 <i>E1.31 (sACN)</i><br>
+Skip out-of-sequence packets (freeze instead of flicker): <input type="checkbox" name="ES"><br>
 Use E1.31 multicast: <input type="checkbox" name="EM"><br>
 E1.31 start universe: <input name="EU" type="number" min="1" max="63999" required><br>
 <i>Reboot required.</i> Check out <a href="https://github.com/ahodges9/LedFx" target="_blank">LedFx</a>!<br>

--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -213,6 +213,7 @@ uint16_t DMXAddress = 1;                      //DMX start address of fixture, a.
 uint8_t  DMXOldDimmer = 0;                    //only update brightness on change
 uint8_t  e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT];          //to detect packet loss
 bool     e131Multicast = false;               //multicast or unicast
+bool     e131SkipOutOfSequence = false;       //freeze instead of flickering
 
 bool mqttEnabled = false;
 char mqttDeviceTopic[33] = "";                //main MQTT topic (individual per device, default is wled/mac)

--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -206,11 +206,12 @@ bool receiveDirect    =  true;                //receive UDP realtime
 bool arlsDisableGammaCorrection = true;       //activate if gamma correction is handled by the source
 bool arlsForceMaxBri = false;                 //enable to force max brightness if source has very dark colors that would be black
 
+#define E131_MAX_UNIVERSE_COUNT 9
 uint16_t e131Universe = 1;                    //settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
 uint8_t  DMXMode = DMX_MODE_MULTIPLE_RGB;     //DMX mode (s.a.)
 uint16_t DMXAddress = 1;                      //DMX start address of fixture, a.k.a. first Channel [for E1.31 (sACN) protocol]
 uint8_t  DMXOldDimmer = 0;                    //only update brightness on change
-uint8_t  e131LastSequenceNumber = 0;          //to detect packet loss
+uint8_t  e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT];          //to detect packet loss
 bool     e131Multicast = false;               //multicast or unicast
 
 bool mqttEnabled = false;
@@ -463,8 +464,6 @@ void serveMessage(AsyncWebServerRequest*, uint16_t, String, String, byte);
 void handleE131Packet(e131_packet_t*, IPAddress);
 void arlsLock(uint32_t,byte);
 void handleOverlayDraw();
-
-#define E131_MAX_UNIVERSE_COUNT 9
 
 //udp interface objects
 WiFiUDP notifierUdp, rgbUdp;

--- a/wled00/wled01_eeprom.ino
+++ b/wled00/wled01_eeprom.ino
@@ -6,7 +6,7 @@
 #define EEPSIZE 2560  //Maximum is 4096
 
 //eeprom Version code, enables default settings instead of 0 init on update
-#define EEPVER 17
+#define EEPVER 18
 //0 -> old version, default
 //1 -> 0.4p 1711272 and up
 //2 -> 0.4p 1711302 and up
@@ -25,6 +25,7 @@
 //15-> 0.9.0-b3
 //16-> 0.9.1
 //17-> 0.9.1-dmx
+//18-> 0.9.1-e131
 
 void commit()
 {
@@ -208,6 +209,7 @@ void saveSettingsToEEPROM()
   EEPROM.write(2181, macroNl);
   EEPROM.write(2182, macroDoublePress);
 
+  EEPROM.write(2189, e131SkipOutOfSequence);
   EEPROM.write(2190, e131Universe & 0xFF);
   EEPROM.write(2191, (e131Universe >> 8) & 0xFF);
   EEPROM.write(2192, e131Multicast);
@@ -505,6 +507,12 @@ void loadSettingsFromEEPROM(bool first)
     noWifiSleep = EEPROM.read(370);
   //}
 
+  if (lastEEPROMversion > 17)
+  {
+    e131SkipOutOfSequence = EEPROM.read(2189);
+  } else {
+    e131SkipOutOfSequence = true;
+  }
 
   receiveDirect = !EEPROM.read(2200);
   notifyMacro = EEPROM.read(2201);

--- a/wled00/wled02_xml.ino
+++ b/wled00/wled02_xml.ino
@@ -324,6 +324,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('c',"SM",notifyMacro);
     sappend('c',"S2",notifyTwice);
     sappend('c',"RD",receiveDirect);
+    sappend('c',"ES",e131SkipOutOfSequence);
     sappend('c',"EM",e131Multicast);
     sappend('v',"EU",e131Universe);
     sappend('v',"DA",DMXAddress);

--- a/wled00/wled02_xml.ino
+++ b/wled00/wled02_xml.ino
@@ -74,8 +74,6 @@ char* XML_response(AsyncWebServerRequest *request, char* dest = nullptr)
         mesg += ".";
         mesg += realtimeIP[i];
       }
-      mesg += " seq=";
-      mesg += e131LastSequenceNumber;
     } else if (realtimeMode == REALTIME_MODE_UDP || realtimeMode == REALTIME_MODE_HYPERION) {
       mesg += "UDP from ";
       mesg += realtimeIP[0];

--- a/wled00/wled03_set.ino
+++ b/wled00/wled03_set.ino
@@ -138,6 +138,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     notifyTwice = request->hasArg("S2");
 
     receiveDirect = request->hasArg("RD");
+    e131SkipOutOfSequence = request->hasArg("ES");
     e131Multicast = request->hasArg("EM");
     t = request->arg("EU").toInt();
     if (t > 0  && t <= 63999) e131Universe = t;

--- a/wled00/wled07_notify.ino
+++ b/wled00/wled07_notify.ino
@@ -97,17 +97,17 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
   // only listen for universes we're handling & allocated memory
   if (uni >= (e131Universe + E131_MAX_UNIVERSE_COUNT)) return;
 
-  // skip out-of-sequence packets
-  if (p->sequence_number < e131LastSequenceNumber[uni-e131Universe] && p->sequence_number > 20 && e131LastSequenceNumber[uni-e131Universe] < 250){
-    DEBUG_PRINT("skipping E1.31 frame (last seq=");
-    DEBUG_PRINT(e131LastSequenceNumber[uni-e131Universe]);
-    DEBUG_PRINT(", current seq=");
-    DEBUG_PRINT(p->sequence_number);
-    DEBUG_PRINT(", universe=");
-    DEBUG_PRINT(uni);
-    DEBUG_PRINTLN(")");
-    return;
-  }
+  if (e131SkipOutOfSequence)
+    if (p->sequence_number < e131LastSequenceNumber[uni-e131Universe] && p->sequence_number > 20 && e131LastSequenceNumber[uni-e131Universe] < 250){
+      DEBUG_PRINT("skipping E1.31 frame (last seq=");
+      DEBUG_PRINT(e131LastSequenceNumber[uni-e131Universe]);
+      DEBUG_PRINT(", current seq=");
+      DEBUG_PRINT(p->sequence_number);
+      DEBUG_PRINT(", universe=");
+      DEBUG_PRINT(uni);
+      DEBUG_PRINTLN(")");
+      return;
+    }
   e131LastSequenceNumber[uni-e131Universe] = p->sequence_number;
 
   // update status info


### PR DESCRIPTION
* track E1.31 seqcuence numbers for each universe individually
* add E1.31 packet out-of-sequence config option (on/off)
  * extends EEPROM format

fixes #742
