### PR TITLE
Add Cache-Control to index

### DIFF
--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -229,14 +229,32 @@ void serveIndexOrWelcome(AsyncWebServerRequest *request)
   }
 }
 
+bool handleIfNoneMatchCacheHeader(AsyncWebServerRequest* request)
+{
+  AsyncWebHeader* header = request->getHeader("If-None-Match");
+  if (header && header->value() == String(VERSION)) {
+    request->send(304);
+    return true;
+  }
+  return false;
+}
+
+bool setStaticContentCacheHeaders(AsyncWebServerResponse *response)
+{
+  response->addHeader(F("Cache-Control"),"max-age=2592000");
+  response->addHeader(F("ETag"), String(VERSION));
+}
 
 void serveIndex(AsyncWebServerRequest* request)
 {
   if (handleFileRead(request, "/index.htm")) return;
 
+  if (handleIfNoneMatchCacheHeader(request)) return;
+
   AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", PAGE_index, PAGE_index_L);
 
   response->addHeader(F("Content-Encoding"),"gzip");
+  setStaticContentCacheHeaders(response);
   
   request->send(response);
 }


### PR DESCRIPTION
 This PR adds the "Cache-Control" header to the index page.
It reduce the subsequent page load time from anything above 300ms (between 300ms to 1 second) to around 22ms (Sometimes more when there is more latency before connecting to the ESP).

It should also help on devices with poor connection and/or low memory since less data is transferred. 

I wrote the code in a way so that we can easily add this header to any other static page/request that doesn't change between updates.

I put a default expire time of 30 days, but with an ETag value set to the current version of WLed, so that the cache can properly expire between updates.

For developers, this cache can easily be circumvented by having the dev tools open and checking the "disable cache"/"disable cache when devtools are open" option.

