### PR TITLE
Fix Hue sync for RGBW white in XY color mode

### DIFF
--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -164,7 +164,7 @@ void colorXYtoRGB(float x, float y, byte* rgb) //coordinates to rgb (https://www
   rgb[0] = 255.0*r;
   rgb[1] = 255.0*g;
   rgb[2] = 255.0*b;
-  if (useRGBW) colorRGBtoRGBW(col);
+  if (useRGBW && strip.rgbwMode == RGBW_MODE_LEGACY) colorRGBtoRGBW(col);
 }
 
 void colorRGBtoXY(byte* rgb, float* xy) //rgb to coordinates (https://www.developers.meethue.com/documentation/color-conversions-rgb-xy)


### PR DESCRIPTION
I noticed that Hue sync was updating the white channel for my RGBW strip even though I had the "auto-calculate white channel" set to None. From what I can tell, the white channel is updated only in Legacy mode when the Hue color mode is "hue" or CT, but for some reason the white channel is always updated when the Hue color mode is RGB. This is a simple fix, assuming the current behavior is not desired.