### PR TITLE
Add status led

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -103,6 +103,7 @@ void WLED::loop()
   }
   yield();
   handleWs();
+  handleStatusLED();
 
 // DEBUG serial logging
 #ifdef WLED_DEBUG
@@ -172,6 +173,10 @@ void WLED::setup()
     SPIFFS.begin(true);
   #endif
     SPIFFS.begin();
+#endif
+
+#if STATUSLED && STATUSLED != LEDPIN
+  pinMode(STATUSLED, OUTPUT);
 #endif
 
   DEBUG_PRINTLN(F("Load EEPROM"));
@@ -503,4 +508,32 @@ void WLED::handleConnection()
       DEBUG_PRINTLN(F("Access point disabled."));
     }
   }
+}
+
+void WLED::handleStatusLED()
+{
+  #if STATUSLED && STATUSLED != LEDPIN
+  ledStatusType = WLED_CONNECTED ? 0 : 2;
+  if (mqttEnabled && ledStatusType != 2) // Wi-Fi takes presendence over MQTT
+    ledStatusType = WLED_MQTT_CONNECTED ? 0 : 4;
+  if (ledStatusType) {
+    if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
+      ledStatusLastMillis = millis();
+      if (ledStatusState) {
+        ledStatusState = 0;
+        digitalWrite(STATUSLED, ledStatusState);
+      } else {
+        ledStatusState = 1;
+        digitalWrite(STATUSLED, ledStatusState);
+      }
+    }
+  } else {
+    #ifdef STATUSLEDINVERTED
+      digitalWrite(STATUSLED, HIGH);
+    #else
+      digitalWrite(STATUSLED, LOW);
+    #endif
+    
+  }
+  #endif
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -519,13 +519,8 @@ void WLED::handleStatusLED()
   if (ledStatusType) {
     if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
       ledStatusLastMillis = millis();
-      if (ledStatusState) {
-        ledStatusState = 0;
-        digitalWrite(STATUSLED, ledStatusState);
-      } else {
-        ledStatusState = 1;
-        digitalWrite(STATUSLED, ledStatusState);
-      }
+      ledStatusState ? 0 : 1;
+      digitalWrite(STATUSLED, ledStatusState);
     }
   } else {
     #ifdef STATUSLEDINVERTED

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -519,7 +519,7 @@ void WLED::handleStatusLED()
   if (ledStatusType) {
     if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
       ledStatusLastMillis = millis();
-      ledStatusState ? 0 : 1;
+      ledStatusState = ledStatusState ? 0 : 1;
       digitalWrite(STATUSLED, ledStatusState);
     }
   } else {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -509,7 +509,7 @@ WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 // Status LED
 #if STATUSLED && STATUSLED != LEDPIN
   WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);
-  WLED_GLOBAL int ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
+  WLED_GLOBAL unsigned short ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
   WLED_GLOBAL bool ledStatusState _INIT(0); // the current LED state
 #endif
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -506,6 +506,13 @@ WLED_GLOBAL WS2812FX strip _INIT(WS2812FX());
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 
+// Status LED
+#if STATUSLED && STATUSLED != LEDPIN
+  WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);
+  WLED_GLOBAL int ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
+  WLED_GLOBAL bool ledStatusState _INIT(0); // the current LED state
+#endif
+
 // debug macro variable definitions
 #ifdef WLED_DEBUG
   WLED_GLOBAL unsigned long debugTime _INIT(0);
@@ -544,5 +551,6 @@ public:
   void initAP(bool resetAP = false);
   void initConnection();
   void initInterfaces();
+  void handleStatusLED();
 };
 #endif        // WLED_H


### PR DESCRIPTION
This pull request adds a status led to WLED. If Wi-Fi is disconnected, the status LED will blink 2 times a second. If MQTT disconnects, the LED will blink 4 times per second. The descriptions below document the variable changes I made:

| Build Flag | Optional | Description |
|-|-|-|
| STATUSLED | Yes, but not defining will disable the functionality | Set this to any pin number besides LEDPIN in order to enable the status LED functionality |
| STATUSLEDINVERTED | Yes | Define this if the status pin should be inverted |

| Global Variable | Description |
|-|-|
| ledStatusLastMillis | Stores the last LED update time from `millis()` |
| ledStatusType | Currently displayed status type. This corresponds to the number of blinks per second. 0 for OK, 2 for Wi-Fi disconnected and 4 for MQTT disconnected. |
| ledStatusState | Current LED state, 0 for `LOW` and 1 for `HIGH` |