### PR TITLE
Update usermod_PIR_sensor_switch.h

### DIFF
--- a/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
+++ b/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
@@ -99,7 +99,9 @@ class PIRsensorSwitch : public Usermod {
      */
     bool handleOffTimer() {
       if (m_offTimerStart > 0 && millis() - m_offTimerStart > m_switchOffDelay) {
-        switchStrip(false);
+        if (m_PIRenabled == true){
+          switchStrip(false);
+        }
         m_offTimerStart = 0;        
         return true;
       }


### PR DESCRIPTION
Current: If I disable PIR after it switch strip on, it'll switch off by timer.
Update: If I disable PIR after it switch strip on, it'll keep strip on.