### PR TITLE
Made PWM frequency configurable; changed ESP32 default PWM frequency

### DIFF
--- a/wled00/NpbWrapper.h
+++ b/wled00/NpbWrapper.h
@@ -112,6 +112,15 @@
   #endif
   #undef RLYPIN
   #define RLYPIN -1 //disable as pin 12 is used by analog LEDs
+  
+  #ifndef PWM_FREQUENCY
+    #ifdef ARDUINO_ARCH_ESP32
+    #define PWM_FREQUENCY 19531
+    #else
+    #define PWM_FREQUENCY 880
+    #endif
+  #endif
+  
 #endif
 
 //automatically uses the right driver method for each platform
@@ -230,18 +239,18 @@ public:
 
     #ifdef WLED_USE_ANALOG_LEDS 
       #ifdef ARDUINO_ARCH_ESP32
-        ledcSetup(0, 5000, 8);
+        ledcSetup(0, PWM_FREQUENCY, 8);
         ledcAttachPin(RPIN, 0);
-        ledcSetup(1, 5000, 8);
+        ledcSetup(1, PWM_FREQUENCY, 8);
         ledcAttachPin(GPIN, 1);
-        ledcSetup(2, 5000, 8);        
+        ledcSetup(2, PWM_FREQUENCY, 8);        
         ledcAttachPin(BPIN, 2);
         if(_type == NeoPixelType_Grbw) 
         {
-          ledcSetup(3, 5000, 8);        
+          ledcSetup(3, PWM_FREQUENCY, 8);        
           ledcAttachPin(WPIN, 3);
           #ifdef WLED_USE_5CH_LEDS
-            ledcSetup(4, 5000, 8);        
+            ledcSetup(4, PWM_FREQUENCY, 8);        
             ledcAttachPin(W2PIN, 4);
           #endif
         }
@@ -258,7 +267,7 @@ public:
           #endif
         }
         analogWriteRange(255);  //same range as one RGB channel
-        analogWriteFreq(880);   //PWM frequency proven as good for LEDs
+        analogWriteFreq(PWM_FREQUENCY);   //PWM frequency proven as good for LEDs
       #endif 
     #endif
   }


### PR DESCRIPTION
Hey there,

I've just compiled WLED for using it on the QuinLED-Quad with some analog RGB strips I have. After switching it on it made a *horrible* beeping sound and many colors and everything below 100% brightness. After a little chat in #quinled-analog in Quindors Discord, somebody recommended to use 19531Hz, which apparently is also the max suggested in the ESPHome docs: https://esphome.io/components/output/ledc.html#recommended-frequencies

With this frequency (but still on 8bit resolution), I have zero beeping noises on any color and any brightness level. So I added this as default for the ESP32 and also made it configurable with a build flag :)

Greetings,

Andy! 