### PR TITLE
Add fields for customization Blynk host

### DIFF
--- a/wled00/blynk.cpp
+++ b/wled00/blynk.cpp
@@ -8,12 +8,12 @@
 uint16_t blHue = 0;
 byte blSat = 255;
 
-void initBlynk(const char* auth)
+void initBlynk(const char *auth, const char *host, uint16_t port)
 {
   #ifndef WLED_DISABLE_BLYNK
   if (!WLED_CONNECTED) return;
   blynkEnabled = (auth[0] != 0);
-  if (blynkEnabled) Blynk.config(auth);
+  if (blynkEnabled) Blynk.config(auth, host, port);
   #endif
 }
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -213,6 +213,10 @@ void deserializeConfig() {
   if (tdd > 20 || tdd == 0)
     getStringFromJson(blynkApiKey, apikey, 36); //normally not present due to security
 
+  JsonObject if_blynk = interfaces[F("blynk")];
+  getStringFromJson(blynkHost, if_blynk[F("host")], 128);
+  CJSON(blynkPort, if_blynk[F("port")]);
+
   JsonObject if_mqtt = interfaces[F("mqtt")];
   CJSON(mqttEnabled, if_mqtt[F("en")]);
   getStringFromJson(mqttServer, if_mqtt[F("broker")], 33);
@@ -531,6 +535,8 @@ void serializeConfig() {
   if_va_macros.add(macroAlexaOff);
   JsonObject if_blynk = interfaces.createNestedObject("blynk");
   if_blynk[F("token")] = strlen(blynkApiKey) ? "Hidden":"";
+  if_blynk[F("host")] = blynkHost;
+  if_blynk[F("port")] = blynkPort;
 
   JsonObject if_mqtt = interfaces.createNestedObject("mqtt");
   if_mqtt[F("en")] = mqttEnabled;

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -79,6 +79,8 @@ Alexa invocation name: <input name="AI" maxlength="32">
 This may impact the responsiveness of the ESP8266.</b><br>
 For best results, only use one of these services at a time.<br>
 (alternatively, connect a second ESP to them and use the UDP sync)<br><br>
+Host: <input name="BH" maxlength="128">
+Port: <input name="BP" type="number" min="1" max="65535" value="80" class="d5"><br>
 Device Auth token: <input name="BK" maxlength="33"><br>
 <i>Clear the token field to disable. </i><a href="https://github.com/Aircoookie/WLED/wiki/Blynk" target="_blank">Setup info</a>
 <h3>MQTT</h3>

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -15,7 +15,7 @@ void handleAlexa();
 void onAlexaChange(EspalexaDevice* dev);
 
 //blynk.cpp
-void initBlynk(const char* auth);
+void initBlynk(const char* auth, const char* host, uint16_t port);
 void handleBlynk();
 void updateBlynk();
 

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -253,6 +253,8 @@ Blynk, MQTT and Hue sync all connect to external hosts!<br>
 This may impact the responsiveness of the ESP8266.</b><br>
 For best results, only use one of these services at a time.<br>
 (alternatively, connect a second ESP to them and use the UDP sync)<br><br>
+Host: <input name="BH" maxlength="128">
+Port: <input name="BP" type="number" min="1" max="65535"><br>
 Device Auth token: <input name="BK" maxlength="33"><br><i>
 Clear the token field to disable. </i><a 
 href="https://github.com/Aircoookie/WLED/wiki/Blynk" target="_blank">Setup info

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -163,8 +163,12 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     alexaEnabled = request->hasArg(F("AL"));
     strlcpy(alexaInvocationName, request->arg(F("AI")).c_str(), 33);
 
+    strlcpy(blynkHost, request->arg("BH").c_str(), 128);
+    t = request->arg(F("BP")).toInt();
+    if (t > 0) blynkPort = t;
+
     if (request->hasArg("BK") && !request->arg("BK").equals(F("Hidden"))) {
-      strlcpy(blynkApiKey, request->arg("BK").c_str(), 36); initBlynk(blynkApiKey);
+      strlcpy(blynkApiKey, request->arg("BK").c_str(), 36); initBlynk(blynkApiKey, blynkHost, blynkPort);
     }
 
     #ifdef WLED_ENABLE_MQTT

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -492,7 +492,7 @@ void WLED::initInterfaces()
   if (ntpEnabled)
     ntpConnected = ntpUdp.begin(ntpLocalPort);
 
-  initBlynk(blynkApiKey);
+  initBlynk(blynkApiKey, blynkHost, blynkPort);
   e131.begin(e131Multicast, e131Port, e131Universe, E131_MAX_UNIVERSE_COUNT);
   reconnectHue();
   initMqtt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -249,6 +249,8 @@ WLED_GLOBAL bool alexaEnabled _INIT(false);                       // enable devi
 WLED_GLOBAL char alexaInvocationName[33] _INIT("Light");          // speech control name of device. Choose something voice-to-text can understand
 
 WLED_GLOBAL char blynkApiKey[36] _INIT("");                       // Auth token for Blynk server. If empty, no connection will be made
+WLED_GLOBAL char blynkHost[128] _INIT("blynk-cloud.com");         // Default Blynk host
+WLED_GLOBAL uint16_t blynkPort _INIT(80);                         // Default Blynk port
 
 WLED_GLOBAL uint16_t realtimeTimeoutMs _INIT(2500);               // ms timeout of realtime mode before returning to normal mode
 WLED_GLOBAL int arlsOffset _INIT(0);                              // realtime LED offset

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -323,6 +323,8 @@ void getSettingsJS(byte subPage, char* dest)
     sappends('s',SET_F("AI"),alexaInvocationName);
     sappend('c',SET_F("SA"),notifyAlexa);
     sappends('s',SET_F("BK"),(char*)((blynkEnabled)?SET_F("Hidden"):""));
+    sappends('s',SET_F("BH"),blynkHost);
+    sappend('v',SET_F("BP"),blynkPort);
 
     #ifdef WLED_ENABLE_MQTT
     sappend('c',SET_F("MQ"),mqttEnabled);


### PR DESCRIPTION
Add fields to 'Sync Interfaces' for customization Blynk host.
Now you can set you own Blynk server.
All you needs its set custom host and port to local Blync server.

![wled_custom_blynk_host](https://user-images.githubusercontent.com/6158734/102458651-74fec080-403c-11eb-8be7-9833efbad9df.PNG)
