### PR TITLE
Added support for BW-LT11

### DIFF
--- a/platformio_override.ini.example
+++ b/platformio_override.ini.example
@@ -28,7 +28,9 @@ build_flags = ${common.build_flags_esp8266}
 ; to drive analog LED strips (aka 5050), uncomment the following
 ; PWM pins 5,12,13,15 are used with Magic Home LED Controller (default)
 ;   -D WLED_USE_ANALOG_LEDS
-; for the H801 controler (PINs 15,13,12,14 (W2 = 04)) uncomment this
+; for the H801 controller (PINs 15,13,12,14 (W2 = 04)) uncomment this
 ;   -D WLED_USE_H801
+; for the BW-LT11 controller (PINs 12,4,14,5 ) uncomment this
+;   -D WLED_USE_BWLT11
 ; and to enable channel 5 for RGBW-CT led strips this
 ;   -D WLED_USE_5CH_LEDS

--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -55,12 +55,18 @@
     #undef BTNPIN
     #undef IR_PIN
     #define IR_PIN  0 //infrared pin (-1 to disable)  MagicHome: 4, H801 Wifi: 0
+  #elif defined(WLED_USE_BWLT11)
+  //PWM pins - to use with BW-LT11
+    #define RPIN 12  //R pin for analog LED strip
+    #define GPIN 4   //G pin for analog LED strip
+    #define BPIN 14  //B pin for analog LED strip
+    #define WPIN 5   //W pin for analog LED strip
   #else
   //PWM pins - PINs 5,12,13,15 are used with Magic Home LED Controller
-    #define RPIN 5   //R pin for analog LED strip   
-    #define GPIN 12   //G pin for analog LED strip
-    #define BPIN 15   //B pin for analog LED strip
-    #define WPIN 13   //W pin for analog LED strip 
+    #define RPIN 5   //R pin for analog LED strip
+    #define GPIN 12  //G pin for analog LED strip
+    #define BPIN 15  //B pin for analog LED strip
+    #define WPIN 13  //W pin for analog LED strip
   #endif
   #undef RLYPIN
   #define RLYPIN -1 //disable as pin 12 is used by analog LEDs


### PR DESCRIPTION
I wanted to add support for the BW-LT11.

These Blitzwolf BW-LT11 can be flashed with Tuya-Convert. 

The LEDs are 5050 Type. But there PINs are different than your defaults. (12,4,14,5 vs. 5,12,15,13)

I made it definable via platformio_override.ini. Hope it is alright.