### PR TITLE
make PCARS usermod compatible with WLED > 0.10.0

### DIFF
--- a/usermods/project_cars_shiftlight/wled06_usermod.ino
+++ b/usermods/project_cars_shiftlight/wled06_usermod.ino
@@ -18,25 +18,6 @@ u16 PCARS_maxRPM;
 long PCARS_lastRead = millis() - 2001;
 float PCARS_rpmRatio;
 
-
-void userSetup()
-{
-  UDP.begin(PCARS_localUdpPort);
-}
-
-void userConnected()
-{
-  // new wifi, who dis?
-}
-
-void userLoop()
-{
-  PCARS_readValues();
-  if (PCARS_lastRead > millis() - 2000) {
-    PCARS_buildcolorbars();
-  }
-}
-
 void PCARS_readValues() {
 
   int PCARS_packetSize = UDP.parsePacket();
@@ -48,7 +29,7 @@ void PCARS_readValues() {
     if (len == 1367) { // Telemetry packet. Ignoring everything else.
       PCARS_lastRead = millis();
 
-      arlsLock(realtimeTimeoutMs, REALTIME_MODE_GENERIC);
+      realtimeLock(realtimeTimeoutMs, REALTIME_MODE_GENERIC);
       // current RPM
       memcpy(&PCARS_tempChar, &PCARS_packet[124], 2);
       PCARS_RPM = (PCARS_tempChar[1] << 8) + PCARS_tempChar[0];
@@ -93,4 +74,22 @@ void PCARS_buildcolorbars() {
   }
   colorUpdated(5);
   strip.show();
+}
+
+void userSetup()
+{
+  UDP.begin(PCARS_localUdpPort);
+}
+
+void userConnected()
+{
+  // new wifi, who dis?
+}
+
+void userLoop()
+{
+  PCARS_readValues();
+  if (PCARS_lastRead > millis() - 2000) {
+    PCARS_buildcolorbars();
+  }
 }


### PR DESCRIPTION
With tis fix, the usermod is still working with WLED Versions > 0.10.0.