### PR TITLE
Add default build task for VSCode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "PlatformIO",
+      "task": "Build",
+      "group": {
+        "kind": "build",
+        "isDefault": true,
+      },
+      "problemMatcher": [
+        "$platformio"
+      ],
+      "presentation": {
+        "panel": "shared",
+      },
+      "dependsOn": [
+        "npm: build"
+      ],
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: build",
+      "detail": "npm run build",
+      "presentation": {
+        "panel": "shared",
+      },
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a `tasks.json` file that defines a default VSCode build tasks that runs the following two build commands in sequential order:

* `npm run build`
* `PlatformIO: Build`

*Rationale*

I was pulling my hair out trying to figure out why my changes to `index.html` weren't taking effect in the compiled binary. Then I discovered there's a second build command to generate the compressed file for inclusion in the binary.

With this change doing `ctrl-shift-B` in VSCode will automatically run both steps and ensure a binary is produced with the updated index.html.

There are no changes to the existing `PlatformIO: Build` step, and triggering PlatformIO build using any of the existing methods (Checkmark in the bottom status bar, ctrl-alt-B, or from the command palette) still does only the PlatformIO build.