### PR TITLE
update MODE_COUNT after candy cane fx was added

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -116,7 +116,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  114
+#define MODE_COUNT  115
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1


### PR DESCRIPTION
It was not possible to select the candy cane effect after it was added in #1445 due to wrong MODE_COUNT.