### PR TITLE
Enable explicit sunrise or sunset

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -109,6 +109,8 @@
 #define NL_MODE_FADE              1            //Fade to target brightness gradually
 #define NL_MODE_COLORFADE         2            //Fade to target brightness and secondary color gradually
 #define NL_MODE_SUN               3            //Sunrise/sunset. Target brightness is set immediately, then Sunrise effect is started. Max 60 min.
+#define NL_MODE_SUNRISE           4            //Explicit choide of sunrise, else identical to NL_MODE_SUN
+#define NL_MODE_SUNSET            5            //Explicit choide of sunset,  else identical to NL_MODE_SUN
 
 //EEPROM size
 #define EEPSIZE 2560  //Maximum is 4096

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -169,7 +169,9 @@
 			<option value="0">Wait and set</option>
 			<option value="1">Fade</option>
 			<option value="2">Fade Color</option>
-			<option value="3">Sunrise</option>
+			<option value="3">Sunrise/Sunset</option>
+			<option value="4">Sunrise</option>
+			<option value="5">Sunset</option>
 		</select>
 		<h3>Advanced</h3>
 		Palette blending:

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -646,11 +646,13 @@ bool handleSet(AsyncWebServerRequest *request, const String& req)
   pos = req.indexOf(F("NF="));
   if (pos > 0)
   {
-    nightlightMode = getNumVal(&req, pos);
-
+    byte tmp = getNumVal(&req, pos);
+    if (tmp > NL_MODE_SUNSET) {
+      tmp = NL_MODE_SUNSET;
+    }
+    nightlightMode = (tmp <= NL_MODE_SUNSET) ? tmp : NL_MODE_SUNSET;
     nightlightActiveOld = false; //re-init
   }
-  if (nightlightMode > NL_MODE_SUN) nightlightMode = NL_MODE_SUN;
 
   #if AUXPIN >= 0
   //toggle general purpose output


### PR DESCRIPTION
Adds explicit nightlight setting for sunrise and explicit setting for sunset.

This allows nightlight function to deterministically start sunrise or sunset (e.g., from HTTP or JSON API).

Fixes #1214