### PR TITLE
Add VSCode build tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,8 +2,19 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Build: HTML and binary",
+      "dependsOn": [
+        "Build: HTML only",
+        "Build: binary only"
+      ],
+      "dependsOrder": "sequence",
+      "problemMatcher": [
+        "$platformio",
+      ],
+    },
+    {
       "type": "PlatformIO",
-      "label": "Build: binary",
+      "label": "Build: binary only",
       "task": "Build",
       "group": {
         "kind": "build",
@@ -21,7 +32,7 @@
       "script": "build",
       "group": "build",
       "problemMatcher": [],
-      "label": "Build: HTML",
+      "label": "Build: HTML only",
       "detail": "npm run build",
       "presentation": {
         "panel": "shared"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "PlatformIO",
+      "task": "Build",
+      "group": {
+        "kind": "build",
+        "isDefault": true,
+      },
+      "problemMatcher": [
+        "$platformio"
+      ],
+      "presentation": {
+        "panel": "shared",
+      },
+      "dependsOn": [
+        "npm: build"
+      ],
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "npm: build",
+      "detail": "npm run build",
+      "presentation": {
+        "panel": "shared",
+      },
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,7 @@
   "tasks": [
     {
       "type": "PlatformIO",
+      "label": "Build: binary",
       "task": "Build",
       "group": {
         "kind": "build",
@@ -12,22 +13,19 @@
         "$platformio"
       ],
       "presentation": {
-        "panel": "shared",
-      },
-      "dependsOn": [
-        "npm: build"
-      ],
+        "panel": "shared"
+      }
     },
     {
       "type": "npm",
       "script": "build",
       "group": "build",
       "problemMatcher": [],
-      "label": "npm: build",
+      "label": "Build: HTML",
       "detail": "npm run build",
       "presentation": {
-        "panel": "shared",
-      },
+        "panel": "shared"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds a `tasks.json` file that defines a default VSCode build tasks that runs the following two build commands in sequential order:

* `npm run build`
* `PlatformIO: Build`

*Rationale*

I was pulling my hair out trying to figure out why my changes to `index.html` weren't taking effect in the compiled binary. Then I discovered there's a second build command to generate the compressed file for inclusion in the binary.

With this change doing `ctrl-shift-B` in VSCode or running `PlatformIO: Build` will automatically run both steps and ensure a binary is produced with the updated index.html.

**Warning**: This alters the default behaviour of the PlatformIO build and anyone doing a fresh clone of this repo who fails to do `npm install` after cloning will get a build error because the HTML build step will fail. If you choose to merge this the steps at https://github.com/Aircoookie/WLED/wiki/Compiling-WLED should get updated to specifically say running `npm install` is required.