### PR TITLE
Return remaining nightlight time in json API

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -318,7 +318,12 @@ void serializeState(JsonObject root)
   nl[F("fade")] = (nightlightMode > NL_MODE_SET); //deprecated
   nl[F("mode")] = nightlightMode;
   nl[F("tbri")] = nightlightTargetBri;
-  
+  if (nightlightActive) {
+      nl[F("rem")] = (nightlightDelayMs - (millis() - nightlightStartTime)) / 1000; // seconds remaining
+  } else {
+      nl[F("rem")] = -1;
+  }
+
   JsonObject udpn = root.createNestedObject("udpn");
   udpn[F("send")] = notifyDirect;
   udpn[F("recv")] = receiveNotifications;
@@ -326,7 +331,7 @@ void serializeState(JsonObject root)
   root[F("lor")] = realtimeOverride;
 
   root[F("mainseg")] = strip.getMainSegmentId();
-  
+
   JsonArray seg = root.createNestedArray("seg");
   for (byte s = 0; s < strip.getMaxSegments(); s++)
   {


### PR DESCRIPTION
This exposes the number of seconds remaining in the nightlight.

Part of: #1150