### PR TITLE
Ability to lookup Usermod by id so Usermods can use other Usermods

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -221,6 +221,7 @@ class UsermodManager {
     void readFromConfig(JsonObject& obj);
 
     bool add(Usermod* um);
+    Usermod* lookup(uint16_t mod_id);
     byte getModCount();
 };
 

--- a/wled00/um_manager.cpp
+++ b/wled00/um_manager.cpp
@@ -15,6 +15,18 @@ void UsermodManager::readFromJsonState(JsonObject& obj) { for (byte i = 0; i < n
 void UsermodManager::addToConfig(JsonObject& obj)       { for (byte i = 0; i < numMods; i++) ums[i]->addToConfig(obj); }
 void UsermodManager::readFromConfig(JsonObject& obj)    { for (byte i = 0; i < numMods; i++) ums[i]->readFromConfig(obj); }
 
+/*
+ * Enables usermods to lookup another Usermod.
+ */
+Usermod* UsermodManager::lookup(uint16_t mod_id) {
+  for (byte i = 0; i < numMods; i++) {
+    if (ums[i]->getId() == mod_id) {
+      return ums[i];
+    }
+  }
+  return nullptr;
+}
+
 bool UsermodManager::add(Usermod* um)
 {
   if (numMods >= WLED_MAX_USERMODS || um == nullptr) return false;


### PR DESCRIPTION
This allows a Usermod to get a pointer to another Usermod, if it is found. One Usermod can then call functions in the other Usermod, if it found, to provide additional functionality.

I couldn't immediately find a way to do this, so I wrote my own. If there is a better way to do this, please let me know.

I have written a v2 Four Line Display Usermod (based on the ssd1306 v1 usermod) which includes a clock during input timeout. I have also written a v2 Rotary Encoder UI Usermod (based on the existing v1 rotary encoder usermods, but much more capable, supporting brightness, effect, effect speed, effect intensity, and palette). Both will happily work stand-alone, but if the Rotary Encoder UI Usermod finds the Four Line Display Usermod, it can provide additional functionality. 

Both usermod submissions coming after this is merged.