### PR TITLE
Add option for faster upload speed in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -179,7 +179,10 @@ extra_scripts             = pio/name-firmware.py
 framework = arduino
 board_build.flash_mode = dout
 monitor_speed = 115200
+# slow upload speed (comment this out with a ';' when building for development use)
 upload_speed = 115200
+# fast upload speed (remove ';' when building for development use)
+; upload_speed = 921600
 
 # ------------------------------------------------------------------------------
 # LIBRARIES: required dependencies


### PR DESCRIPTION
Hey,
while developing WLED I was always looking for this option, because the default upload speed is `115200` and that is very slow.
This makes it much easier to increase the upload speed and so its very useful for developing.