### PR TITLE
Async temperature usermod

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -227,24 +227,6 @@ upload_speed = 921600
 board_build.ldscript = ${common.ldscript_4m1m}
 build_flags = ${common.build_flags_esp8266} 
 
-; move to platformio_override.ini before PR
-; lib_deps were copied from above, but should use a variable
-[env:d1_mini_usermod_dallas_temperature_C]
-board = d1_mini
-platform = ${common.platform_wled_default}
-upload_speed = 921600
-board_build.ldscript = ${common.ldscript_4m1m}
-build_flags = ${common.build_flags_esp8266} -D USERMOD_DALLASTEMPERATURE -D USERMOD_DALLASTEMPERATURE_CELSIUS
-lib_deps =
-    FastLED@3.3.2
-    NeoPixelBus@2.5.7
-    ESPAsyncTCP@1.2.0
-    ESPAsyncUDP
-    AsyncTCP@1.0.3
-    https://github.com/Aircoookie/ESPAsyncWebServer
-    IRremoteESP8266@2.7.3
-    milesburton/DallasTemperature@^3.9.0
-
 [env:heltec_wifi_kit_8]
 board = d1_mini
 platform = ${common.platform_wled_default}

--- a/platformio.ini
+++ b/platformio.ini
@@ -227,6 +227,24 @@ upload_speed = 921600
 board_build.ldscript = ${common.ldscript_4m1m}
 build_flags = ${common.build_flags_esp8266} 
 
+; move to platformio_override.ini before PR
+; lib_deps were copied from above, but should use a variable
+[env:d1_mini_usermod_dallas_temperature_C]
+board = d1_mini
+platform = ${common.platform_wled_default}
+upload_speed = 921600
+board_build.ldscript = ${common.ldscript_4m1m}
+build_flags = ${common.build_flags_esp8266} -D USERMOD_DALLASTEMPERATURE -D USERMOD_DALLASTEMPERATURE_CELSIUS
+lib_deps =
+    FastLED@3.3.2
+    NeoPixelBus@2.5.7
+    ESPAsyncTCP@1.2.0
+    ESPAsyncUDP
+    AsyncTCP@1.0.3
+    https://github.com/Aircoookie/ESPAsyncWebServer
+    IRremoteESP8266@2.7.3
+    milesburton/DallasTemperature@^3.9.0
+
 [env:heltec_wifi_kit_8]
 board = d1_mini
 platform = ${common.platform_wled_default}

--- a/usermods/Temperature/platformio_override.ini
+++ b/usermods/Temperature/platformio_override.ini
@@ -1,7 +1,7 @@
 ; Options
 ; -------
 ; USERMOD_DALLASTEMPERATURE                      - define this to have this user mod included wled00\usermods_list.cpp
-; USERMOD_DALLASTEMPERATURE_CELSIUS              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
+; USERMOD_DALLASTEMPERATURE_CELSIUS              - define this to report temperatures in degrees celsius, otherwise fahrenheit will be reported
 ; USERMOD_DALLASTEMPERATURE_MEASUREMENT_INTERVAL - the number of milliseconds between measurements, defaults to 60 seconds
 ; USERMOD_DALLASTEMPERATURE_FIRST_MEASUREMENT_AT - the number of milliseconds after boot to take first measurement, defaults to 20 seconds
 ;

--- a/usermods/Temperature/platformio_override.ini
+++ b/usermods/Temperature/platformio_override.ini
@@ -1,0 +1,13 @@
+; Options
+; -------
+; USERMOD_DALLASTEMPERATURE                      - define this to have this user mod included wled00\usermods_list.cpp
+; USERMOD_DALLASTEMPERATURE_CELSIUS              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
+; USERMOD_DALLASTEMPERATURE_MEASUREMENT_INTERVAL - the number of milliseconds between measurements, defaults to 60 seconds
+; USERMOD_DALLASTEMPERATURE_FIRST_MEASUREMENT_AT - the number of milliseconds after boot to take first measurement, defaults to 20 seconds
+;
+[env:d1_mini_usermod_dallas_temperature_C]
+extends = env:d1_mini
+build_flags = ${common.build_flags_esp8266} -D USERMOD_DALLASTEMPERATURE -D USERMOD_DALLASTEMPERATURE_CELSIUS
+lib_deps = ${env.lib_deps}
+    milesburton/DallasTemperature@^3.9.0
+    OneWire@~2.3.5

--- a/usermods/Temperature/readme.md
+++ b/usermods/Temperature/readme.md
@@ -5,11 +5,18 @@ This usermod will read from an attached DS18B20 temperature sensor (as available
 The temperature is displayed both in the Info section of the web UI as well as published to the `/temperature` MQTT topic if enabled.  
 This usermod will be expanded with support for different sensor types in the future.
 
+If temperature sensor is not detected during boot, this usermod will be disabled.
+
 ## Installation
 
-Copy `usermod_temperature.h` to the wled00 directory.  
-Uncomment the corresponding lines in `usermods_list.cpp` and compile!  
-If this is the only v2 usermod you plan to use, you can alternatively replace `usermods_list.h` in wled00 with the one in this folder.
+Copy the example `platformio_override.ini` to the root directory.  This file should be placed in the same directory as `platformio.ini`.
+
+### Define Your Options
+
+* `USERMOD_DALLASTEMPERATURE`                      - define this to have this user mod included wled00\usermods_list.cpp
+* `USERMOD_DALLASTEMPERATURE_CELSIUS`              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
+* `USERMOD_DALLASTEMPERATURE_MEASUREMENT_INTERVAL` - the number of milliseconds between measurements, defaults to 60 seconds
+* `USERMOD_DALLASTEMPERATURE_FIRST_MEASUREMENT_AT` - the number of milliseconds after boot to take first measurement, defaults to 20 seconds
 
 ## Project link
 
@@ -17,7 +24,10 @@ If this is the only v2 usermod you plan to use, you can alternatively replace `u
 
 ### PlatformIO requirements
 
-You might have to uncomment `DallasTemperature@~3.8.0`,`OneWire@~2.3.5 under` `[common]` section in `platformio.ini`:
+If you are using `platformio_override.ini`, you should be able to refresh the task list and see your custom task, for example `env:d1_mini_usermod_dallas_temperature_C`.
+
+
+If you are not using `platformio_override.ini`, you might have to uncomment `DallasTemperature@~3.8.0`,`OneWire@~2.3.5 under` `[common]` section in `platformio.ini`:
 
 ```ini
 # platformio.ini
@@ -38,3 +48,11 @@ lib_deps_external =
   OneWire@~2.3.5
 ...
 ```
+
+## Change Log
+
+2020-09-12 
+* Changed to use async, non-blocking implementation
+* Do not report low temperatures that indicate an error to mqtt
+* Disable plugin if temperature sensor not detected
+* Report the number of seconds until the first read in the info screen instead of sensor error

--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -22,27 +22,58 @@ class UsermodTemperature : public Usermod {
   private:
     //set last reading as "40 sec before boot", so first reading is taken after 20 sec
     unsigned long lastMeasurement = UINT32_MAX - 40000;
+    // last time requestTemperatures was called
+    unsigned long lastTempRequest;
+    bool waitingForConversion = false;
     float temperature = 0.0f;
+
+    void requestTemperatures() {
+      sensor.requestTemperatures();
+      waitingForConversion = true;
+      lastTempRequest = millis();
+    }
+
+    /**
+     * Calculates the elapsed milliseconds since the specified time.
+     * Handles the case where millis() rolls over after roughly 49.7 days
+     */
+    unsigned long elapsed(unsigned long since) {
+      unsigned long now = millis();
+
+      // no rollover?
+      if (since <= now) {
+        return now - since;
+      }
+
+      // rollover in millis - happens after roughly 49.7 days
+      return (UINT32_MAX - since) + now;
+    }
+
   public:
     void getReading() {
-      sensor.requestTemperatures();
       #ifdef TEMP_CELSIUS
       temperature = sensor.getTempCByIndex(0);
       #else
       temperature = sensor.getTempFByIndex(0);
       #endif
+      waitingForConversion = false;
     }
 
     void setup() {
       sensor.begin();
       sensor.setResolution(9);
+      sensor.setWaitForConversion(false); // do not block waiting for reading
     }
 
     void loop() {
-      if (millis() - lastMeasurement > MEASUREMENT_INTERVAL)
+      if (!waitingForConversion && elapsed(lastMeasurement) > MEASUREMENT_INTERVAL)
       {
-        getReading();
-
+        requestTemperatures();
+      }
+      else if (waitingForConversion && elapsed(lastTempRequest) > 94 /* 93.75ms per the datasheet */)
+      {
+        getReading(); // this will reset waitingForConversion = false
+ 
         if (WLED_MQTT_CONNECTED) {
           char subuf[38];
           strcpy(subuf, mqttDeviceTopic);

--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -70,7 +70,7 @@ class UsermodTemperature : public Usermod {
       {
         requestTemperatures();
       }
-      else if (waitingForConversion && elapsed(lastTempRequest) > 94 /* 93.75ms per the datasheet */)
+      else if (waitingForConversion && elapsed(lastTempRequest) >= 94 /* 93.75ms per the datasheet */)
       {
         getReading(); // this will reset waitingForConversion = false
  

--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -11,78 +11,96 @@
 #define TEMPERATURE_PIN 14
 #endif
 
-#define MEASUREMENT_INTERVAL 60000 //1 Minute
-
-#define ELAPSED(current, previous) ((previous) <= (current) ? (current) - (previous) : (UINT32_MAX - previous) + current)
+// the frequency to check temperature, 1 minute
+#define MEASUREMENT_INTERVAL 60000
+// how many seconds after boot to take first measurement, 20 seconds
+#define FIRST_MEASUREMENT_AT 20000 
 
 OneWire oneWire(TEMPERATURE_PIN);
 DallasTemperature sensor(&oneWire);
 
 class UsermodTemperature : public Usermod {
   private:
+    // The device's unique 64-bit serial code stored in on-board ROM.
+    // Reading directly from the sensor device address is faster than
+    // reading from index. When reading by index, DallasTemperature
+    // must first look up the device address at the specified index.
+    DeviceAddress sensorDeviceAddress;
     // set last reading as "40 sec before boot", so first reading is taken after 20 sec
-    unsigned long lastMeasurement = UINT32_MAX - 40000;
+    unsigned long lastMeasurement = UINT32_MAX - (MEASUREMENT_INTERVAL - FIRST_MEASUREMENT_AT);
     // last time requestTemperatures was called
-    unsigned long lastTemperatureRequest;
+    unsigned long lastTemperaturesRequest;
+    float temperature = -100; // default to -100, DS18B20 only goes down to -50C
     // indicates requestTemperatures has been called but the sensor measurement is not complete
     bool waitingForConversion = false;
-
-    float temperature = DEVICE_DISCONNECTED_C;
-	  DeviceAddress deviceAddress;
+    // simple flag to indicate we have finished the first getTemperature call
+    bool getTemperatureComplete = false;
 
     void requestTemperatures() {
-      sensor.requestTemperatures();
-      waitingForConversion = true;
-      lastTemperatureRequest = millis();
+        // there is requestTemperaturesByAddress however it 
+        // appears to do more work, 
+        // TODO: measure exection time difference
+        sensor.requestTemperatures(); 
+        lastTemperaturesRequest = millis();
+        waitingForConversion = true;
+    }
+
+    void getTemperature() {
+      #ifdef USERMOD_DALLASTEMPERATURE_CELSIUS
+      temperature = sensor.getTempC(sensorDeviceAddress);
+      #else
+      temperature = sensor.getTempF(sensorDeviceAddress);
+      #endif
+
+      lastMeasurement = millis();
+      waitingForConversion = false;
+      getTemperatureComplete = true;
     }
 
   public:
-    void getReading() {
-      #ifdef USERMOD_DALLASTEMPERATURE_CELSIUS
-      //temperature = sensor.getTempCByIndex(0);
-      temperature = sensor.getTempC((uint8_t*) deviceAddress);
-      #else
-      temperature = sensor.getTempFByIndex(0);
-      #endif
-      waitingForConversion = false;
-    }
+
 
     void setup() {
       sensor.begin();
-      sensor.setResolution(9);
-      sensor.setWaitForConversion(false); // do not block waiting for reading
-      // get the device's address to avoid getTemp(C|F)ByIndex calling this every time
-      if (!sensor.getAddress(deviceAddress, 0)) {
-        // ...
-      }
+      // get the unique 64-bit serial code stored in on-board ROM
+      sensor.getAddress(sensorDeviceAddress, 0);
+      // set the resolution for this specific device
+      sensor.setResolution(sensorDeviceAddress, 9, true);
+      // do not block waiting for reading
+      sensor.setWaitForConversion(false); 
     }
 
     void loop() {
       unsigned long now = millis();
 
-      // lastMeasurement only gets updated after we finish our measurement
-      if (ELAPSED(now, lastMeasurement) < MEASUREMENT_INTERVAL)
+      // check to see if we are due for taking a measurement
+      // lastMeasurement will not be updated until the conversion
+      // is complete the the reading is finished
+      if (now - lastMeasurement < MEASUREMENT_INTERVAL)
       {
         return;
       }
 
+      // we are due for a measurement, if we are not already waiting 
+      // for a conversion to complete, then make a new request for temps
       if (!waitingForConversion)
       {
-        // haven't requested the temperature yet
         requestTemperatures();
         return;
       }
 
-      if (ELAPSED(now, lastTemperatureRequest) >= 94 /* 93.75ms per the datasheet */)
+      // we were waiting for a conversion to complete, have we waited log enough?
+      if (now - lastTemperaturesRequest >= 94 /* 93.75ms per the datasheet */)
       {
-        getReading(); // this will reset waitingForConversion = false
-        lastMeasurement = millis();
-
+        getTemperature();
+ 
         if (WLED_MQTT_CONNECTED) {
           char subuf[38];
           strcpy(subuf, mqttDeviceTopic);
-          if (temperature != DEVICE_DISCONNECTED_C) {
-            // dont publish -127 as the graph will get messed up
+          if (-100 <= temperature) {
+            // dont publish super low temperature as the graph will get messed up
+            // the DallasTemperature library returns -127C or -196.6F when problem
+            // reading the sensor
             strcat(subuf, "/temperature");
             mqtt->publish(subuf, 0, true, String(temperature).c_str());
           } else {
@@ -97,7 +115,16 @@ class UsermodTemperature : public Usermod {
       if (user.isNull()) user = root.createNestedObject("u");
 
       JsonArray temp = user.createNestedArray("Temperature");
-      if (temperature == DEVICE_DISCONNECTED_C) {
+
+      if (!getTemperatureComplete) {
+        // if we haven't read the sensor yet, let the user know
+        // that we are still waiting for the first measurement
+        temp.add((FIRST_MEASUREMENT_AT - millis()) / 1000);
+        temp.add(" sec until read");
+        return;
+      }
+
+      if (temperature <= -100) {
         temp.add(0);
         temp.add(" Sensor Error!");
         return;

--- a/usermods/Temperature/usermods_list.cpp
+++ b/usermods/Temperature/usermods_list.cpp
@@ -9,7 +9,10 @@
  * \/ \/ \/
  */
 //#include "usermod_v2_example.h"
-#include "usermod_temperature.h"
+#ifdef USERMOD_DALLASTEMPERATURE
+#include "../usermods/Temperature/usermod_temperature.h"
+#endif
+
 //#include "usermod_v2_empty.h"
 
 void registerUsermods()
@@ -20,6 +23,9 @@ void registerUsermods()
    * \/ \/ \/
    */
   //usermods.add(new MyExampleUsermod());
+#ifdef USERMOD_DALLASTEMPERATURE
   usermods.add(new UsermodTemperature());
+#endif
+
   //usermods.add(new UsermodRenameMe());
 }

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -10,7 +10,9 @@
  * \/ \/ \/
  */
 //#include "usermod_v2_example.h"
-//#include "usermod_temperature.h"
+#ifdef USERMOD_DALLASTEMPERATURE
+#include "../usermods/Temperature/usermod_temperature.h"
+#endif
 //#include "usermod_v2_empty.h"
 
 void registerUsermods()
@@ -21,6 +23,8 @@ void registerUsermods()
    * \/ \/ \/
    */
   //usermods.add(new MyExampleUsermod());
-  //usermods.add(new UsermodTemperature());
+  #ifdef USERMOD_DALLASTEMPERATURE
+  usermods.add(new UsermodTemperature());
+  #endif
   //usermods.add(new UsermodRenameMe());
 }


### PR DESCRIPTION
This PR improves the DallasTemperature usermod. The improvements include:

- Use non-blocking read of sensor. Previous version would block for ~94 ms on each time the temperature is read. See [WaitForConversion](https://github.com/milesburton/Arduino-Temperature-Control-Library/blob/master/examples/WaitForConversion/WaitForConversion.ino) example.
- does not report `0 Sensor Error` before the first temperature is read. Now will display the number of seconds until the first sensor read.
- if sensor is not found during setup, the usermod is disabled. It will not report Temperature in the info and will not continue to try to read the sensor.
- will not report super low temperature that is beyond the senor's specs. The DallasTemperature  library will return really low values for temperature to indicate an error
- add example platformio_override.ini
- allow customization of the temperature read interval and number of seconds after boot to read sensor via compile time #define 
- changed most preprocessor directives to start with `USERMOD_DALLASTEMPERATURE_` to avoid conflicts with other mods or WLED source.
