### PR TITLE
Add hex color input

### DIFF
--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -935,6 +935,8 @@ input[type=number]::-webkit-outer-spin-button {
 				<div class="sliderdisplay"></div>
 			</div><br>
 		</div>
+		<input name="HC" type="text" placeholder="#000000" onkeyup="hcUpdate()" />
+		<p class="labels" style="display: none;" id="invalidHexColor">Invalid hex color</p>
 		<div id="wwrap">
 			<p class="labels">White channel</p>
 			<div class="sliderwrap il">
@@ -2120,6 +2122,22 @@ function mergeDeep(target, ...sources) {
 	}
 	return mergeDeep(target, ...sources);
 }
+
+function hcUpdate() {
+	const regex = /^#([0-9a-f]{6})$/i;
+	if (regex.test(document.getElementsByName("HC")[0].value)) {
+		document.getElementById("invalidHexColor").style.display = "none";
+		cpick.color.set(document.getElementsByName("HC")[0].value);
+		cpick.forceUpdate();
+		setColor(1);
+	} else {
+		document.getElementById("invalidHexColor").style.display = "block";
+	}
+}
+
+cpick.on('color:change', function(color) {
+	document.getElementsByName("HC")[0].value = color.hexString;
+});
 
 size();
 _C.style.setProperty('--n', N);

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -935,7 +935,7 @@ input[type=number]::-webkit-outer-spin-button {
 				<div class="sliderdisplay"></div>
 			</div><br>
 		</div>
-		<input name="HC" type="text" placeholder="#000000" onkeyup="hcUpdate()" />
+		<input name="HC" type="text" placeholder="#000000" onkeyup="hcUpdate()" spellcheck="false" />
 		<p class="labels" style="display: none;" id="invalidHexColor">Invalid hex color</p>
 		<div id="wwrap">
 			<p class="labels">White channel</p>


### PR DESCRIPTION
This PR relates to issue #1084 and adds a hex color input to the main index page of the UI. If the hex color is not supported, a small message will appear saying "Invalid hex color." Otherwise, the new hex color will be set in the color picker and will be set on the LEDs as well.

Edit: I've also added code to disable the web browser's spell check in the text box as you could see in the GIF.

Here's a small GIF of what was added:
![GIF of new hex input](https://i.imgur.com/jl9vr65.gif)