### PR TITLE
Increase buffer size

### DIFF
--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -120,7 +120,7 @@ class UsermodTemperature : public Usermod {
         getTemperature();
  
         if (WLED_MQTT_CONNECTED) {
-          char subuf[38];
+          char subuf[45];
           strcpy(subuf, mqttDeviceTopic);
           if (-100 <= temperature) {
             // dont publish super low temperature as the graph will get messed up


### PR DESCRIPTION
Avoid buffer overflows with longer mqtt topics
mqtDeviceTopic in wled.h is defined with a size of 33, so this should be set to 45 to accommodate the additional 12 characters - /temperature

I was using a base WLED mqtt topic of "xxxxxx/outdoor/pergola/wled" and every time the temperature mod would attempt a publish to mqtt I'd get a overflow and reboot

Increasing the buffer to allow the full size.