### PR TITLE
Firefox Custom Scrollbar

### DIFF
--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -60,6 +60,8 @@ body {
 				-ms-user-select: none;
 						user-select: none;
 	-webkit-tap-highlight-color: transparent;
+  scrollbar-width: 6px;
+  scrollbar-color: var(--c-sb) transparent;
 }
 
 html,
@@ -823,11 +825,6 @@ input[type=number]::-webkit-outer-spin-button {
 
 .expanded {
 	display: block;
-}
-
-body {
-  scrollbar-width: 6px;
-  scrollbar-color: var(--c-sb) transparent;
 }
 
 ::-webkit-scrollbar {

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -825,6 +825,11 @@ input[type=number]::-webkit-outer-spin-button {
 	display: block;
 }
 
+body {
+  scrollbar-width: 6px;
+  scrollbar-color: var(--c-sb) transparent;
+}
+
 ::-webkit-scrollbar {
 	width: 6px;
 }


### PR DESCRIPTION
Firefox supports [limited scrollbar customization](https://drafts.csswg.org/css-scrollbars-1/), but currently, WLED does not support them as the CSS differs between Chrome and Firefox. I've added the code to enable the limited customization that Firefox supports, which is not all that Chrome does, but the new scrollbar definitely looks better than the default.

**Before**:
![Old Scrollbar](https://i.imgur.com/T3EGpRr.png)

**After**:
![New Scrollbar](https://i.imgur.com/3QobvTC.png)