### PR TITLE
Fix multi-universe ArtNet output

### DIFF
--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -2,7 +2,7 @@
 <html><head><meta name="viewport" content="width=500"><meta charset="utf-8"><title>Sync Settings</title>
 <script>var d=document;
 function H(){window.open("https://github.com/Aircoookie/WLED/wiki/Settings#sync-settings");}function B(){window.open("/settings","_self");}
-function adj(){if (d.Sf.DI.value == 6454) {if (d.Sf.DA.value == 1) d.Sf.DA.value = 0; if (d.Sf.EU.value == 1) d.Sf.EU.value = 0;} 
+function adj(){if (d.Sf.DI.value == 6454) {if (d.Sf.DA.value == 1) d.Sf.DA.value = 0; if (d.Sf.EU.value == 1) d.Sf.EU.value = 0;}
                else if (d.Sf.DI.value == 5568) {if (d.Sf.DA.value == 0) d.Sf.DA.value = 1; if (d.Sf.EU.value == 0) d.Sf.EU.value = 1;} }
 function SP(){var p = d.Sf.DI.value; d.getElementById("xp").style.display = (p > 0)?"none":"block"; if (p > 0) d.Sf.EP.value = p;}
 function SetVal(){switch(parseInt(d.Sf.EP.value)){case 5568: d.Sf.DI.value = 5568; break; case 6454: d.Sf.DI.value = 6454; break; }; SP();}
@@ -41,7 +41,7 @@ Send notifications twice: <input type="checkbox" name="S2">
 <h3>Realtime</h3>
 Receive UDP realtime: <input type="checkbox" name="RD"><br><br>
 <i>Network DMX input</i><br>
-Type: 
+Type:
 <select name=DI onchange="SP(); adj();">
 <option value=5568>E1.31 (sACN)</option>
 <option value=6454>Art-Net</option>
@@ -60,7 +60,7 @@ DMX mode:
 <option value=2>Single DRGB</option>
 <option value=3>Effect</option>
 <option value=4>Multi RGB</option>
-<option value=5>Multi DRGB</option>
+<option value=5>Dimmer + Multi RGB</option>
 </select><br>
 <a href="https://github.com/Aircoookie/WLED/wiki/E1.31-DMX" target="_blank">E1.31 info</a><br>
 Timeout: <input name="ET" type="number" min="1" max="65000" required> ms<br>

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -109,8 +109,8 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, bool isArtnet){
       colSec[2]       = e131_data[DMXAddress+10];
       if (dmxChannels-DMXAddress+1 > 11)
       {
-        col[3]          = e131_data[DMXAddress+11]; //white
-        colSec[3]       = e131_data[DMXAddress+12];
+        col[3]        = e131_data[DMXAddress+11]; //white
+        colSec[3]     = e131_data[DMXAddress+12];
       }
       transitionDelayTemp = 0;                        // act fast
       colorUpdated(NOTIFIER_CALL_MODE_NOTIFICATION);  // don't send UDP
@@ -122,23 +122,23 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, bool isArtnet){
       {
         realtimeLock(realtimeTimeoutMs, mde);
         if (realtimeOverride) return;
-        uint16_t previousLEDs, dmxOffset;
+        uint16_t previousLeds, dmxOffset;
         if (previousUniverses == 0) {
           if (dmxChannels-DMXAddress < 1) return;
           dmxOffset = DMXAddress;
-          previousLEDs = 0;
+          previousLeds = 0;
           // First DMX address is dimmer in DMX_MODE_MULTIPLE_DRGB mode.
           if (DMXMode == DMX_MODE_MULTIPLE_DRGB) {
-              strip.setBrightness( e131_data[dmxOffset++]);
+            strip.setBrightness(e131_data[dmxOffset++]);
           }
         } else {
           // All subsequent universes start at the first channel.
           dmxOffset = isArtnet ? 0 : 1;
-          uint16_t possibleLEDsFirstUniverse = (MAX_CHANNELS_PER_UNIVERSE - DMXAddress) / 3;
-          previousLEDs = possibleLEDsFirstUniverse + (previousUniverses - 1) * MAX_LEDS_PER_UNIVERSE;
+          uint16_t ledsInFirstUniverse = (MAX_CHANNELS_PER_UNIVERSE - DMXAddress) / 3;
+          previousLeds = ledsInFirstUniverse + (previousUniverses - 1) * MAX_LEDS_PER_UNIVERSE;
         }
-        uint16_t ledCount = previousLEDs + (dmxChannels - dmxOffset) / 3;
-        for (uint16_t i = previousLEDs; i < ledCount; i++) {
+        uint16_t ledsTotal = previousLeds + (dmxChannels - dmxOffset) / 3;
+        for (uint16_t i = previousLeds; i < ledsTotal; i++) {
           setRealtimePixel(i, e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++], 0);
         }
         break;


### PR DESCRIPTION
The existing code was very buggy - a 512 channel ArtNet packet sent data to
171 LEDs, not 170. Also the second ArtNet universe was off-by-one.

The math was very confusing with so many branches. The reduces the
amount of code and amount of branching.

Tested with Resolume + my own ArtNet software + 252 LEDs for ArtNet.
Tested with LedFx for e1.31

I suspect further refinement is warranted, arguably the start channel for ArtNet is also "1" (not "0"), at the first byte, while the e1.31 buffer has channel 1 at the second byte due to the start code. 