### PR TITLE
bus_wrapper fixes/improvements for ESP32 SPI

### DIFF
--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -122,7 +122,7 @@ class BusDigital : public Bus {
     //Fix for turning off onboard LED breaking bus
     #ifdef LED_BUILTIN
     if (_bri == 0 && b > 0) {
-      if (_pins[0] == LED_BUILTIN || _pins[1] == LED_BUILTIN) PolyBus::begin(_busPtr, _iType); 
+      if (_pins[0] == LED_BUILTIN || _pins[1] == LED_BUILTIN) PolyBus::begin(_busPtr, _iType, _pins); 
     }
     #endif
     _bri = b;
@@ -159,7 +159,7 @@ class BusDigital : public Bus {
   }
 
   void reinit() {
-    PolyBus::begin(_busPtr, _iType);
+    PolyBus::begin(_busPtr, _iType, _pins);
   }
 
   void cleanup() {

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -328,14 +328,15 @@ class PolyBus {
       case I_32_I0_TM1_4: busPtr = new B_32_I0_TM1_4(len, pins[0]); break;
       case I_32_I1_TM1_4: busPtr = new B_32_I1_TM1_4(len, pins[0]); break;
     #endif
-      case I_HS_DOT_3: busPtr = new B_HS_DOT_3(len, pins[0], pins[1]); break;
-      case I_SS_DOT_3: busPtr = new B_SS_DOT_3(len, pins[0], pins[1]); break;
-      case I_HS_LPD_3: busPtr = new B_HS_LPD_3(len, pins[0], pins[1]); break;
-      case I_SS_LPD_3: busPtr = new B_SS_LPD_3(len, pins[0], pins[1]); break;
-      case I_HS_WS1_3: busPtr = new B_HS_WS1_3(len, pins[0], pins[1]); break;
-      case I_SS_WS1_3: busPtr = new B_SS_WS1_3(len, pins[0], pins[1]); break;
-      case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[0], pins[1]); break;
-      case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[0], pins[1]); break;
+      // for 2-wire: pins[1] is clk, pins[0] is dat.  begin expects (len, clk, dat)
+      case I_HS_DOT_3: busPtr = new B_HS_DOT_3(len, pins[1], pins[0]); break;
+      case I_SS_DOT_3: busPtr = new B_SS_DOT_3(len, pins[1], pins[0]); break;
+      case I_HS_LPD_3: busPtr = new B_HS_LPD_3(len, pins[1], pins[0]); break;
+      case I_SS_LPD_3: busPtr = new B_SS_LPD_3(len, pins[1], pins[0]); break;
+      case I_HS_WS1_3: busPtr = new B_HS_WS1_3(len, pins[1], pins[0]); break;
+      case I_SS_WS1_3: busPtr = new B_SS_WS1_3(len, pins[1], pins[0]); break;
+      case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[1], pins[0]); break;
+      case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[1], pins[0]); break;
     }
     begin(busPtr, busType);
     return busPtr;
@@ -835,10 +836,11 @@ class PolyBus {
       #endif
       uint8_t t = I_NONE;
       switch (busType) {
-        case TYPE_APA102:  t = I_SS_DOT_3;
-        case TYPE_LPD8806: t = I_SS_LPD_3;
-        case TYPE_WS2801:  t = I_SS_WS1_3;
-        case TYPE_P9813:   t = I_SS_P98_3;
+        case TYPE_APA102:  t = I_SS_DOT_3; break;
+        case TYPE_LPD8806: t = I_SS_LPD_3; break;
+        case TYPE_WS2801:  t = I_SS_WS1_3; break;
+        case TYPE_P9813:   t = I_SS_P98_3; break;
+        default: t=I_NONE;
       }
       if (t > I_NONE && isHSPI) t--; //hardware SPI has one smaller ID than software
       return t;

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -191,7 +191,7 @@
 //handles pointer type conversion for all possible bus types
 class PolyBus {
   public:
-  static void begin(void* busPtr, uint8_t busType) {
+  static void begin(void* busPtr, uint8_t busType, uint8_t* pins) {
     switch (busType) {
       case I_NONE: break;
     #ifdef ESP8266
@@ -211,6 +211,10 @@ class PolyBus {
       case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->Begin(); break;
       case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->Begin(); break;
       case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->Begin(); break;
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->Begin(); break;
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->Begin(); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->Begin(); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Begin(); break;
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_R0_NEO_3: (static_cast<B_32_R0_NEO_3*>(busPtr))->Begin(); break;
@@ -253,14 +257,15 @@ class PolyBus {
       case I_32_R7_TM1_4: (static_cast<B_32_R7_TM1_4*>(busPtr))->Begin(); break;
       case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->Begin(); break;
       case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->Begin(); break;
+      // ESP32 can (and should, to avoid inadvertantly driving the chip select signal) specify the pins used for SPI, but only in begin()
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
     #endif
-      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->Begin(); break;
       case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->Begin(); break;
-      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->Begin(); break;
       case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->Begin(); break;
-      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->Begin(); break;
       case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->Begin(); break;
-      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Begin(); break;
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->Begin(); break;
     }
   };
@@ -338,7 +343,7 @@ class PolyBus {
       case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[1], pins[0]); break;
       case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[1], pins[0]); break;
     }
-    begin(busPtr, busType);
+    begin(busPtr, busType, pins);
     return busPtr;
   };
   static void show(void* busPtr, uint8_t busType) {
@@ -831,8 +836,7 @@ class PolyBus {
       #ifdef ESP8266
       if (pins[0] == P_8266_HS_MOSI && pins[1] == P_8266_HS_CLK) isHSPI = true;
       #else
-      if (pins[0] == P_32_HS_MOSI && pins[1] == P_32_HS_CLK) isHSPI = true;
-      if (pins[0] == P_32_VS_MOSI && pins[1] == P_32_VS_CLK) isHSPI = true;
+        if(!num) isHSPI = true; // temporary hack to limit use of hardware SPI to a single SPI peripheral: only allow ESP32 hardware serial on segment 0
       #endif
       uint8_t t = I_NONE;
       switch (busType) {


### PR DESCRIPTION
Fixes:

- missing breaks in switch(busType identifying SPI LEDs)
- set correct pin order for begin()

Improvements:

- Identifying ESP32 hardware SPI by pin number is broken and flawed, replace with temporary hack instead until a better method of assigned resources can be devised
  - NeoPixelBus doesn't support HSPI, only VSPI right now, so matching HSPI pins to enable a non-existent VSPI driver is broken
  - ESP32 SPI peripherals can use alternate pins, so choosing to use hardware SPI only on the default pins is flawed
- Specify pins during Begin() call to allow for alternate pins and avoid driving the chip select signal

Testing:

- Dotstar Software/Hardware output was tested on ESP32
- Other SPI protocols and ESP8266 support were not tested
