### PR TITLE
Add status pixel

### DIFF
--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -121,18 +121,20 @@ void _overlayAnalogCountdown()
 
 void _overlayStatusPixel()
 {
-  if (briT == 0) {
-    strip.setRange(1, ledCount-1, 0);
-    #ifdef STATUSPIXELBRI
-      strip.setBrightness(STATUSPIXELBRI);
+  #if STATUSLED == -1
+    if (briT == 0) {
+      strip.setRange(1, ledCount-1, 0);
+      #ifdef STATUSPIXELBRI
+        strip.setBrightness(STATUSPIXELBRI);
+      #else
+        strip.setBrightness(255);
+      #endif
+    }
+    #ifdef STATUSPIXELCOL
+      strip.setPixelColor(0, (ledStatusState ? STATUSPIXELCOL : 0));
     #else
-      strip.setBrightness(255);
+      strip.setPixelColor(0, (ledStatusState ? 255 : 0));
     #endif
-  }
-  #ifdef STATUSPIXELCOL
-    strip.setPixelColor(0, (ledStatusState ? STATUSPIXELCOL : 0));
-  #else
-    strip.setPixelColor(0, (ledStatusState ? 255 : 0));
   #endif
 }
 

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -119,6 +119,10 @@ void _overlayAnalogCountdown()
   overlayRefreshMs = 998;
 }
 
+void _overlayStatusPixel()
+{
+  strip.setPixelColor(0, (ledStatusState ? 255 : 0));
+}
 
 void handleOverlayDraw() {
   if (!overlayCurrent) return;
@@ -126,6 +130,7 @@ void handleOverlayDraw() {
   {
     case 1: _overlayAnalogClock(); break;
     case 3: _drawOverlayCronixie(); break;
+    case 4: _overlayStatusPixel(); break;
   }
 }
 

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -123,9 +123,17 @@ void _overlayStatusPixel()
 {
   if (briT == 0) {
     strip.setRange(1, ledCount-1, 0);
-    strip.setBrightness(255);
+    #ifdef STATUSPIXELBRI
+      strip.setBrightness(STATUSPIXELBRI);
+    #else
+      strip.setBrightness(255);
+    #endif
   }
-  strip.setPixelColor(0, (ledStatusState ? 255 : 0));
+  #ifdef STATUSPIXELCOL
+    strip.setPixelColor(0, (ledStatusState ? STATUSPIXELCOL : 0));
+  #else
+    strip.setPixelColor(0, (ledStatusState ? 255 : 0));
+  #endif
 }
 
 void handleOverlayDraw() {

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -121,6 +121,10 @@ void _overlayAnalogCountdown()
 
 void _overlayStatusPixel()
 {
+  if (briT == 0) {
+    strip.setRange(1, ledCount-1, 0);
+    strip.setBrightness(255);
+  }
   strip.setPixelColor(0, (ledStatusState ? 255 : 0));
 }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -103,6 +103,7 @@ void WLED::loop()
   }
   yield();
   handleWs();
+  handleStatusLED();
 
 // DEBUG serial logging
 #ifdef WLED_DEBUG
@@ -172,6 +173,10 @@ void WLED::setup()
     SPIFFS.begin(true);
   #endif
     SPIFFS.begin();
+#endif
+
+#if STATUSLED && STATUSLED != LEDPIN
+  pinMode(STATUSLED, OUTPUT);
 #endif
 
   DEBUG_PRINTLN(F("Load EEPROM"));
@@ -503,4 +508,32 @@ void WLED::handleConnection()
       DEBUG_PRINTLN(F("Access point disabled."));
     }
   }
+}
+
+void WLED::handleStatusLED()
+{
+  #if STATUSLED && STATUSLED != LEDPIN
+  ledStatusType = WLED_CONNECTED ? 0 : 2;
+  if (mqttEnabled && ledStatusType != 2) // Wi-Fi takes presendence over MQTT
+    ledStatusType = WLED_MQTT_CONNECTED ? 0 : 4;
+  if (ledStatusType) {
+    if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
+      ledStatusLastMillis = millis();
+      if (ledStatusState) {
+        ledStatusState = 0;
+        digitalWrite(STATUSLED, ledStatusState);
+      } else {
+        ledStatusState = 1;
+        digitalWrite(STATUSLED, ledStatusState);
+      }
+    }
+  } else {
+    #ifdef STATUSLEDINVERTED
+      digitalWrite(STATUSLED, HIGH);
+    #else
+      digitalWrite(STATUSLED, LOW);
+    #endif
+    
+  }
+  #endif
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -514,7 +514,7 @@ void WLED::handleStatusLED()
 {
   #if STATUSLED && STATUSLED != LEDPIN
     ledStatusType = WLED_CONNECTED ? 0 : 1;
-    if (mqttEnabled && ledStatusType != 2) // Wi-Fi takes presendence over MQTT
+    if (mqttEnabled && ledStatusType != 1) // Wi-Fi takes presendence over MQTT
       ledStatusType = WLED_MQTT_CONNECTED ? 0 : 2;
     if (ledStatusType) {
       if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -519,13 +519,8 @@ void WLED::handleStatusLED()
   if (ledStatusType) {
     if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
       ledStatusLastMillis = millis();
-      if (ledStatusState) {
-        ledStatusState = 0;
-        digitalWrite(STATUSLED, ledStatusState);
-      } else {
-        ledStatusState = 1;
-        digitalWrite(STATUSLED, ledStatusState);
-      }
+      ledStatusState ? 0 : 1;
+      digitalWrite(STATUSLED, ledStatusState);
     }
   } else {
     #ifdef STATUSLEDINVERTED

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -519,7 +519,7 @@ void WLED::handleStatusLED()
   if (ledStatusType) {
     if (millis() - ledStatusLastMillis >= (1000/ledStatusType)) {
       ledStatusLastMillis = millis();
-      ledStatusState ? 0 : 1;
+      ledStatusState = ledStatusState ? 0 : 1;
       digitalWrite(STATUSLED, ledStatusState);
     }
   } else {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -276,7 +276,7 @@ WLED_GLOBAL bool useAMPM _INIT(false);            // 12h/24h clock format
 WLED_GLOBAL byte currentTimezone _INIT(0);        // Timezone ID. Refer to timezones array in wled10_ntp.ino
 WLED_GLOBAL int utcOffsetSecs _INIT(0);           // Seconds to offset from UTC before timzone calculation
 
-WLED_GLOBAL byte overlayDefault _INIT(0);                               // 0: no overlay 1: analog clock 2: single-digit clocl 3: cronixie
+WLED_GLOBAL byte overlayDefault _INIT(0);                               // 0: no overlay 1: analog clock 2: single-digit clocl 3: cronixie 4: status pixel
 WLED_GLOBAL byte overlayMin _INIT(0), overlayMax _INIT(ledCount - 1);   // boundaries of overlay mode
 
 WLED_GLOBAL byte analogClock12pixel _INIT(0);               // The pixel in your strip where "midnight" would be
@@ -511,6 +511,10 @@ WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
   WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);
   WLED_GLOBAL unsigned short ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
   WLED_GLOBAL bool ledStatusState _INIT(0); // the current LED state
+  #if STATUSLED == -1
+    WLED_GLOBAL bool lastActive _INIT(0); // if the overlay was last active
+    WLED_GLOBAL byte lastOverlay _INIT(overlayDefault); // last active overlay (before status pixel overlay)
+  #endif
 #endif
 
 // debug macro variable definitions

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -509,7 +509,7 @@ WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 // Status LED
 #if STATUSLED && STATUSLED != LEDPIN
   WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);
-  WLED_GLOBAL int ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
+  WLED_GLOBAL unsigned short ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
   WLED_GLOBAL bool ledStatusState _INIT(0); // the current LED state
 #endif
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -506,6 +506,13 @@ WLED_GLOBAL WS2812FX strip _INIT(WS2812FX());
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 
+// Status LED
+#if STATUSLED && STATUSLED != LEDPIN
+  WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);
+  WLED_GLOBAL int ledStatusType _INIT(0); // current status type - corresponds to number of blinks per second
+  WLED_GLOBAL bool ledStatusState _INIT(0); // the current LED state
+#endif
+
 // debug macro variable definitions
 #ifdef WLED_DEBUG
   WLED_GLOBAL unsigned long debugTime _INIT(0);
@@ -544,5 +551,6 @@ public:
   void initAP(bool resetAP = false);
   void initConnection();
   void initInterfaces();
+  void handleStatusLED();
 };
 #endif        // WLED_H


### PR DESCRIPTION
This PR builds upon my last PR, #1264, but instead of using a GPIO LED, the user can now use the first pixel as a status LED.

New build flags:
| Build Flag | Optional | Description |
|-|-|-|
| STATUSLED | Yes, but not defining will disable the functionality | Set this to -1 in order to enable status pixel. |

New global variables:
| Global Variable | Description |
|-|-|
| lastActive | Stores if the status was last active so when we disable it, we only disable it once instead of setting `currentOverlay` to `lastOverlay` over and over again. |
| lastOverlay | Same as `currentOverlay`, but it stores the last overlay before enabling the status pixel overlay. That way we can go back to whatever overlay mode the user previously set. |