### PR TITLE
ESP8266: Allow auto modem sleep if power off and sleep permitted

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -84,10 +84,12 @@ void WLED::loop()
 
     handleHue();
     handleBlynk();
-
     yield();
+
     if (!offMode)
       strip.service();
+    else if (offMode && !noWifiSleep)
+      delay(1);
   }
   yield();
 #ifdef ESP8266

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -89,8 +89,8 @@ void WLED::loop()
     if (!offMode)
       strip.service();
 #ifdef ESP8266
-    else if (offMode && !noWifiSleep)
-      delay(1);
+    else if (!noWifiSleep)
+      delay(1); //required to make sure ESP enters modem sleep (see #1184)
 #endif
   }
   yield();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -88,8 +88,10 @@ void WLED::loop()
 
     if (!offMode)
       strip.service();
+#ifdef ESP8266
     else if (offMode && !noWifiSleep)
       delay(1);
+#endif
   }
   yield();
 #ifdef ESP8266


### PR DESCRIPTION
Closes #1144. 

Adds a 1ms delay _only_ when main power is off and the `noWifiSleep` option is not active, and _only_ for the ESP8266. This is needed for the automatic modem sleep to operate on the ESP8266 between DTIM beacons. The ESP32 appears to have a different mechanism, via the `esp_wifi_set_ps()` API call, but that a problem for another issue/PR. 

I'm leaving this as a draft for now, until I've been able to test it for a few days for unforeseen side effects. ;)

To show the effect of this on my Wemos D1 Mini, I powered it via USB and put a calibrated power meter on it. The LED Strip and relay is still being powered via the main PSU. 

[Pre PR video - ~150ma continous](https://drive.google.com/file/d/1qxgkezETsACZFKeU4QbLtIcT25076euF/view?usp=sharing)

[Post PR - rolling 90-120ma](https://drive.google.com/file/d/1r2apWgB8K0hsdP80Ym6kVgxmejDOsFzI/view?usp=sharing)

[Post PR - rolling 80-140ma - second meter](https://drive.google.com/file/d/1r14A52LPN_nJZGMMwX72nC6COJwpHkWP/view?usp=sharing)