### PR TITLE
Fix IR-Remote type to cfg.json

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -435,7 +435,7 @@ void serializeConfig() {
   #if defined(IRPIN) && IRPIN > -1
   JsonObject hw_ir = hw.createNestedObject("ir");
   hw_ir[F("pin")] = IRPIN;
-  hw_ir[F("type")] = 0;
+  hw_ir[F("type")] = irEnabled;              // the byte 'irEnabled' does contain the IR-Remote Type ( 0=disabled )
   #endif
 
   #if defined(RLYPIN) && RLYPIN > -1


### PR DESCRIPTION
...instead of defaulting it to 0 

The IR-Remote was disabled after each reboot (because in the JSON Object of the IR got hardcoded a "0").
I changed this to the IR-Remote type (which is stored in the byte `irEnabled`).