### PR TITLE
Disable onboard LED when LEDs are not in use

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -650,7 +650,6 @@ class WS2812FX {
     void handle_palette(void);
 
     bool
-      firstRun = true,
       shouldStartBus = false,
       _useRgbw = false,
       _skipFirstMode,

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -650,6 +650,8 @@ class WS2812FX {
     void handle_palette(void);
 
     bool
+      firstRun = true,
+      shouldStartBus = false,
       _useRgbw = false,
       _skipFirstMode,
       _triggered;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -396,14 +396,18 @@ void WS2812FX::setBrightness(uint8_t b) {
     {
       _segments[i].setOption(SEG_OPTION_FREEZE, false);
     }
-    if (!shouldStartBus)
-      shouldStartBus = true;
+    #if LEDPIN == LED_BUILTIN
+      if (!shouldStartBus)
+        shouldStartBus = true;
+    #endif
   } else {
-    if (shouldStartBus) {
-      shouldStartBus = false;
-      const uint8_t ty = _useRgbw ? 2 : 1;
-      bus->Begin((NeoPixelType)ty, _lengthRaw);
-    }
+    #if LEDPIN == LED_BUILTIN
+      if (shouldStartBus) {
+        shouldStartBus = false;
+        const uint8_t ty = _useRgbw ? 2 : 1;
+        bus->Begin((NeoPixelType)ty, _lengthRaw);
+      }
+    #endif
   }
   if (SEGENV.next_time > millis() + 22 && millis() - _lastShow > MIN_SHOW_DELAY) show();//apply brightness change immediately if no refresh soon
 }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -396,6 +396,13 @@ void WS2812FX::setBrightness(uint8_t b) {
     {
       _segments[i].setOption(SEG_OPTION_FREEZE, false);
     }
+    (!shouldStartBus) ? (shouldStartBus = true) : (firstRun = false);
+  } else {
+    if (shouldStartBus) {
+      shouldStartBus = false;
+      const uint8_t ty = _useRgbw ? 2 : 1;
+      bus->Begin((NeoPixelType)ty, _lengthRaw);
+    }
   }
   if (SEGENV.next_time > millis() + 22 && millis() - _lastShow > MIN_SHOW_DELAY) show();//apply brightness change immediately if no refresh soon
 }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -396,7 +396,8 @@ void WS2812FX::setBrightness(uint8_t b) {
     {
       _segments[i].setOption(SEG_OPTION_FREEZE, false);
     }
-    (!shouldStartBus) ? (shouldStartBus = true) : (firstRun = false);
+    if (!shouldStartBus)
+      shouldStartBus = true;
   } else {
     if (shouldStartBus) {
       shouldStartBus = false;

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -87,7 +87,7 @@ void handleIO()
   {
     lastOnTime = millis();
     if (offMode)
-    { 
+    {
       #if RLYPIN >= 0
        digitalWrite(RLYPIN, RLYMDE);
       #endif
@@ -95,9 +95,13 @@ void handleIO()
     }
   } else if (millis() - lastOnTime > 600)
   {
-    #if RLYPIN >= 0
-     if (!offMode) digitalWrite(RLYPIN, !RLYMDE);
-    #endif
+     if (!offMode) {
+      pinMode(LEDPIN, OUTPUT);
+      digitalWrite(LEDPIN, HIGH);
+      #if RLYPIN >= 0
+       digitalWrite(RLYPIN, !RLYMDE);
+      #endif
+     }
     offMode = true;
   }
 

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -97,8 +97,8 @@ void handleIO()
   {
      if (!offMode) {
       #if LEDPIN == LED_BUILTIN
-        pinMode(LEDPIN, OUTPUT);
-        digitalWrite(LEDPIN, HIGH);
+        pinMode(LED_BUILTIN, OUTPUT);
+        digitalWrite(LED_BUILTIN, HIGH);
       #endif
       #if RLYPIN >= 0
        digitalWrite(RLYPIN, !RLYMDE);

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -96,8 +96,10 @@ void handleIO()
   } else if (millis() - lastOnTime > 600)
   {
      if (!offMode) {
-      pinMode(LEDPIN, OUTPUT);
-      digitalWrite(LEDPIN, HIGH);
+      #if LEDPIN == LED_BUILTIN
+        pinMode(LEDPIN, OUTPUT);
+        digitalWrite(LEDPIN, HIGH);
+      #endif
       #if RLYPIN >= 0
        digitalWrite(RLYPIN, !RLYMDE);
       #endif


### PR DESCRIPTION
This pull request seeks to disable the onboard LED when the LEDs are not in use, closing issue #18 and #1210 🎉

As of now, please do not merge this pull request as I am seeking input on how to go about enabling this option. Currently, it is on by default, which shouldn't be an issue, but should this be a build flag or enabled in the UI instead? Please either leave a review suggestion for me to accept or let me know and I can try to implement it myself.