### PR TITLE
Add PC RGB notes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,14 @@ WS2811 | 12v | 3-LED segments
 WS2815 | 12v | 
 GS8208 | 12v |
 
+## 🧊 Compatibe PC RGB Fans and ARGB accessories
+Brand | Model | Comments
+|---|---|---|
+Corsair | HD120 Fan | Uses WS2812B, data-in only
+PCCOOLER | Moonlight 5-pack Fans | Uses WS2812B, includes Data-out connector to keep each fan uniquely addressable if wired in series like traditional LED strips
+Any | 5v 3-pin ARGB for PC | Any PC RGB device that supports the 5v 3-pin ARGB motherboard header should work fine with WLED. All the major motherboard vendors support the Corsair HD120 and PCCOOLER fans listed, so we can safely assume any device that supports motherboard ARGB 5V 3-Pin standard will work with WLED.
+
+
 ## ✌️ Other
 
 Licensed under the MIT license  


### PR DESCRIPTION
add info for pc argb enthusiasts to know they can use WLED as an alternative to the motherboard controller.