### PR TITLE
Use string derived from serverDescription for wifi.hostname()

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -147,7 +147,7 @@ shared_libdeps_dir = ./wled00/src
 framework = arduino
 board_build.flash_mode = dout
 monitor_speed = 115200
-upload_speed = 921600
+upload_speed = 115200
 lib_extra_dirs =
     ${common.shared_libdeps_dir}
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -147,7 +147,7 @@ shared_libdeps_dir = ./wled00/src
 framework = arduino
 board_build.flash_mode = dout
 monitor_speed = 115200
-upload_speed = 115200
+upload_speed = 921600
 lib_extra_dirs =
     ${common.shared_libdeps_dir}
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -324,15 +324,32 @@ void WLED::initConnection()
   DEBUG_PRINT(clientSSID);
   DEBUG_PRINTLN("...");
 
+  // convert the "serverDescription" into something usable as a DNS hostname
+  String hostname; 
+  const char *pC = serverDescription;
+  while (*pC) { // while !null  
+    if (isAlphaNumeric(*pC)) {          // if the current char is alpha-numeric...
+      hostname += *pC;                  // ...its usable, append it to the hostname
+    } else if (0 < hostname.length()) { // else, if the hostname isn't empty...
+      hostname += '-';                  // ...put in a hyphen.  (hostname can't start with a hypen)
+    }
+    // else do nothing - no leading hyphens.
+    pC++;
+  }
+  // if the hostname is left blank, use the mac address
+  if (0 == hostname.length()) {
+    hostname = escapedMac;
+  }
+  
 #ifdef ESP8266
-  WiFi.hostname(serverDescription);
+  WiFi.hostname(hostname.c_str());
 #endif
 
   WiFi.begin(clientSSID, clientPass);
 
 #ifdef ARDUINO_ARCH_ESP32
   WiFi.setSleep(!noWifiSleep);
-  WiFi.setHostname(serverDescription);
+  WiFi.setHostname(hostname.c_str());
 #else
   wifi_set_sleep_type((noWifiSleep) ? NONE_SLEEP_T : MODEM_SLEEP_T);
 #endif


### PR DESCRIPTION
The code was sending illegal hostname strings to WiFi.hostname() (which is then submitted to DHCP and often times to DNS.)  A valid hostname contains only alphanumeric characters and hyphens (though it can't start with a hypen.)  This change simply alters the value passed to wifi.hostname() by replacing all non alphanum chars with hyphens while ensuring the first char is never a hyphen.  If the resulting hostname is empty, it uses the escapedMac value (which I'm assuming is initialized by the time this code executes.)

This change would result issue #1033