### PR TITLE
check payload to avoid npe

### DIFF
--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -56,6 +56,12 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
 
   DEBUG_PRINT("MQTT msg: ");
   DEBUG_PRINTLN(topic);
+
+  // paranoia check to avoid npe if no payload
+  if (payload==nullptr) {
+    DEBUG_PRINTLN("no payload -> leave");
+    return;
+  }
   DEBUG_PRINTLN(payload);
 
   //no need to check the topic because we only get topics we are subscribed to


### PR DESCRIPTION
With mqtt enabled and iobroker i get exception 28 and reboot in a loop.
This PR is to fix this and handle empty mqtt-messages.


`Exception 28: LoadProhibited: A load referenced a page mapped with an attribute that does not permit loads
Decoding 114 results
0x40233530: Print::println(char const*) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Print.cpp line 198
0x40215dc7: onMqttMessage(char*, char*, AsyncMqttClientMessageProperties, unsigned int, unsigned int, unsigned int) at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/mqtt.cpp line 73
0x402541a3: ppTxPkt at ?? line ?
0x4024772f: ieee80211_output_pbuf at ?? line ?
0x40237e2a: std::_Function_handler ::_M_invoke(std::_Any_data const&, char*, char*, AsyncMqttClientMessageProperties, unsigned int, unsigned int, unsigned int) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2073
0x40105797: wdt_feed at ?? line ?
0x4021a824: AsyncMqttClient::_onMessage(char*, char*, unsigned char, bool, bool, unsigned int, unsigned int, unsigned int, unsigned short) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2174
:  (inlined by) AsyncMqttClient::_onMessage(char*, char*, unsigned char, bool, bool, unsigned int, unsigned int, unsigned int, unsigned short) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client/AsyncMqttClient.cpp line 523
0x40263894: etharp_send_ip at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/netif/etharp.c line 435
0x40215d4c: onMqttMessage(char*, char*, AsyncMqttClientMessageProperties, unsigned int, unsigned int, unsigned int) at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/mqtt.cpp line 55
0x40237e34: std::_Function_base::_Base_manager ::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 1934
0x40237e14: std::_Function_handler ::_M_invoke(std::_Any_data const&, char*, char*, AsyncMqttClientMessageProperties, unsigned int, unsigned int, unsigned int) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2069
0x40263b20: etharp_output_to_arp_index at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/netif/etharp.c line 890
0x40100e20: umm_free_core at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266\umm_malloc/umm_malloc.cpp line 316
0x40237fb5: std::_Function_handler    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>, std::_Placeholder3>, std::_Placeholder4>, std::_Placeholder5>, std::_Placeholder6>, std::_Placeholder7>, std::_Placeholder8>, std::_Placeholder9>)> >::_M_invoke(std::_Any_data const&, char*, char*, unsigned char, bool, bool, unsigned int, unsigned int, unsigned int, unsigned short) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2073
0x4021a433: AsyncMqttClient::_onData(AsyncClient*, char*, unsigned int) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client/AsyncMqttClient.cpp line 402
0x4021b75d: AsyncMqttClientInternals::PublishPacket::_preparePayloadHandling(unsigned int) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client\AsyncMqttClient\Packets/PublishPacket.cpp line 72
0x4021b805: AsyncMqttClientInternals::PublishPacket::parseVariableHeader(char*, unsigned int, unsigned int*) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client\AsyncMqttClient\Packets/PublishPacket.cpp line 55
0x4021a591: AsyncMqttClient::_onData(AsyncClient*, char*, unsigned int) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client/AsyncMqttClient.cpp line 440
0x40219908: std::_Function_base::_Base_manager    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>)> >::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 1931
0x40237ef8: std::_Function_handler    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>)> >::_M_invoke(std::_Any_data const&, unsigned short, unsigned char) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 1893
:  (inlined by) std::_Function_handler    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>)> >::_M_invoke(std::_Any_data const&, unsigned short, unsigned char) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2071
0x402198bc: std::_Function_base::_Base_manager    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>, std::_Placeholder3>, std::_Placeholder4>, std::_Placeholder5>, std::_Placeholder6>, std::_Placeholder7>, std::_Placeholder8>, std::_Placeholder9>)> >::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 1931
0x40237f7c: std::_Function_handler    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>, std::_Placeholder3>, std::_Placeholder4>, std::_Placeholder5>, std::_Placeholder6>, std::_Placeholder7>, std::_Placeholder8>, std::_Placeholder9>)> >::_M_invoke(std::_Any_data const&, char*, char*, unsigned char, bool, bool, unsigned int, unsigned int, unsigned int, unsigned short) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 1893
:  (inlined by) std::_Function_handler    (AsyncMqttClient*, std::_Placeholder1>, std::_Placeholder2>, std::_Placeholder3>, std::_Placeholder4>, std::_Placeholder5>, std::_Placeholder6>, std::_Placeholder7>, std::_Placeholder8>, std::_Placeholder9>)> >::_M_invoke(std::_Any_data const&, char*, char*, unsigned char, bool, bool, unsigned int, unsigned int, unsigned int, unsigned short) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2071
0x40100744: millis at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_wiring.cpp line 188
0x40100744: millis at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_wiring.cpp line 188
0x4021a5c4: std::_Function_handler ::_M_invoke(std::_Any_data const&, void*, AsyncClient*, void*, unsigned int) at c:\users\dirk\.platformio\packages\toolchain-xtensa\xtensa-lx106-elf\include\c++\4.8.2/functional line 2073
0x40226f64: AsyncClient::_recv(tcp_pcb*, pbuf*, long) at D:\Daten\Dirk\Documents\Arduino\WLED/.pio\libdeps\nodemcuv2_debug\ESPAsyncTCP@1.2.0\src/ESPAsyncTCP.cpp line 420
0x40226fa8: AsyncClient::_s_recv(void*, tcp_pcb*, pbuf*, long) at D:\Daten\Dirk\Documents\Arduino\WLED/.pio\libdeps\nodemcuv2_debug\ESPAsyncTCP@1.2.0\src/ESPAsyncTCP.cpp line 498
0x40266398: tcp_input at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/tcp_in.c line 394 (discriminator 1)
0x401009d0: pvPortMalloc at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/heap.cpp line 271
0x40264901: ip_input at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/ipv4/ip.c line 559
0x4010064c: ets_post at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 177
0x40263e41: ethernet_input at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/netif/etharp.c line 1379
0x4025467b: pp_tx_idle_timeout at ?? line ?
0x402545ee: pp_tx_idle_timeout at ?? line ?
0x40259fcf: ets_snprintf at ?? line ?
0x4010524d: call_user_start_local at ?? line ?
0x40105253: call_user_start_local at ?? line ?
0x4010000d: call_user_start at ?? line ?
0x40252e1c: cont_ret at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/cont.S line 142
0x40252dcd: cont_continue at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/cont.S line 51
0x4010403f: lmacProcessTXStartData at ?? line ?
0x4010403c: lmacProcessTXStartData at ?? line ?
0x40102f9f: wDev_ProcessFiq at ?? line ?
0x40102df0: wDev_ProcessFiq at ?? line ?
0x4023b7d9: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c line 251
0x4023b7c8: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c line 246
0x4027f820: sleep_reset_analog_rtcreg_8266 at ?? line ?
0x4023f9ba: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c line 233
0x4023b69d: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c line 194 (discriminator 1)
0x4023f9ba: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c line 233
0x4023f8f0: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c line 180
0x4023b7c8: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c line 246
0x4023f9ba: __ssputs_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c line 233
0x4027f820: sleep_reset_analog_rtcreg_8266 at ?? line ?
0x401045c9: lmacRecycleMPDU at ?? line ?
0x4023fdeb: _svfprintf_r at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf.c line 667
0x4023b7c8: _printf_i at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/nano-vfprintf_i.c line 246
0x40104e55: lmacProcessAckTimeout at ?? line ?
0x4010311e: wDev_ProcessFiq at ?? line ?
0x4027f80f: sleep_reset_analog_rtcreg_8266 at ?? line ?
0x4021a177: AsyncMqttClient::publish(char const*, unsigned char, bool, char const*, unsigned int, bool, unsigned short) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client/AsyncMqttClient.cpp line 864
0x4023bf78: sprintf at /home/earle/src/esp-quick-toolchain/repo/newlib/newlib/libc/stdio/sprintf.c line 646
0x40261a70: tcp_write at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/tcp_out.c line 633
0x40261a1c: tcp_write at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/tcp_out.c line 586
0x40100744: millis at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_wiring.cpp line 188
0x40226c39: AsyncClient::add(char const*, unsigned int, unsigned char) at D:\Daten\Dirk\Documents\Arduino\WLED/.pio\libdeps\nodemcuv2_debug\ESPAsyncTCP@1.2.0\src/ESPAsyncTCP.cpp line 256
0x4021a1b8: AsyncMqttClient::publish(char const*, unsigned char, bool, char const*, unsigned int, bool, unsigned short) at C:\Users\Dirk\Documents\Arduino\WLED-master/wled00\src\dependencies\async-mqtt-client/AsyncMqttClient.cpp line 869
0x40215f0c: publishMqtt() at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/mqtt.cpp line 104
0x401009d0: pvPortMalloc at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/heap.cpp line 271
0x40260f0c: pbuf_alloc at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/pbuf.c line 366
0x40230bc0: esp8266::MDNSImplementation::MDNSResponder::_udpAppendBuffer(unsigned char const*, unsigned int) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266mDNS\src/LEAmDNS_Transfer.cpp line 1096
0x40230180: esp8266::MDNSImplementation::MDNSResponder::stcMDNSSendParameter::addDomainCacheItem(void const*, bool, unsigned short) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266mDNS\src/LEAmDNS_Structs.cpp line 2445 (discriminator 1)
0x401010f4: malloc at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266\umm_malloc/umm_malloc.cpp line 511
0x40230180: esp8266::MDNSImplementation::MDNSResponder::stcMDNSSendParameter::addDomainCacheItem(void const*, bool, unsigned short) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266mDNS\src/LEAmDNS_Structs.cpp line 2445 (discriminator 1)
0x4022f638: esp8266::MDNSImplementation::MDNSResponder::stcMDNS_RRDomain::addLabel(char const*, bool) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266mDNS\src/LEAmDNS_Structs.cpp line 763 (discriminator 2)
0x40230bc0: esp8266::MDNSImplementation::MDNSResponder::_udpAppendBuffer(unsigned char const*, unsigned int) at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266mDNS\src/LEAmDNS_Transfer.cpp line 1096
0x40255097: pp_attach at ?? line ?
0x402550e6: pp_attach at ?? line ?
0x4010064c: ets_post at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 177
0x40101e94: pp_post at ?? line ?
0x402541a3: ppTxPkt at ?? line ?
0x4024772f: ieee80211_output_pbuf at ?? line ?
0x40105797: wdt_feed at ?? line ?
0x40263881: etharp_send_ip at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/netif/etharp.c line 431
0x40263894: etharp_send_ip at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/netif/etharp.c line 435
0x4010064c: ets_post at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 177
0x40101e94: pp_post at ?? line ?
0x40105147: lmacRxDone at ?? line ?
0x40102a2b: rcReachRetryLimit at ?? line ?
0x4010064c: ets_post at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 177
0x40102c0c: rcReachRetryLimit at ?? line ?
0x401030ce: wDev_ProcessFiq at ?? line ?
0x40264ba2: ip_output_if at /home/gauchard/dev/esp8266/esp8266/tools/sdk/lwip/src/core/ipv4/ip.c line 631
0x40102df0: wDev_ProcessFiq at ?? line ?
0x40226850: WiFiUDP::parsePacket() at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiUdp.cpp line 197
0x4021d416: handleNotifications() at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/udp.cpp line 127
0x40100744: millis at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_wiring.cpp line 188
0x4025bc4a: wifi_get_opmode at ?? line ?
0x4025ce2b: wifi_station_get_connect_status at ?? line ?
0x4022685c: WiFiUDP::parsePacket() at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiUdp.cpp line 199
0x4021d433: handleNotifications() at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/udp.cpp line 131
0x4021e4ff: WLED::handleConnection() at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/wled.cpp line 467
0x4010064c: ets_post at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 177
0x40235803: esp_get_cycle_count at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_features.h line 92
:  (inlined by) ?? at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Esp.h line 181
:  (inlined by) esp_yield_within_cont at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 111
:  (inlined by) __yield at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 130
0x4021e685: WLED::loop() at D:\Daten\Dirk\Documents\Arduino\WLED/wled00/wled.cpp line 60
0x4021f158: loop at D:/Daten/Dirk/Documents/Arduino/WLED/wled00/wled00.ino line 21
0x402358f0: loop_wrapper() at C:\Users\Dirk\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/core_esp8266_main.cpp line 197
`