### PR TITLE
Fix bug where messages sent to the group topic were incorrectly ignored

### DIFF
--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -68,7 +68,7 @@ void onMqttMessage(char* topic, char* payload, AsyncMqttClientMessageProperties 
   if (strncmp(topic, mqttDeviceTopic, topicPrefixLen) == 0) {
       topic += topicPrefixLen;
   } else {
-      size_t topic_prefix_len = strlen(mqttGroupTopic);
+      topicPrefixLen = strlen(mqttGroupTopic);
       if (strncmp(topic, mqttGroupTopic, topicPrefixLen) == 0) {
           topic += topicPrefixLen;
       } else {


### PR DESCRIPTION
The MQTT commands work fine if sent to the device topic, but not when the same command is sent to the group topic.

They were being incorrectly ignored because the string comparison was accidentally doing the group topic comparison with the length from the device topic.

If they happened to be the same length, then everything will have been fine, but when they're different lengths, messages to the group topic are ignored.