### PR TITLE
fix alexa discovery

### DIFF
--- a/wled00/src/dependencies/espalexa/Espalexa.h
+++ b/wled00/src/dependencies/espalexa/Espalexa.h
@@ -60,6 +60,7 @@
 
 #include "EspalexaDevice.h"
 
+#define DEVICE_UNIQUE_ID_LENGTH 12
 
 class Espalexa {
 private:
@@ -116,13 +117,45 @@ private:
     return "";
   }
   
-  //Workaround functions courtesy of Sonoff-Tasmota
-  uint32_t encodeLightId(uint8_t idx)
+  String byte2hex(uint8_t zahl)
   {
-    uint8_t mac[6];
-    WiFi.macAddress(mac);
-    uint32_t id = (mac[3] << 20) | (mac[4] << 12) | (mac[5] << 4) | (idx & 0xF);
-    return id;
+    String hstring = String(zahl, HEX);
+    if (zahl < 16)
+    {
+      hstring = "0" + hstring;
+    }
+    return hstring;
+  }
+
+  String makeMD5(String text)
+  {
+    unsigned char bbuf[16];
+    String hash = "";
+    MD5Builder md5;
+    md5.begin();
+    md5.add(text);
+    md5.calculate();
+  
+    md5.getBytes(bbuf);
+    for (uint8_t i = 0; i < 16; i++)
+    {
+      hash += byte2hex(bbuf[i]);
+    }
+    return hash;
+  }
+
+  String encodeLightId(uint8_t idx)
+  {
+    String mac = WiFi.macAddress();
+    mac.replace(":","");
+    mac.toLowerCase();
+
+    //Unique id must be 12 character len.
+    //use the MAC, add the device name, then use a truncated MD5 hash as unique id
+    EspalexaDevice* dev = devices[idx-1];
+    mac.concat(dev->getName());
+    String hash = makeMD5(mac).substring(0,DEVICE_UNIQUE_ID_LENGTH);
+    return hash;
   }
 
   uint32_t decodeLightId(uint32_t id) {
@@ -161,10 +194,10 @@ private:
     
     sprintf_P(buf, PSTR("{\"state\":{\"on\":%s,\"bri\":%u%s%s,\"alert\":\"none%s\",\"mode\":\"homeautomation\",\"reachable\":true},"
                    "\"type\":\"%s\",\"name\":\"%s\",\"modelid\":\"%s\",\"manufacturername\":\"Philips\",\"productname\":\"E%u"
-                   "\",\"uniqueid\":\"%u\",\"swversion\":\"espalexa-2.4.6\"}")
+                   "\",\"uniqueid\":\"%s\",\"swversion\":\"espalexa-2.4.6\"}")
                    
     , (dev->getValue())?"true":"false", dev->getLastValue()-1, buf_col, buf_ct, buf_cm, typeString(dev->getType()),
-    dev->getName().c_str(), modelidString(dev->getType()), static_cast<uint8_t>(dev->getType()), encodeLightId(deviceId+1));
+    dev->getName().c_str(), modelidString(dev->getType()), static_cast<uint8_t>(dev->getType()), encodeLightId(deviceId+1).c_str());
   }
   
   //Espalexa status page /espalexa
@@ -222,7 +255,7 @@ private:
         "<URLBase>http://%s:80/</URLBase>"
         "<device>"
           "<deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>"
-          "<friendlyName>Espalexa (%s)</friendlyName>"
+          "<friendlyName>Philips hue (%s:80)</friendlyName>"
           "<manufacturer>Royal Philips Electronics</manufacturer>"
           "<manufacturerURL>http://www.philips.com</manufacturerURL>"
           "<modelDescription>Philips hue Personal Wireless Lighting</modelDescription>"
@@ -237,8 +270,8 @@ private:
           
     server->send(200, "text/xml", buf);
     
-    EA_DEBUG("Send setup.xml");
-    //EA_DEBUGLN(setup_xml);
+    EA_DEBUGLN("Send setup.xml");
+    EA_DEBUGLN(buf);
   }
   
   //init the server
@@ -290,7 +323,7 @@ private:
     sprintf(s, "%d.%d.%d.%d", localIP[0], localIP[1], localIP[2], localIP[3]);
 
     char buf[1024];
-    
+
     sprintf_P(buf,PSTR("HTTP/1.1 200 OK\r\n"
       "EXT:\r\n"
       "CACHE-CONTROL: max-age=100\r\n" // SSDP_INTERVAL
@@ -298,7 +331,7 @@ private:
       "SERVER: FreeRTOS/6.0.5, UPnP/1.0, IpBridge/1.17.0\r\n" // _modelName, _modelNumber
       "hue-bridgeid: %s\r\n"
       "ST: urn:schemas-upnp-org:device:basic:1\r\n"  // _deviceType
-      "USN: uuid:2f402f80-da50-11e1-9b23-%s::ssdp:all\r\n" // _uuid::_deviceType
+      "USN: uuid:2f402f80-da50-11e1-9b23-%s::upnp:rootdevice\r\n" // _uuid::_deviceType
       "\r\n"),s,escapedMac.c_str(),escapedMac.c_str());
 
     espalexaUdp.beginPacket(espalexaUdp.remoteIP(), espalexaUdp.remotePort());
@@ -362,20 +395,26 @@ public:
     if (!packetSize) return; //no new udp packet
     
     EA_DEBUGLN("Got UDP!");
-    char packetBuffer[255]; //buffer to hold incoming udp packet
-    uint16_t len = espalexaUdp.read(packetBuffer, 254);
-    if (len > 0) {
-      packetBuffer[len] = 0;
-    }
-    espalexaUdp.flush();
-    if (!discoverable) return; //do not reply to M-SEARCH if not discoverable
-    
-    String request = packetBuffer;
-    if(request.indexOf("M-SEARCH") >= 0) {
-      EA_DEBUGLN(request);
-      if(request.indexOf("upnp:rootdevice") > 0 || request.indexOf("asic:1") > 0 || request.indexOf("ssdp:all") > 0) {
-        EA_DEBUGLN("Responding search req...");
-        respondToSearch();
+    if (packetSize > 0) {
+      unsigned char packetBuffer[packetSize+1]; //buffer to hold incoming udp packet
+      int len = espalexaUdp.read(packetBuffer, packetSize+1);
+      packetBuffer[packetSize] = 0;
+
+      espalexaUdp.flush();
+      if (!discoverable) return; //do not reply to M-SEARCH if not discoverable
+
+      String request = (const char *) packetBuffer;
+      if(request.indexOf("M-SEARCH") >= 0) {
+        EA_DEBUGLN(request);
+        if(request.indexOf("ssdp:discover") > 0 && 
+           (request.indexOf("upnp:rootdevice") > 0 || 
+            //request.indexOf("asic:1") > 0 ||
+            request.indexOf("ssdp:all") > 0 ||
+            request.indexOf("device:basic:1") > 0 ))
+        {
+          EA_DEBUGLN("Responding search req...");
+          respondToSearch();
+        }
       }
     }
   }
@@ -530,7 +569,7 @@ public:
         String jsonTemp = "{";
         for (int i = 0; i<currentDeviceCount; i++)
         {
-          jsonTemp += "\"" + String(encodeLightId(i+1)) + "\":";
+          jsonTemp += "\"" + String(i+1) + "\":";
           char buf[512];
           deviceJsonString(i+1, buf);
           jsonTemp += buf;


### PR DESCRIPTION
Hello,

Alexa discovery is broken in Wled 0.11.0 but it work fine for me on another project using Fauxmo esp library on a wemos d1 mini .
I Analyzed the messages exchaged between my echo show and the d1 and I compared them against the Fauxmo lib.
I've found that the 7 digit unique id calculated by Wled is not correct, it must be 12 character long so I ported the Fauxmo id calculation into Wled and fixed also the checks on M-SEARCH message since on my echo show upnp:rootdevice was used instead of ssdp:all.
Everything tested with Wled on my d1 mini and Alexa discovery now works fine. I can controll the on/off, bri, and color from Alexa.