### PR TITLE
mutiple RGBW leds support for DMX control

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -71,6 +71,7 @@
 #define DMX_MODE_EFFECT           3            //trigger standalone effects of WLED (11 channels)
 #define DMX_MODE_MULTIPLE_RGB     4            //every LED is addressed with its own RGB (ledCount * 3 channels)
 #define DMX_MODE_MULTIPLE_DRGB    5            //every LED is addressed with its own RGB and share a master dimmer (ledCount * 3 + 1 channels)
+#define DMX_MODE_MULTIPLE_RGBW    6            //every LED is addressed with its own RGBW (ledCount * 4 channels)
 
 //Light capability byte (unused) 0bRRCCTTTT
 //bits 0/1/2/3: specifies a type of LED driver. A single "driver" may have different chip models but must have the same protocol/behavior

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -64,6 +64,7 @@ DMX mode:
 <option value=3>Effect</option>
 <option value=4>Multi RGB</option>
 <option value=5>Dimmer + Multi RGB</option>
+<option value=6>Multi RGBW</option>
 </select><br>
 <a href="https://github.com/Aircoookie/WLED/wiki/E1.31-DMX" target="_blank">E1.31 info</a><br>
 Timeout: <input name="ET" type="number" min="1" max="65000" required> ms<br>

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -1,6 +1,7 @@
 #include "wled.h"
 
-#define MAX_LEDS_PER_UNIVERSE 170
+#define MAX_3_CH_LEDS_PER_UNIVERSE 170
+#define MAX_4_CH_LEDS_PER_UNIVERSE 128
 #define MAX_CHANNELS_PER_UNIVERSE 512
 
 /*
@@ -161,8 +162,12 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
 
     case DMX_MODE_MULTIPLE_DRGB:
     case DMX_MODE_MULTIPLE_RGB:
+    case DMX_MODE_MULTIPLE_RGBW:
       {
         realtimeLock(realtimeTimeoutMs, mde);
+        bool is4Chan = (DMXMode == DMX_MODE_MULTIPLE_RGBW);
+        const uint16_t dmxChannelsPerLed = is4Chan ? 4 : 3;
+        const uint16_t ledsPerUniverse = is4Chan ? MAX_4_CH_LEDS_PER_UNIVERSE : MAX_3_CH_LEDS_PER_UNIVERSE;
         if (realtimeOverride) return;
         uint16_t previousLeds, dmxOffset;
         if (previousUniverses == 0) {
@@ -176,36 +181,20 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
         } else {
           // All subsequent universes start at the first channel.
           dmxOffset = (protocol == P_ARTNET) ? 0 : 1;
-          uint16_t ledsInFirstUniverse = (MAX_CHANNELS_PER_UNIVERSE - DMXAddress) / 3;
-          previousLeds = ledsInFirstUniverse + (previousUniverses - 1) * MAX_LEDS_PER_UNIVERSE;
+          uint16_t ledsInFirstUniverse = (MAX_CHANNELS_PER_UNIVERSE - DMXAddress) / dmxChannelsPerLed;
+          previousLeds = ledsInFirstUniverse + (previousUniverses - 1) * ledsPerUniverse;
         }
-        uint16_t ledsTotal = previousLeds + (dmxChannels - dmxOffset +1) / 3;
-        for (uint16_t i = previousLeds; i < ledsTotal; i++) {
-          setRealtimePixel(i, e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++], 0);
+        uint16_t ledsTotal = previousLeds + (dmxChannels - dmxOffset +1) / dmxChannelsPerLed;
+        if (!is4Chan) {
+          for (uint16_t i = previousLeds; i < ledsTotal; i++) {
+            setRealtimePixel(i, e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++], 0);
+          }
+        } else {
+          for (uint16_t i = previousLeds; i < ledsTotal; i++) {
+            setRealtimePixel(i, e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++]);
+          }
         }
         break;
-      }
-      case DMX_MODE_MULTIPLE_RGBW:   //Implementation of RGBW leds
-      {
-        const byte dmxChannelsperLed=4;   //4 DMX Channels/Led
-        const byte ledsPerUniverse=128;   //Max.128 leds/Universe      
-        realtimeLock(realtimeTimeoutMs, mde);
-        if (realtimeOverride) return;
-        uint16_t previousLeds, dmxOffset;
-        if (previousUniverses == 0) {
-          if (dmxChannels-DMXAddress < 1) return;
-          dmxOffset = DMXAddress;
-          previousLeds = 0;
-        } else{
-          dmxOffset = (protocol == P_ARTNET) ? 0 : 1;
-          uint16_t ledsInFirstUniverse = (MAX_CHANNELS_PER_UNIVERSE - DMXAddress) / dmxChannelsperLed;   
-          previousLeds = ledsInFirstUniverse + (previousUniverses - 1) * ledsPerUniverse; // Max leds/universe is only 128 with 4 Ch./led
-        }
-        uint16_t ledsTotal = previousLeds + (dmxChannels - dmxOffset +1) / dmxChannelsperLed;
-        for (uint16_t i = previousLeds; i < ledsTotal; i++) {
-          setRealtimePixel(i, e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++], e131_data[dmxOffset++]);
-        }
-        break;         
       }
     default:
       DEBUG_PRINTLN(F("unknown E1.31 DMX mode"));

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -238,7 +238,8 @@ type="checkbox" name="ES"><br>DMX start address: <input name="DA" type="number"
 min="0" max="510" required><br>DMX mode: <select name="DM"><option value="0">
 Disabled</option><option value="1">Single RGB</option><option value="2">
 Single DRGB</option><option value="3">Effect</option><option value="4">Multi RGB
-</option><option value="5">Dimmer + Multi RGB</option></select><br><a 
+</option><option value="5">Dimmer + Multi RGB</option><option value="6">
+Multi RGBW</option></select><br><a 
 href="https://github.com/Aircoookie/WLED/wiki/E1.31-DMX" target="_blank">
 E1.31 info</a><br>Timeout: <input name="ET" type="number" min="1" max="65000" 
 required> ms<br>Force max brightness: <input type="checkbox" name="FB"><br>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -152,7 +152,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     t = request->arg(F("DA")).toInt();
     if (t >= 0  && t <= 510) DMXAddress = t;
     t = request->arg(F("DM")).toInt();
-    if (t >= DMX_MODE_DISABLED && t <= DMX_MODE_MULTIPLE_DRGB) DMXMode = t;
+    if (t >= DMX_MODE_DISABLED && t <= DMX_MODE_MULTIPLE_RGBW) DMXMode = t;
     t = request->arg(F("ET")).toInt();
     if (t > 99  && t <= 65000) realtimeTimeoutMs = t;
     arlsForceMaxBri = request->hasArg(F("FB"));

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -262,7 +262,7 @@ WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this
 #endif
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
 WLED_GLOBAL uint16_t e131Port _INIT(5568);                        // DMX in port. E1.31 default is 5568, Art-Net is 6454
-WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGBW-1);            // DMX mode (s.a.)
+WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGB);            // DMX mode (s.a.)
 WLED_GLOBAL uint16_t DMXAddress _INIT(1);                         // DMX start address of fixture, a.k.a. first Channel [for E1.31 (sACN) protocol]
 WLED_GLOBAL byte DMXOldDimmer _INIT(0);                           // only update brightness on change
 WLED_GLOBAL byte e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT]; // to detect packet loss

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -262,7 +262,7 @@ WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this
 #endif
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
 WLED_GLOBAL uint16_t e131Port _INIT(5568);                        // DMX in port. E1.31 default is 5568, Art-Net is 6454
-WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGB);            // DMX mode (s.a.)
+WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGBW-1);            // DMX mode (s.a.)
 WLED_GLOBAL uint16_t DMXAddress _INIT(1);                         // DMX start address of fixture, a.k.a. first Channel [for E1.31 (sACN) protocol]
 WLED_GLOBAL byte DMXOldDimmer _INIT(0);                           // only update brightness on change
 WLED_GLOBAL byte e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT]; // to detect packet loss


### PR DESCRIPTION
RGBW support for individual leds through DMX control. (Tested with E1.31 & Artnet)
-Added option 'Multi RGBW' to the settings
-Modified e131.cpp accordingly
-Tuned other parameters to make it work
To do: Same for other DMX options
