### PR TITLE
Add new mode "Solid Glitter".

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3322,3 +3322,15 @@ CRGB WS2812FX::pacifica_one_layer(uint16_t i, CRGBPalette16& p, uint16_t cistart
   uint8_t sindex8 = scale16(sindex16, 240);
   return ColorFromPalette(p, sindex8, bri, LINEARBLEND);
 }
+
+//Solid colour background with glitter
+uint16_t WS2812FX::mode_solid_glitter()
+{
+  fill(SEGCOLOR(0));
+
+  if (SEGMENT.intensity > random8())
+  {
+    setPixelColor(random16(SEGLEN), ULTRAWHITE);
+  }
+  return FRAMETIME;
+}

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -98,7 +98,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  103
+#define MODE_COUNT  104
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -203,6 +203,7 @@
 #define FX_MODE_HEARTBEAT              100
 #define FX_MODE_PACIFICA               101
 #define FX_MODE_CANDLE_MULTI           102
+#define FX_MODE_SOLID_GLITTER          103
 
 class WS2812FX {
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
@@ -394,6 +395,7 @@ class WS2812FX {
       _mode[FX_MODE_HEARTBEAT]               = &WS2812FX::mode_heartbeat;
       _mode[FX_MODE_PACIFICA]                = &WS2812FX::mode_pacifica;
       _mode[FX_MODE_CANDLE_MULTI]            = &WS2812FX::mode_candle_multi;
+      _mode[FX_MODE_SOLID_GLITTER]           = &WS2812FX::mode_solid_glitter;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -562,7 +564,7 @@ class WS2812FX {
       mode_twinklecat(void),
       mode_halloween_eyes(void),
       mode_static_pattern(void),
-	    mode_tri_static_pattern(void),
+      mode_tri_static_pattern(void),
       mode_spots(void),
       mode_spots_fade(void),
       mode_glitter(void),
@@ -580,8 +582,8 @@ class WS2812FX {
       mode_ripple_rainbow(void),
       mode_heartbeat(void),
       mode_pacifica(void),
-      mode_candle_multi(void);
-      
+      mode_candle_multi(void),
+      mode_solid_glitter(void);
 
   private:
     NeoPixelWrapper *bus;
@@ -667,7 +669,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Noise 1","Noise 2","Noise 3","Noise 4","Colortwinkles","Lake","Meteor","Meteor Smooth","Railway","Ripple",
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
-"Heartbeat","Pacifica","Candle Multi"
+"Heartbeat","Pacifica","Candle Multi", "Solid Glitter"
 ])=====";
 
 


### PR DESCRIPTION
This simple change adds a new mode called "Solid Glitter".

It combines the "Solid" mode which gives a solid, static colour to all LEDs configurable from the colour picker and then overlays glitter (hyperwhite pixels which flash on for one frame) which is reactive to the intensity slider.

It's a simple change, but the effect is very pleasant.
