### PR TITLE
Added Window Matrix Effect

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -118,7 +118,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  118
+#define MODE_COUNT  119
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -238,6 +238,7 @@
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
 #define FX_MODE_DYNAMIC_SMOOTH         117
+#define FX_MODE_CUSTOM_MATRIX15        118
 
 
 class WS2812FX {
@@ -577,6 +578,7 @@ class WS2812FX {
       _mode[FX_MODE_BLENDS]                  = &WS2812FX::mode_blends;
       _mode[FX_MODE_TV_SIMULATOR]            = &WS2812FX::mode_tv_simulator;
       _mode[FX_MODE_DYNAMIC_SMOOTH]          = &WS2812FX::mode_dynamic_smooth;
+      _mode[FX_MODE_CUSTOM_MATRIX15]         = &WS2812FX::mode_custom_matrix15;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -791,7 +793,8 @@ class WS2812FX {
       mode_candy_cane(void),
       mode_blends(void),
       mode_tv_simulator(void),
-      mode_dynamic_smooth(void);
+      mode_dynamic_smooth(void),
+      mode_custom_matrix15(void);
 
   private:
     NeoPixelWrapper *bus;
@@ -840,7 +843,9 @@ class WS2812FX {
       tricolor_chase(uint32_t, uint32_t),
       twinklefox_base(bool),
       spots_base(uint16_t),
-      phased_base(uint8_t);
+      phased_base(uint8_t),
+      custom_matrix15(uint32_t [7], uint8_t [300], uint8_t);
+
 
     CRGB twinklefox_one_twinkle(uint32_t ms, uint8_t salt, bool cat);
     CRGB pacifica_one_layer(uint16_t i, CRGBPalette16& p, uint16_t cistart, uint16_t wavescale, uint8_t bri, uint16_t ioff);
@@ -891,7 +896,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
 "Heartbeat","Pacifica","Candle Multi", "Solid Glitter","Sunrise","Phased","Twinkleup","Noise Pal", "Sine","Phased Noise",
-"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth"
+"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth","Window Matrix 15"
 ])=====";
 
 


### PR DESCRIPTION
Created a new Window Matrix (15 wide x 20 tall) effect with choices for Christmas (tree, candy cane, star, snowflake) and upcoming Valentines Day (heart). (Depending on space, would create more over time for all holidays, sport teams, etc.) 

The idea was to create a year round matrix for a window that can be seen from a distance while keeping the matrix cost down.   While high density matrix mats are available, to make them large enough would require several mats costing over $100/window with much of the matrix resolution being wasted.  Using 2 of the 30 pixels/meter strips or 300 pixels, you can create a 18" (45.7mm) x 25" (63.5mm) for under $40/window.  

I wanted to avoid running a full scale presentation software to drive the matrix. I wanted to have a small, self contained microprocessor that I could place at the matrix that had a web interface that would allow me to modify the displayed image.  WLED seemed like the perfect solution.

User Interface / Options: Images are selected using the Segment Intensity slider.  Most images use Primary colors 1 and 2 (segcolor 0 and 1) for some foreground color choices and color 3 (segcolor 2) for background color.  Using this, some animation is possible by changing some background and or accent colors.  Note: Segment must be at least 300 pixels or the first few pixels are set to red indicating an error. 

**Possible Upgrades/Issues:**  
* There seems to be a push for space optimization. Each image choice is currently 300 bytes (1 byte/pixel) of flash.  Only need 1/2 a byte for each pixel to store the color code.  This could be optimized by some form of encoding the pixels or maybe to somehow create a 4 bit unsigned int (not sure if possible).   Current config allows you to visualize the image in the array.  Encoding would make it much less intuitive.   
* An ideal solution would allow users to create their own array and upload it to the flash (or load from web) without requiring you to compile the code. This is beyond my current coding ability.
* Another space saving solution, if necessary, might be to add a build flag creating an "optional build" for matrices and requiring a larger memory microprocessor board.
* I would like to use pallets more and create animation on background pixels like ever changing background colors.
* It would be interesting to use color codes 8 and 9 to indicate pixel turning on / off of primary 1 and 2.
* It would be interesting to add an animation affect to rotate the image using formulas at 22.5 degree increments.