### PR TITLE
Button-click type in MQTT topic

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -1,19 +1,5 @@
 #include "wled.h"
 
-/* 
- * Sending button state over MQTT
- * User const define in const.h
- */
-
-void publishMQTTBTNClick(int clickTypeBtn)
-{
-  if (!WLED_MQTT_CONNECTED ) return; // if MQTT is not connected stop
-  char subuf[38];
-  strcpy(subuf, mqttDeviceTopic);
-  strcat(subuf, "/btn");             // publish in /btn topic
-  mqtt->publish(subuf, 0, true, String(clickTypeBtn).c_str()); // send MQTT publication
-}
-
 /*
  * Physical IO
  */
@@ -27,7 +13,7 @@ void shortPressAction()
   } else {
     applyMacro(macroButton);
   }
-  publishMQTTBTNClick(BTN_SIMPLE_CLICK);
+  mqttBTNState = BTN_SIMPLE_CLICK;
 }
 
 bool isButtonPressed()
@@ -60,7 +46,7 @@ void handleButton()
         else _setRandomColor(false,true);
 
         buttonLongPressed = true;
-         publishMQTTBTNClick(BTN_LONG_CLICK);
+         mqttBTNState = BTN_LONG_CLICK;
       }
     }
   }
@@ -81,7 +67,7 @@ void handleButton()
         if (doublePress)
         {
           applyMacro(macroDoublePress);
-          publishMQTTBTNClick(BTN_DOUBLE_CLICK);
+          mqttBTNState = BTN_DOUBLE_CLICK;
         }
         else buttonWaitTime = millis();
       } else shortPressAction();

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -1,5 +1,20 @@
 #include "wled.h"
 
+/* 
+ * Sending button state over MQTT
+ * User cont define in const.h
+ */
+
+void publishMQTTBTNClick(int clickTypeBtn)
+{
+  if (!WLED_MQTT_CONNECTED ) return; // ajout de || !buttonMQTTEnabled qud pret
+  //if(mqtt == nullptr) return;
+  char subuf[38];
+  strcpy(subuf, mqttDeviceTopic);
+  strcat(subuf, "/btn");
+  mqtt->publish(subuf, 0, true, String(clickTypeBtn).c_str());
+}
+
 /*
  * Physical IO
  */
@@ -13,6 +28,7 @@ void shortPressAction()
   } else {
     applyMacro(macroButton);
   }
+  publishMQTTBTNClick(BTN_SIMPLE_CLICK);
 }
 
 bool isButtonPressed()
@@ -45,6 +61,7 @@ void handleButton()
         else _setRandomColor(false,true);
 
         buttonLongPressed = true;
+         publishMQTTBTNClick(BTN_LONG_CLICK);
       }
     }
   }
@@ -62,7 +79,11 @@ void handleButton()
     else if (!buttonLongPressed) { //short press
       if (macroDoublePress)
       {
-        if (doublePress) applyMacro(macroDoublePress);
+        if (doublePress)
+        {
+          applyMacro(macroDoublePress);
+          publishMQTTBTNClick(BTN_DOUBLE_CLICK);
+        }
         else buttonWaitTime = millis();
       } else shortPressAction();
     }

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -2,17 +2,16 @@
 
 /* 
  * Sending button state over MQTT
- * User cont define in const.h
+ * User const define in const.h
  */
 
 void publishMQTTBTNClick(int clickTypeBtn)
 {
-  if (!WLED_MQTT_CONNECTED ) return; // ajout de || !buttonMQTTEnabled qud pret
-  //if(mqtt == nullptr) return;
+  if (!WLED_MQTT_CONNECTED ) return; // if MQTT is not connected stop
   char subuf[38];
   strcpy(subuf, mqttDeviceTopic);
-  strcat(subuf, "/btn");
-  mqtt->publish(subuf, 0, true, String(clickTypeBtn).c_str());
+  strcat(subuf, "/btn");             // publish in /btn topic
+  mqtt->publish(subuf, 0, true, String(clickTypeBtn).c_str()); // send MQTT publication
 }
 
 /*

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -13,7 +13,7 @@ void shortPressAction()
   } else {
     applyMacro(macroButton);
   }
-  mqttBTNState = BTN_SIMPLE_CLICK;
+  publishMQTTBTNClick(BTN_SIMPLE_CLICK);
 }
 
 bool isButtonPressed()
@@ -46,7 +46,7 @@ void handleButton()
         else _setRandomColor(false,true);
 
         buttonLongPressed = true;
-         mqttBTNState = BTN_LONG_CLICK;
+         publishMQTTBTNClick(BTN_LONG_CLICK);
       }
     }
   }
@@ -67,7 +67,7 @@ void handleButton()
         if (doublePress)
         {
           applyMacro(macroDoublePress);
-          mqttBTNState = BTN_DOUBLE_CLICK;
+          publishMQTTBTNClick(BTN_DOUBLE_CLICK);
         }
         else buttonWaitTime = millis();
       } else shortPressAction();

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -129,6 +129,11 @@
 
 #define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
 
+// int to be send over MQTT to depict button clicks 
+#define BTN_SIMPLE_CLICK      1001 //sent to broker when short click
+#define BTN_DOUBLE_CLICK      1002 //sent to broker when double click
+#define BTN_LONG_CLICK        1003 //sent to broker when long click
+
 // Size of buffer for API JSON object (increase for more segments)
 #ifdef ESP8266
   #define JSON_BUFFER_SIZE 9216

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -110,6 +110,7 @@ void parseLxJson(int lxValue, byte segId, bool secondary);
 //mqtt.cpp
 bool initMqtt();
 void publishMqtt();
+void publishMQTTBTNClick(int clickTypeBtn);
 
 //ntp.cpp
 void handleNetworkTime();

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -112,7 +112,7 @@ void publishMqtt()
   char subuf[38];
   strcpy(subuf, mqttDeviceTopic);
   strcat(subuf, "/btn");             // publish in /btn topic
-  mqtt->publish(subuf, 0, true, String(mqttBTNState ).c_str()); // send MQTT publication
+  mqtt->publish(subuf, 0, true, String(mqttBTNState).c_str()); // send MQTT publication
 }
 
 

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -107,7 +107,6 @@ void publishMqtt()
   strcpy(subuf, mqttDeviceTopic);
   strcat(subuf, "/v");
   mqtt->publish(subuf, 0, true, apires);
-  
 }
 
 // publish button state

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -113,6 +113,7 @@ void publishMqtt()
   strcpy(subuf, mqttDeviceTopic);
   strcat(subuf, "/btn");             // publish in /btn topic
   mqtt->publish(subuf, 0, true, String(mqttBTNState).c_str()); // send MQTT publication
+  mqttBTNState = 0; // to prevent updating button state to the next publishing outside a click event
 }
 
 

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -107,6 +107,12 @@ void publishMqtt()
   strcpy(subuf, mqttDeviceTopic);
   strcat(subuf, "/v");
   mqtt->publish(subuf, 0, true, apires);
+  
+ // publish button state
+  char subuf[38];
+  strcpy(subuf, mqttDeviceTopic);
+  strcat(subuf, "/btn");             // publish in /btn topic
+  mqtt->publish(subuf, 0, true, String(mqttBTNState ).c_str()); // send MQTT publication
 }
 
 

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -108,14 +108,17 @@ void publishMqtt()
   strcat(subuf, "/v");
   mqtt->publish(subuf, 0, true, apires);
   
- // publish button state
-  char subuf[38];
-  strcpy(subuf, mqttDeviceTopic);
-  strcat(subuf, "/btn");             // publish in /btn topic
-  mqtt->publish(subuf, 0, true, String(mqttBTNState).c_str()); // send MQTT publication
-  mqttBTNState = 0; // to prevent updating button state to the next publishing outside a click event
 }
 
+// publish button state
+void publishMQTTBTNClick(int clickTypeBtn)
+{
+  if (!WLED_MQTT_CONNECTED) return;
+  char subuf[38];
+  strcpy(subuf, mqttDeviceTopic);
+  strcat(subuf, "/btn");
+  mqtt->publish(subuf, 0, true, String(clickTypeBtn).c_str());
+}
 
 //HA autodiscovery was removed in favor of the native integration in HA v0.102.0
 
@@ -153,4 +156,5 @@ bool initMqtt()
 #else
 bool initMqtt(){return false;}
 void publishMqtt(){}
+void publishMQTTBTNClick(int clickTypeBtn){}
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -260,7 +260,6 @@ WLED_GLOBAL char mqttUser[41] _INIT("");                   // optional: username
 WLED_GLOBAL char mqttPass[41] _INIT("");                   // optional: password for MQTT auth
 WLED_GLOBAL char mqttClientID[41] _INIT("");               // override the client ID
 WLED_GLOBAL uint16_t mqttPort _INIT(1883);
-WLED_GLOBAL uint16_t mqttBTNState _INIT(0);                //depict btn state / valorized with const in const.h
 
 WLED_GLOBAL bool huePollingEnabled _INIT(false);           // poll hue bridge for light state
 WLED_GLOBAL uint16_t huePollIntervalMs _INIT(2500);        // low values (< 1sec) may cause lag but offer quicker response

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -260,6 +260,7 @@ WLED_GLOBAL char mqttUser[41] _INIT("");                   // optional: username
 WLED_GLOBAL char mqttPass[41] _INIT("");                   // optional: password for MQTT auth
 WLED_GLOBAL char mqttClientID[41] _INIT("");               // override the client ID
 WLED_GLOBAL uint16_t mqttPort _INIT(1883);
+WLED_GLOBAL uint16_t mqttBTNState _INIT(0);                //depict btn state / valorized with const in const.h
 
 WLED_GLOBAL bool huePollingEnabled _INIT(false);           // poll hue bridge for light state
 WLED_GLOBAL uint16_t huePollIntervalMs _INIT(2500);        // low values (< 1sec) may cause lag but offer quicker response


### PR DESCRIPTION
Hi There,

I propose a really tiny modification to send over mqtt the button-click type, in a '[mqttDeviceTopic]/btn' topic.
it can takes 3 differents values corresponding of short, double and long click. defined as constants in 'const.h'

In button.cpp is calling 'publishMQTTBTNClick' a dedicated function in mqtt.cpp.

=> I haven't implement the publishing in the global 'publishMqtt' in order to handle click that do not change leds status.
 for instance, you could send a long click that is defined to trigger an empty macro.

The objective is a better interaction with home automation for device based on Wled.

Tested on Wemos D1 mini / mosquitto broker on RPI3 / Jeedom home automation.
Compiled through arduino IDE.
