### PR TITLE
Change product name on JSON page

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -405,7 +405,7 @@ void serializeInfo(JsonObject root)
   root["opt"] = os;
   
   root["brand"] = "WLED";
-  root["product"] = "FOSS";
+  root["product"] = root["arch"].as<String>() + ' ' + root["core"].as<String>() + " (" + root["lwip"].as<String>() + ')';
   root["mac"] = escapedMac;
 }
 


### PR DESCRIPTION
This PR introduces that the product name on the JSON page is the actual board type and environment instead of displaying "FOSS." I've made it match the "Environment" row of the table found on the info tab. I find this to be a much more accurate description of the device that's running WLED.

Here's how it's displayed on the HomeAsssistant devices menu:
![HomeAssistant Screenshot](https://i.imgur.com/xXadqbP.png)