### PR TITLE
Add PWN Pins for esp_rgbww_controller

### DIFF
--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -71,6 +71,14 @@
     #define BPIN 5   //B pin for analog LED strip
     #define WPIN 15  //W pin for analog LED strip
     #define W2PIN 12 //W2 pin for analog LED strip
+  #elif defined(WLED_USE_PLJAKOBS_PCB)
+  // PWM pins - to use with esp_rgbww_controller from patrickjahns/pljakobs (https://github.com/pljakobs/esp_rgbww_controller)
+    #define RPIN 12  //R pin for analog LED strip
+    #define GPIN 13  //G pin for analog LED strip
+    #define BPIN 14  //B pin for analog LED strip
+    #define WPIN 4   //W pin for analog LED strip
+    #define W2PIN 5  //W2 pin for analog LED strip
+    #undef IR_PIN
   #else
   //PWM pins - PINs 5,12,13,15 are used with Magic Home LED Controller
     #define RPIN 5   //R pin for analog LED strip


### PR DESCRIPTION
Add PWM pins - to use with esp_rgbww_controller from patrickjahns/pljakobs
https://github.com/pljakobs/esp_rgbww_controller

I've used this pio env to build:
```
[env:esp_rgbww_controller]
board = d1_mini
platform = ${common.platform_wled_default}
board_build.ldscript = ${common.ldscript_4m1m}
build_flags = ${common.build_flags_esp8266} 
  -D WLED_DISABLE_BLYNK
  -D WLED_DISABLE_CRONIXIE 
  -D WLED_DISABLE_HUESYNC 
  -D WLED_DISABLE_INFRARED
  -D WLED_USE_ANALOG_LEDS
  -D WLED_USE_PLJAKOBS_PCB
  -D WLED_USE_5CH_LEDS
```