### PR TITLE
Add build configuration for SP501A controller

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -362,6 +362,12 @@ lib_ignore =
 	ESPAsyncUDP
 platform = espressif32@1.12.4
 
+[env:sp501a]
+board = esp_wroom_02
+platform = ${common.platform_wled_default}
+board_build.ldscript = ${common.ldscript_2m1m}
+build_flags = ${common.build_flags_esp8266} -D LEDPIN=3 -D BTNPIN=1
+
 # ------------------------------------------------------------------------------
 # travis test board configurations
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This controller uses ESP8285 with 2MB built-in flash.
Features:
- LED string is connected to GPIO3,
- On/off button connected to GPIO1,
- Built-in transistors to drive non-addressable R-G-B-Wc-Ww strips
  (by default not connected, only pads are present).

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>