### PR TITLE
platformio.ini: Support ANAVI Miracle Controller

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -361,6 +361,14 @@ board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags_esp8266}
 
+[env:anavi_miracle_controller]
+board = d1_mini
+platform = ${common.platform_wled_default}
+platform_packages = ${common.platform_packages}
+board_build.ldscript = ${common.ldscript_4m1m}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags_esp8266} -D LEDPIN=12 -D IRPIN=-1 -D RLYPIN=2
+
 # ------------------------------------------------------------------------------
 # custom board configurations
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Add support for ANAVI Miracle Controller open source hardware
development board with ESP8266. For the moment use a single LED
strip connected to LED1.

Signed-off-by: Leon Anavi <leon@anavi.org>