### PR TITLE
add LED-Strip Clock effect

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -116,7 +116,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  115
+#define MODE_COUNT  116
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -233,6 +233,7 @@
 #define FX_MODE_DANCING_SHADOWS        112
 #define FX_MODE_WASHING_MACHINE        113
 #define FX_MODE_CANDY_CANE             114
+#define FX_MODE_STRIPCLOCK             115
 
 class WS2812FX {
   typedef uint16_t (WS2812FX::*mode_ptr)(void);
@@ -461,6 +462,7 @@ class WS2812FX {
       _mode[FX_MODE_DANCING_SHADOWS]         = &WS2812FX::mode_dancing_shadows;
       _mode[FX_MODE_WASHING_MACHINE]         = &WS2812FX::mode_washing_machine;
       _mode[FX_MODE_CANDY_CANE]              = &WS2812FX::mode_candy_cane;
+      _mode[FX_MODE_STRIPCLOCK]              = &WS2812FX::mode_strip_clock;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -670,7 +672,8 @@ class WS2812FX {
       mode_chunchun(void),
       mode_dancing_shadows(void),
       mode_washing_machine(void),
-      mode_candy_cane(void);
+      mode_candy_cane(void),
+      mode_strip_clock(void);
 
   private:
     NeoPixelWrapper *bus;
@@ -758,7 +761,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
 "Heartbeat","Pacifica","Candle Multi", "Solid Glitter","Sunrise","Phased","Twinkleup","Noise Pal", "Sine","Phased Noise",
-"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane"
+"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Strip Clock"
 ])=====";
 
 


### PR DESCRIPTION
This effect is similar to the already existing Analog Clock Overlay. However, due to it being an effect it can be more easily started via home-assistant for example. Is far as I could see, the overlay cannot be de-/activated via the JSON API. Additionally, the overlay doesn't allow customizing the colors.

I am not sure if that warrants an additional effect, or if the overlay should be extended. It might also not be the best idea to fully re-implement the effect, but both overlay and effect should use the same logic?

If you have any suggestion or thoughts on it let me know. 