### PR TITLE
Bump espressif8266 to v2.6.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -68,15 +68,18 @@ arduino_core_2_6_1 = espressif8266@2.3.0
 arduino_core_2_6_2 = espressif8266@2.3.1
 arduino_core_2_6_3 = espressif8266@2.3.3
 arduino_core_2_7_1 = espressif8266@2.5.1
+arduino_core_2_7_2 = espressif8266@2.6.0
+arduino_core_2_7_3 = espressif8266@2.6.1
+arduino_core_2_7_4 = espressif8266@2.6.2
 
 # Development platforms
 arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
 arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
 
 # Platform to use for ESP8266
-platform_wled_default = ${common.arduino_core_2_7_1}
+platform_wled_default = ${common.arduino_core_2_7_4}
 # We use 2.7.0+ on analog boards because of PWM flicker fix
-platform_latest = ${common.arduino_core_2_7_1}
+platform_latest = ${common.arduino_core_2_7_4}
 
 # ------------------------------------------------------------------------------
 # FLAGS: DEBUG
@@ -234,7 +237,7 @@ build_flags = ${common.build_flags_esp8266} -D LEDPIN=1 -D WLED_DISABLE_INFRARED
 
 [env:esp32dev]
 board = esp32dev
-platform = espressif32@1.11.2
+platform = espressif32@1.12.4
 build_flags = ${common.build_flags_esp32} 
 lib_ignore =
   ESPAsyncTCP
@@ -314,7 +317,7 @@ build_flags = ${common.build_flags_esp8266} -D USE_WS2801
 
 [env:custom32_LEDPIN_16]
 board = esp32dev
-platform = espressif32@1.11.2
+platform = espressif32@1.12.4
 build_flags = ${common.build_flags_esp32} -D LEDPIN=16 
 lib_ignore =
   ESPAsyncTCP
@@ -322,7 +325,7 @@ lib_ignore =
 
 [env:wemos_shield_esp32]
 board = esp32dev
-platform = espressif32@1.11.2
+platform = espressif32@1.12.4
 upload_port = /dev/cu.SLAB_USBtoUART
 monitor_port = /dev/cu.SLAB_USBtoUART
 upload_speed = 460800
@@ -337,7 +340,7 @@ build_flags = ${common.build_flags_esp32} -D LEDPIN=27 -D BTNPIN=39
 lib_ignore = 
 	ESPAsyncTCP
 	ESPAsyncUDP
-platform = espressif32@1.11.2
+platform = espressif32@1.12.4
 
 # ------------------------------------------------------------------------------
 # travis test board configurations


### PR DESCRIPTION
This PR bumps the espressif8266 to v2.6.2, which is Arduino core 2.7.4. I have done limited testing of this, but I can confirm that it's working on my ESP-12E based NodeMCU development board.