### PR TITLE
Improvements for SPI-based LEDs

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -79,7 +79,7 @@ void WS2812FX::finalizeInit(bool supportWhite, uint16_t countPixels, bool skipFi
   #ifdef ESP8266
   for (uint8_t i = 0; i < busses.getNumBusses(); i++) {
     Bus* b = busses.getBus(i);
-    if ((!IS_DIGITAL(b->getType()) || IS_2PIN(b->getType()))) continue;
+    if ((!IS_DIGITAL(b->getType()) || (NUM_PINS(b->getType() > 1)))) continue;
     uint8_t pins[5];
     b->getPins(pins);
     BusDigital* bd = static_cast<BusDigital*>(b);

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -19,7 +19,7 @@ struct BusConfig {
   bool reversed = false;
   uint16_t clkspeed;
   uint8_t pins[5] = {LEDPIN, 255, 255, 255, 255};
-  BusConfig(uint8_t busType, uint8_t* ppins, uint16_t pstart, uint16_t len = 1, uint8_t pcolorOrder = COL_ORDER_GRB, bool rev = false, uint16_t clkSpeed = 5001UL) {
+  BusConfig(uint8_t busType, uint8_t* ppins, uint16_t pstart, uint16_t len = 1, uint8_t pcolorOrder = COL_ORDER_GRB, bool rev = false, uint16_t clkSpeed = 5000UL) {
     type = busType; count = len; start = pstart; colorOrder = pcolorOrder; reversed = rev; clkspeed = clkSpeed;
     uint8_t nPins = 1;
     if (type > 47) nPins = NUM_PINS(type);
@@ -95,10 +95,7 @@ class BusDigital : public Bus {
     if (!IS_DIGITAL(bc.type) || !bc.count) return;
     for(int i=0; i<NUM_PINS(bc.type); i++) {
       _pins[i] = bc.pins[i];
-      Serial.print(" ");
-      Serial.print(_pins[i]);
       if (!pinManager.allocatePin(_pins[i])) {
-        Serial.println("failed");
         cleanup(); return;
       }
     }
@@ -180,11 +177,9 @@ class BusDigital : public Bus {
     _valid = false;
     _busPtr = nullptr;
     _clkSpeed = 5000UL;
-    pinManager.deallocatePin(_pins[0]);
-    pinManager.deallocatePin(_pins[1]);
-    pinManager.deallocatePin(_pins[2]);
-    pinManager.deallocatePin(_pins[3]);
-    pinManager.deallocatePin(_pins[4]);
+    for(int i=0; i<5; i++) {
+      pinManager.deallocatePin(_pins[i]);
+    }
   }
 
   ~BusDigital() {

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -831,7 +831,7 @@ class PolyBus {
   //gives back the internal type index (I_XX_XXX_X above) for the input 
   static uint8_t getI(uint8_t busType, uint8_t* pins, uint8_t num = 0) {
     if (!IS_DIGITAL(busType)) return I_NONE;
-    if (IS_2PIN(busType)) { //SPI LED chips
+    if (NUM_PINS(busType) > 1) { //SPI LED chips
       bool isHSPI = false;
       #ifdef ESP8266
       if (pins[0] == P_8266_HS_MOSI && pins[1] == P_8266_HS_CLK) isHSPI = true;

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -258,11 +258,11 @@ class PolyBus {
       case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->Begin(); break;
       case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->Begin(); break;
       // ESP32 can (and should, to avoid inadvertantly driving the chip select signal) specify the pins used for SPI, but only in begin()
-      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
-      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
-      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
-      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Begin(pins[1], -1, pins[0], -1); break;
     #endif
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->Begin(pins[0], -1, pins[1], -1); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->Begin(pins[0], -1, pins[1], -1); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Begin(pins[0], -1, pins[1], -1); break;
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->Begin(pins[0], -1, pins[1], -1); break;
       case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->Begin(); break;
       case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->Begin(); break;
       case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->Begin(); break;
@@ -333,15 +333,15 @@ class PolyBus {
       case I_32_I0_TM1_4: busPtr = new B_32_I0_TM1_4(len, pins[0]); break;
       case I_32_I1_TM1_4: busPtr = new B_32_I1_TM1_4(len, pins[0]); break;
     #endif
-      // for 2-wire: pins[1] is clk, pins[0] is dat.  begin expects (len, clk, dat)
-      case I_HS_DOT_3: busPtr = new B_HS_DOT_3(len, pins[1], pins[0]); break;
-      case I_SS_DOT_3: busPtr = new B_SS_DOT_3(len, pins[1], pins[0]); break;
-      case I_HS_LPD_3: busPtr = new B_HS_LPD_3(len, pins[1], pins[0]); break;
-      case I_SS_LPD_3: busPtr = new B_SS_LPD_3(len, pins[1], pins[0]); break;
-      case I_HS_WS1_3: busPtr = new B_HS_WS1_3(len, pins[1], pins[0]); break;
-      case I_SS_WS1_3: busPtr = new B_SS_WS1_3(len, pins[1], pins[0]); break;
-      case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[1], pins[0]); break;
-      case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[1], pins[0]); break;
+      // for 2-wire: pins[0] is clk, pins[1] is dat.  begin expects (len, clk, dat)
+      case I_HS_DOT_3: busPtr = new B_HS_DOT_3(len, pins[0], pins[1]); break;
+      case I_SS_DOT_3: busPtr = new B_SS_DOT_3(len, pins[0], pins[1]); break;
+      case I_HS_LPD_3: busPtr = new B_HS_LPD_3(len, pins[0], pins[1]); break;
+      case I_SS_LPD_3: busPtr = new B_SS_LPD_3(len, pins[0], pins[1]); break;
+      case I_HS_WS1_3: busPtr = new B_HS_WS1_3(len, pins[0], pins[1]); break;
+      case I_SS_WS1_3: busPtr = new B_SS_WS1_3(len, pins[0], pins[1]); break;
+      case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[0], pins[1]); break;
+      case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[0], pins[1]); break;
     }
     begin(busPtr, busType, pins, clkspeed);
     return busPtr;
@@ -834,7 +834,7 @@ class PolyBus {
     if (NUM_PINS(busType) > 1) { //SPI LED chips
       bool isHSPI = false;
       #ifdef ESP8266
-      if (pins[0] == P_8266_HS_MOSI && pins[1] == P_8266_HS_CLK) isHSPI = true;
+      if (pins[1] == P_8266_HS_MOSI && pins[0] == P_8266_HS_CLK) isHSPI = true;
       #else
         if(!num) isHSPI = true; // temporary hack to limit use of hardware SPI to a single SPI peripheral: only allow ESP32 hardware serial on segment 0
       #endif

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -191,7 +191,7 @@
 //handles pointer type conversion for all possible bus types
 class PolyBus {
   public:
-  static void begin(void* busPtr, uint8_t busType, uint8_t* pins) {
+  static void begin(void* busPtr, uint8_t busType, uint8_t* pins, uint16_t clkspeed) {
     switch (busType) {
       case I_NONE: break;
     #ifdef ESP8266
@@ -269,7 +269,7 @@ class PolyBus {
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->Begin(); break;
     }
   };
-  static void* create(uint8_t busType, uint8_t* pins, uint16_t len) {
+  static void* create(uint8_t busType, uint8_t* pins, uint16_t len, uint16_t clkspeed) {
     void* busPtr = nullptr;
     switch (busType) {
       case I_NONE: break;
@@ -343,7 +343,7 @@ class PolyBus {
       case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[1], pins[0]); break;
       case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[1], pins[0]); break;
     }
-    begin(busPtr, busType, pins);
+    begin(busPtr, busType, pins, clkspeed);
     return busPtr;
   };
   static void show(void* busPtr, uint8_t busType) {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -127,10 +127,11 @@ void deserializeConfig() {
     if (start + length > ledCount) length = ledCount - start;
     uint8_t ledType = elm[F("type")] | TYPE_WS2812_RGB;
     bool reversed = elm[F("rev")];
+    uint16_t clockSpeed = elm[F("clkspeed")] | 5000;
     //RGBW mode is enabled if at least one of the strips is RGBW
     useRGBW = (useRGBW || BusManager::isRgbw(ledType));
     s++;
-    BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed);
+    BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, clockSpeed);
     mem += busses.memUsage(bc);
     if (mem <= MAX_LED_MEMORY) busses.add(bc);
   }

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -114,11 +114,15 @@
 #define TYPE_APA102              51
 #define TYPE_LPD8806             52
 #define TYPE_P9813               53
+// Pixelvation Engine uses 2-bit/4-bit SPI: temporary hack using bits 6/7=0b01, digital: bits 4/5: 0b01, range 80-95
+#define TYPE_APA102_2BIT         80
+#define TYPE_APA102_4BIT         81
+
 
 #define IS_DIGITAL(t) (t & 0x10) //digital are 16-31 and 48-63
 #define IS_PWM(t)     (t > 40 && t < 46)
 #define NUM_PWM_PINS(t) (t - 40) //for analog PWM 41-45 only
-#define IS_2PIN(t)      (t > 47)
+#define NUM_PINS(t)     ((t < 48) ? 1 : (t < 64) ? 2 : (t == TYPE_APA102_2BIT) ? 3 : 5)
 
 //Color orders
 #define COL_ORDER_GRB             0           //GRB(w),defaut


### PR DESCRIPTION
Still a work in progress...

This code has had limited testing (ESP32 and APA102 LEDs only) on another (private) branch, but not after the commits were cherry picked into this new branch off of dev

To set clkspeed, manually edit cfg.json.  To set the SPI LED order, reverse the fields in LED settings, or manually edit cfg.json