### PR TITLE
Add Dancing Shadows effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3565,6 +3565,7 @@ uint16_t WS2812FX::mode_chunchun(void)
   return FRAMETIME;
 }
 
+
 typedef struct Spotlight {
   float speed;
   uint8_t colorIdx;
@@ -3574,21 +3575,13 @@ typedef struct Spotlight {
   uint8_t type;
 } spotlight;
 
-static const uint8_t SPOT_TYPE_SOLID       = 0;
-static const uint8_t SPOT_TYPE_GRADIENT    = 1;
-static const uint8_t SPOT_TYPE_2X_GRADIENT = 2;
-static const uint8_t SPOT_TYPE_2X_DOT      = 3;
-static const uint8_t SPOT_TYPE_3X_DOT      = 4;
-static const uint8_t SPOT_TYPE_4X_DOT      = 5;
-static const uint8_t SPOT_TYPES_COUNT      = 6;
-
-/*
- * Blends the specified color with the existing pixel color.
- */
-void WS2812FX::blendPixelColor(uint16_t n, uint32_t color, uint8_t blend)
-{
-  setPixelColor(n, color_blend(getPixelColor(n), color, blend));
-}
+#define SPOT_TYPE_SOLID       0
+#define SPOT_TYPE_GRADIENT    1
+#define SPOT_TYPE_2X_GRADIENT 2
+#define SPOT_TYPE_2X_DOT      3
+#define SPOT_TYPE_3X_DOT      4
+#define SPOT_TYPE_4X_DOT      5
+#define SPOT_TYPES_COUNT      6
 
 /*
  * Spotlights moving back and forth that cast dancing shadows.

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -101,7 +101,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  112
+#define MODE_COUNT  113
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -215,6 +215,7 @@
 #define FX_MODE_PHASEDNOISE            109
 #define FX_MODE_FLOW                   110
 #define FX_MODE_CHUNCHUN               111
+#define FX_MODE_DANCING_SHADOWS        112
 
 class WS2812FX {
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
@@ -418,6 +419,7 @@ class WS2812FX {
       _mode[FX_MODE_PHASEDNOISE]             = &WS2812FX::mode_phased_noise;
       _mode[FX_MODE_FLOW]                    = &WS2812FX::mode_flow;
       _mode[FX_MODE_CHUNCHUN]                = &WS2812FX::mode_chunchun;
+      _mode[FX_MODE_DANCING_SHADOWS]         = &WS2812FX::mode_dancing_shadows;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -613,7 +615,8 @@ class WS2812FX {
       mode_sinewave(void),
       mode_phased_noise(void),
       mode_flow(void),
-      mode_chunchun(void);
+      mode_chunchun(void),
+      mode_dancing_shadows(void);
 
   private:
     NeoPixelWrapper *bus;
@@ -665,6 +668,8 @@ class WS2812FX {
 
     CRGB twinklefox_one_twinkle(uint32_t ms, uint8_t salt, bool cat);
     CRGB pacifica_one_layer(uint16_t i, CRGBPalette16& p, uint16_t cistart, uint16_t wavescale, uint8_t bri, uint16_t ioff);
+
+    void blendPixelColor(uint16_t n, uint32_t color, uint8_t blend);
     
     uint32_t _lastPaletteChange = 0;
     uint32_t _lastShow = 0;
@@ -701,7 +706,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
 "Heartbeat","Pacifica","Candle Multi", "Solid Glitter","Sunrise","Phased","Twinkleup","Noise Pal", "Sine","Phased Noise",
-"Flow","Chunchun"
+"Flow","Chunchun","Dancing Shadows"
 ])=====";
 
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -598,6 +598,14 @@ void WS2812FX::fill(uint32_t c) {
 }
 
 /*
+ * Blends the specified color with the existing pixel color.
+ */
+void WS2812FX::blendPixelColor(uint16_t n, uint32_t color, uint8_t blend)
+{
+  setPixelColor(n, color_blend(getPixelColor(n), color, blend));
+}
+
+/*
  * fade out function, higher rate = quicker fade
  */
 void WS2812FX::fade_out(uint8_t rate) {


### PR DESCRIPTION
This adds the Dancing Shadows effect. It's adapted to WLED from [an art project](https://github.com/xxv/dancing-shadows) I did a while back of the same name.

This effect looks best with the speed & intensity set to halfway points and on strings of 100+ LEDs that are arranged linearly. I particularly enjoy feeding a strip of LEDs through tree branches or other things that cast nice shadows onto a ceiling or wall.

To make the code a little cleaner, I added a helper method `blendPixelColor()` that draws a pixel by blending it with the existing pixel color. I'm not sure if this belongs alongside the other drawing methods, so feel free to move it if you think it'd be helpful. I'd be happy to inline it too if that's preferable.

I tried to do some memory optimization and would be happy to take another pass at it if that'd be preferred.