### PR TITLE
Change SP501A -> SP501E build configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -362,7 +362,7 @@ lib_ignore =
 	ESPAsyncUDP
 platform = espressif32@1.12.4
 
-[env:sp501a]
+[env:sp501e]
 board = esp_wroom_02
 platform = ${common.platform_wled_default}
 board_build.ldscript = ${common.ldscript_2m1m}


### PR DESCRIPTION
Fix a typo in previous commit. Correct board name is SP501E.

Signed-off-by: Lech Perczak <lech.perczak@gmail.com>