### PR TITLE
implement DMX proxy mode via MAX485

### DIFF
--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -47,6 +47,7 @@ Type:
 </select><br>
 <div id=xp>Port: <input name="EP" type="number" min="1" max="65535" value="5568" class="d5" required><br></div>
 Multicast: <input type="checkbox" name="EM"><br>
+Proxy Universe <input name=PU type=number min=0 max=63999 required> to DMX via MAX485 DI pin connected to D4 (0=disabled, compile with WLED_ENABLE_DMX)<br>
 Start universe: <input name="EU" type="number" min="0" max="63999" required><br>
 <i>Reboot required.</i> Check out <a href="https://github.com/ahodges9/LedFx" target="_blank">LedFx</a>!<br>
 Skip out-of-sequence packets: <input type="checkbox" name="ES"><br>

--- a/wled00/dmx.cpp
+++ b/wled00/dmx.cpp
@@ -8,11 +8,12 @@
  */
 
 #ifdef WLED_ENABLE_DMX
-#include "src/dependencies/dmx/ESPDMX.h"
-DMXESPSerial dmx;
 
 void handleDMX()
 {
+  // don't act, when in DMX Proxy mode
+  if (e131ProxyUniverse != 0) return;
+
   // TODO: calculate brightness manually if no shutter channel is set
 
   uint8_t brightness = strip.getBrightness();

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -25,6 +25,15 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, bool isArtnet){
     seq = p->sequence_number;
   }
 
+  #ifdef WLED_ENABLE_DMX
+  // does not act on out-of-order packets yet
+  if (e131ProxyUniverse > 0 && uni == e131ProxyUniverse) {
+    for (uint16_t i = 1; i <= dmxChannels; i++)
+      dmx.write(i, e131_data[i]);
+    dmx.update();
+  }
+  #endif
+
   // only listen for universes we're handling & allocated memory
   if (uni >= (e131Universe + E131_MAX_UNIVERSE_COUNT)) return;
 

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -212,6 +212,7 @@ function S(){GCH(15);GetV();mMap();}function H(){window.open("https://github.com
 <button type="button" onclick="B()">Back</button><button type="submit">Save</button><hr>
 <h2>Imma firin ma lazer (if it has DMX support)</h2><!-- TODO: Change to something less-meme-related //-->
 
+<i>This functionality may be disabled by DMX Proxy Universe &ne; 0 on sync settings page</i><br>
 <i>Number of fixtures is taken from LED config page</i><br>
 
 Channels per fixture (15 max): <input type="number" min="1" max="15" name="CN" maxlength="2" onchange="mMap();"><br />
@@ -293,6 +294,7 @@ Type:
 </select><br>
 <div id=xp>Port: <input name=EP type=number min=1 max=65535 value=5568 class=d5 required><br></div>
 Multicast: <input type=checkbox name=EM><br>
+Proxy Universe <input name=PU type=number min=0 max=63999 required> to DMX via MAX485 DI pin connected to D4 (0=disabled, compile with WLED_ENABLE_DMX)<br>
 Start universe: <input name=EU type=number min=0 max=63999 required><br>
 <i>Reboot required.</i> Check out <a href=https://github.com/ahodges9/LedFx target=_blank>LedFx</a>!<br>
 Skip out-of-sequence packets: <input type=checkbox name=ES><br>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -144,6 +144,10 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     e131Multicast = request->hasArg("EM");
     t = request->arg("EP").toInt();
     if (t > 0) e131Port = t;
+    #ifdef WLED_ENABLE_DMX // include only if DMX is enabled
+    t = request->arg("PU").toInt();
+    if (t >= 0  && t <= 63999) e131ProxyUniverse = t;
+    #endif
     t = request->arg("EU").toInt();
     if (t >= 0  && t <= 63999) e131Universe = t;
     t = request->arg("DA").toInt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -76,6 +76,10 @@
   #include "src/dependencies/blynk/BlynkSimpleEsp.h"
 #endif
 
+#ifdef WLED_ENABLE_DMX
+  #include "src/dependencies/dmx/ESPDMX.h"
+#endif
+
 #include "src/dependencies/e131/ESPAsyncE131.h"
 #include "src/dependencies/async-mqtt-client/AsyncMqttClient.h"
 #include "src/dependencies/json/AsyncJson-v6.h"
@@ -226,6 +230,10 @@ WLED_GLOBAL bool receiveDirect _INIT(true);                       // receive UDP
 WLED_GLOBAL bool arlsDisableGammaCorrection _INIT(true);          // activate if gamma correction is handled by the source
 WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to force max brightness if source has very dark colors that would be black
 
+#ifdef WLED_ENABLE_DMX
+WLED_GLOBAL DMXESPSerial dmx;
+WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this E1.31 (sACN) / ArtNet universe via MAX485 (0 = disabled)
+#endif
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
 WLED_GLOBAL uint16_t e131Port _INIT(5568);                        // DMX in port. E1.31 default is 5568, Art-Net is 6454
 WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGB);            // DMX mode (s.a.)

--- a/wled00/wled_eeprom.cpp
+++ b/wled00/wled_eeprom.cpp
@@ -7,7 +7,7 @@
  */
 
 //eeprom Version code, enables default settings instead of 0 init on update
-#define EEPVER 19
+#define EEPVER 20
 //0 -> old version, default
 //1 -> 0.4p 1711272 and up
 //2 -> 0.4p 1711302 and up
@@ -28,6 +28,7 @@
 //17-> 0.9.1-dmx
 //18-> 0.9.1-e131
 //19-> 0.9.1n
+//20-> 0.9.1p
 
 void commit()
 {
@@ -210,6 +211,11 @@ void saveSettingsToEEPROM()
   EEPROM.write(2180, macroCountdown);
   EEPROM.write(2181, macroNl);
   EEPROM.write(2182, macroDoublePress);
+
+  #ifdef WLED_ENABLE_DMX
+  EEPROM.write(2185, e131ProxyUniverse & 0xFF);
+  EEPROM.write(2186, (e131ProxyUniverse >> 8) & 0xFF);
+  #endif
 
   EEPROM.write(2187, e131Port & 0xFF);
   EEPROM.write(2188, (e131Port >> 8) & 0xFF);
@@ -523,6 +529,13 @@ void loadSettingsFromEEPROM(bool first)
   {
     e131Port = EEPROM.read(2187) + ((EEPROM.read(2188) << 8) & 0xFF00);
   }
+
+  #ifdef WLED_ENABLE_DMX
+  if (lastEEPROMversion > 19)
+  {
+    e131ProxyUniverse = EEPROM.read(2185) + ((EEPROM.read(2186) << 8) & 0xFF00);
+  }
+  #endif
 
   receiveDirect = !EEPROM.read(2200);
   notifyMacro = EEPROM.read(2201);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -330,6 +330,9 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',"EP",e131Port);
     sappend('c',"ES",e131SkipOutOfSequence);
     sappend('c',"EM",e131Multicast);
+    #ifdef WLED_ENABLE_DMX
+    sappend('v',"PU",e131ProxyUniverse);
+    #endif
     sappend('v',"EU",e131Universe);
     sappend('v',"DA",DMXAddress);
     sappend('v',"DM",DMXMode);


### PR DESCRIPTION
output a configurable universe (E1.31 or ArtNet) via MAX485 module that connects its DI to D4 on d1_mini.
as this function competes with DMX output for the same hardware, the universe to proxy acts as a switch.
0       = DMX OUTPUT (of configured WLED LEDs, which is the classic behaviour)
1-63999 = DMX PROXY  (selected universe, ArtNet is limited up to 32768)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Proxy Universe setting to forward E1.31 data directly to DMX output
* Configure Proxy Universe value in Sync settings (0–63999 range; 0 = disabled)
* Setting is automatically saved and persists across device restarts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->