### PR TITLE
Use ldscript_1m128k in platformio_override.ini.sample

### DIFF
--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -11,7 +11,7 @@ default_envs = WLED_tasmota_1M
 board = esp01_1m
 platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
-board_build.ldscript = ${common.ldscript_1m0m}
+board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags_esp8266}
 ; *********************************************************************


### PR DESCRIPTION
The current value ldscript_1m0m doesn't exist anymore and WLED won't compile. Using ldscript_1m128k makes it compile.