### PR TITLE
Add ESP32 touch sensors as button alternative

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -334,6 +334,14 @@ lib_ignore =
   ESPAsyncTCP
   ESPAsyncUDP
 
+[env:custom32_TOUCHPIN_T0]
+board = esp32dev
+platform = espressif32@1.12.4
+build_flags = ${common.build_flags_esp32} -D TOUCHPIN=T0
+lib_ignore =
+  ESPAsyncTCP
+  ESPAsyncUDP
+
 [env:wemos_shield_esp32]
 board = esp32dev
 platform = espressif32@1.12.4

--- a/platformio_override.ini.example
+++ b/platformio_override.ini.example
@@ -21,6 +21,7 @@ build_flags = ${common.build_flags_esp8266}
 ; PIN defines - uncomment and change, if needed:
 ;   -D LEDPIN=2
 ;   -D BTNPIN=0
+;   -D TOUCHPIN=T0
 ;   -D IR_PIN=4
 ;   -D RLYPIN=12
 ;   -D RLYMDE=1

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -15,13 +15,24 @@ void shortPressAction()
   }
 }
 
+bool isButtonPressed()
+{
+  #ifdef BTNPIN
+    if (digitalRead(BTNPIN) == LOW) return true;
+  #endif
+  #ifdef TOUCHPIN
+    if (touchRead(TOUCHPIN) <= TOUCH_THRESHOLD) return true;
+  #endif
+  return false;
+}
+
 
 void handleButton()
 {
-#ifdef BTNPIN
+#if defined(BTNPIN) || defined(TOUCHPIN)
   if (!buttonEnabled) return;
-  
-  if (digitalRead(BTNPIN) == LOW) //pressed
+
+  if (isButtonPressed()) //pressed
   {
     if (!buttonPressedBefore) buttonPressedTime = millis();
     buttonPressedBefore = true;
@@ -37,7 +48,7 @@ void handleButton()
       }
     }
   }
-  else if (digitalRead(BTNPIN) == HIGH && buttonPressedBefore) //released
+  else if (!isButtonPressed() && buttonPressedBefore) //released
   {
     long dur = millis() - buttonPressedTime;
     if (dur < 50) {buttonPressedBefore = false; return;} //too short "press", debounce

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -126,4 +126,6 @@
 
 #define ABL_MILLIAMPS_DEFAULT 850; // auto lower brightness to stay close to milliampere limit
 
+#define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
+
 #endif

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -21,6 +21,7 @@ void updateBlynk();
 
 //button.cpp
 void shortPressAction();
+bool isButtonPressed();
 void handleButton();
 void handleIO();
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -246,8 +246,8 @@ void WLED::beginStrip()
 #endif
 
   // disable button if it is "pressed" unintentionally
-#ifdef BTNPIN
-  if (digitalRead(BTNPIN) == LOW)
+#if defined(BTNPIN) || defined(TOUCHPIN)
+  if (isButtonPressed())
     buttonEnabled = false;
 #else
   buttonEnabled = false;


### PR DESCRIPTION
This PR adds the option to use the builtin ESP32 touch sensors with the existing button functionality. So it can trigger custom macros etc. without additional hardware.
Like with physical buttons it can be enabled with a define, in this case `TOUCHPIN`. If a normal `BTNPIN` is defined as well, it will read both and will execute the action if at least one of them is pressed/touched.
Should fix issue #752.