### PR TITLE
Change default access point name

### DIFF
--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -270,7 +270,12 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     if (request->hasArg("RS")) //complete factory reset
     {
       clearEEPROM();
-      serveMessage(request, 200, "All Settings erased.", "Connect to WLED-AP to setup again",255);
+      escapedMac = WiFi.macAddress();
+      escapedMac.replace(":", "");
+      escapedMac.toLowerCase();
+      strcpy(apSSID, "WLED-");
+      sprintf(apSSID + 5, "%*s", 6, escapedMac.c_str() + 6);
+      serveMessage(request, 200, "All Settings erased.", "Connect to " + String(apSSID) + " to setup again", 255);
       doReboot = true;
     }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -260,7 +260,8 @@ void WLED::initAP(bool resetAP)
     return;
 
   if (!apSSID[0] || resetAP)
-    strcpy(apSSID, "WLED-AP");
+    strcpy(apSSID, "WLED-");
+    sprintf(apSSID + 5, "%*s", 6, escapedMac.c_str() + 6);
   if (resetAP)
     strcpy(apPass, DEFAULT_AP_PASS);
   DEBUG_PRINT("Opening access point ");


### PR DESCRIPTION
This proposed pull request changes the default "WLED-AP" access point name to "WLED-xxxxxx" where "xxxxxx" is the last four characters of the device's MAC address. This will allow users to differentiate their devices before setting them up and this change stops multiple devices from broadcasting on the same SSID, which may be a problem if you have multiple instances.