### PR TITLE
Reenable compiler warnings for ESP32 platform on PlatformIO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -122,7 +122,7 @@ build_flags =
 
 build_unflags =
   -Wall
-  -Wreorder
+  -Werror=reorder ; (temporarily?) needed to surpress errors in wled00/NpbWrapper.h:
   -Wdeprecated-declarations
 
 # enables all features for travis CI
@@ -159,7 +159,7 @@ build_flags =
   -DMIMETYPE_MINIMAL
 
 [esp32]
-build_flags = -w -g
+build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DCONFIG_LITTLEFS_FOR_IDF_3_2
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -65,7 +65,9 @@
   #include <ESPmDNS.h>
   #include <AsyncTCP.h>
   //#include "SPIFFS.h"
-  #define CONFIG_LITTLEFS_FOR_IDF_3_2
+  #ifndef CONFIG_LITTLEFS_FOR_IDF_3_2
+    #define CONFIG_LITTLEFS_FOR_IDF_3_2
+  #endif
   #include <LITTLEFS.h>
 #endif
 


### PR DESCRIPTION
- remove "-w" ("Suppress all warnings, including those which GNU CPP issues by default.") from esp32.build_flags
- change build_unflags to suppress errors in wled00/NpbWrapper.h
- only define CONFIG_LITTLEFS_FOR_IDF_3_2 if not already defined to avoid another error

I opened a separate issue #1686 to cover fixing the errors in NpbWrapper.h, so hopefully `-Werror=reorder` can be removed in the future