### PR TITLE
Re-added countdown setup

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -590,6 +590,7 @@ void serializeConfig() {
   goal.add(countdownYear); goal.add(countdownMonth); goal.add(countdownDay);
   goal.add(countdownHour); goal.add(countdownMin); goal.add(countdownSec);
   cntdwn[F("macro")] = macroCountdown;
+  setCountdown();
 
   JsonArray timers_ins = timers.createNestedArray("ins");
 


### PR DESCRIPTION
I think that in the transition to FS storage, the countdown timer setup has been forgotten. On the current version, when the countdown is set, `countdownTime` is not set, and remains at the default. 

`setCountdown()` used to be called in `saveSettingsToEEPROM()` so I thought that the `serializeConfig()` function was the best place to re-add the functionality. 