### PR TITLE
Remove ESPAsyncUDP version requirement

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -163,7 +163,7 @@ lib_deps =
     FastLED@3.3.2
     NeoPixelBus@2.5.7
     ESPAsyncTCP@1.2.0
-    ESPAsyncUDP@697c75a025
+    ESPAsyncUDP
     AsyncTCP@1.0.3
     https://github.com/Aircoookie/ESPAsyncWebServer
     IRremoteESP8266@2.7.3


### PR DESCRIPTION
The version requirement for the ESPAsyncUDP lib_dep has been causing failed builds in platformio and Travis-CI since 7/6/2020. Removing the version requirement fixes this issue. 
Please see the error below:

```Looking for ESPAsyncUDP library in registry
Found: https://platformio.org/lib/show/359/ESPAsyncUDP
LibraryManager: Installing id=359 @ 697c75a025
UndefinedPackageVersion: Could not find a version that satisfies the requirement '697c75a025' for your system 'linux_x86_64':