### PR TITLE
Add PlatformIO and npm install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,14 +31,15 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"platformio.platformio-ide"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+	"postCreateCommand": "npm install",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"


### PR DESCRIPTION
This adds the following two items to the devcontainer initialization:

- Installs the PlatformIO extension automatically since it's required to do anything useful
- Runs `npm install`

With these changes a devcontainer created directly with a cloned WLED repo can do a build with no additional required steps.

To test:

1. Make sure you have the [VSCode - Remote](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extensions installed
2. Inside VSCode run `Remote-Containers: Clone repository in container volume...`
3. Point to https://github.com/danecreekphotography/WLED/tree/devcontainer-updates

Once the volume is created hit the checkmark and voila! A build.