### PR TITLE
Add utility function to expose if strip is being updated

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -480,7 +480,9 @@ class WS2812FX {
       gammaCorrectCol = true,
       applyToAllSelected = true,
       segmentsAreIdentical(Segment* a, Segment* b),
-      setEffectConfig(uint8_t m, uint8_t s, uint8_t i, uint8_t p);
+      setEffectConfig(uint8_t m, uint8_t s, uint8_t i, uint8_t p),
+      // return true if the strip is being sent pixel updates
+      isUpdating(void);
 
     uint8_t
       mainSegment = 0,

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -218,8 +218,11 @@ void WS2812FX::setPixelColor(uint16_t i, byte r, byte g, byte b, byte w)
                               //you can set it to 0 if the ESP is powered by USB and the LEDs by external
 
 void WS2812FX::show(void) {
-  if (_callback) _callback();
-  
+
+  // avoid race condition, caputre _callback value
+  show_callback callback = _callback;
+  if (callback) callback();
+
   //power limit calculation
   //each LED can draw up 195075 "power units" (approx. 53mA)
   //one PU is the power it takes to have 1 channel 1 step brighter per brightness step
@@ -291,10 +294,24 @@ void WS2812FX::show(void) {
     bus->SetBrightness(_brightness);
   }
   
+  // some buses send asynchronously and this method will return before
+  // all of the data has been sent.
+  // See https://github.com/Makuna/NeoPixelBus/wiki/ESP32-NeoMethods#neoesp32rmt-methods
   bus->Show();
   _lastShow = millis();
 }
 
+/**
+ * Returns a true value if any of the strips are still being updated.
+ * On some hardware (ESP32), strip updates are done asynchronously.
+ */
+bool WS2812FX::isUpdating() {
+  return !bus->CanShow();
+}
+
+/**
+ * Forces the next frame to be computed on all active segments.
+ */
 void WS2812FX::trigger() {
   _triggered = true;
 }

--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -296,11 +296,26 @@ public:
 
   void Show()
   {
-    byte b;
     switch (_type)
     {
       case NeoPixelType_Grb:  _pGrb->Show();  break;
       case NeoPixelType_Grbw: _pGrbw->Show(); break;
+    }
+  }
+
+  /** 
+   * This will return true if enough time has passed since the last time Show() was called. 
+   * This also means that calling Show() will not cause any undue waiting. If the method for 
+   * the defined bus is hardware that sends asynchronously, then call CanShow() will let 
+   * you know if it has finished sending the data from the last Show().
+   */
+  bool CanShow()
+  {
+    switch (_type)
+    {
+      case NeoPixelType_Grb:  return _pGrb->CanShow();
+      case NeoPixelType_Grbw: return _pGrbw->CanShow();
+      default: return true;
     }
   }
 


### PR DESCRIPTION
This PR addresses issue #1461. In some areas, like the dallas one wire temperature usermod, we must avoid doing things that could impact the precise timing required by the WS2801 protocol. Issues can be observed that due to timing issues, the colors sent to the strips get messed up.  This can be seen in the logic analyzer capture below.

ESP32
WLED 0.10.2 or 0.11.0
WLED Effect: Solid Blue 0x000038

When delays are introduced, the colors bits are moving around sending other color codes causing the lights to go crazy when the sensor is read.

![pulseview_zqMDhmmNZ6](https://user-images.githubusercontent.com/1844480/101721916-ef887880-3a5d-11eb-911c-b86a6737db28.png)

This PR lays the ground work to allow the temperature usermod to find a time between frame updates to read the sensor.