### PR TITLE
fix json state variable typo for sunset offset

### DIFF
--- a/usermods/UserModv2_SunRiseAndSet/UserMod_SunRiseAndSet.h
+++ b/usermods/UserModv2_SunRiseAndSet/UserMod_SunRiseAndSet.h
@@ -166,7 +166,7 @@ public:
         vars["rise_mac"] = m_sunriseMacro;
         vars["set_mac"] = m_sunsetMacro;
         vars["rise_off"] = m_sunriseOffset;
-        vars["set_off"] = m_sunsetMacro;
+        vars["set_off"] = m_sunsetOffset;
     }
 
     ~UserMod_SunRiseAndSet(void)


### PR DESCRIPTION
Only a visual bug, but a bug nevertheless.