### PR TITLE
Use 22.5 for the TM1814 max current

### DIFF
--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -2,9 +2,6 @@
 #define BusWrapper_h
 
 #include "NeoPixelBrightnessBus.h"
-#include "FX.h"
-
-extern WS2812FX strip;  // Provides access to global settings for LEDs.
 
 //Hardware SPI Pins
 #define P_8266_HS_MOSI 13
@@ -199,8 +196,8 @@ class PolyBus {
   static void beginTM1814(void* busPtr) {
     T tm1814_strip = static_cast<T>(busPtr);
     tm1814_strip->Begin();
-    const uint16_t mA = strip.milliampsPerLed * 10;
-    tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/mA, /*G*/mA, /*B*/mA, /*W*/mA));
+    // Max current for each LED (22.5 mA).
+    tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/225, /*G*/225, /*B*/225, /*W*/225));
   }
   static void begin(void* busPtr, uint8_t busType, uint8_t* pins) {
     switch (busType) {

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -2,6 +2,9 @@
 #define BusWrapper_h
 
 #include "NeoPixelBrightnessBus.h"
+#include "FX.h"
+
+extern WS2812FX strip;  // Provides access to global settings for LEDs.
 
 //Hardware SPI Pins
 #define P_8266_HS_MOSI 13
@@ -196,9 +199,8 @@ class PolyBus {
   static void beginTM1814(void* busPtr) {
     T tm1814_strip = static_cast<T>(busPtr);
     tm1814_strip->Begin();
-    // Max current for each LED (38.0 mA).
-    const uint16_t max = NeoTm1814Settings::MaxCurrent;
-    tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/max, /*G*/max, /*B*/max, /*W*/max));
+    const uint16_t mA = strip.milliampsPerLed * 10;
+    tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/mA, /*G*/mA, /*B*/mA, /*W*/mA));
   }
   static void begin(void* busPtr, uint8_t busType, uint8_t* pins) {
     switch (busType) {


### PR DESCRIPTION
Configure the TM1814 constant current at 22.5 mA as this seems to be a common value for several different RGBW LED chips.

I had originally intended this PR to use the `strip.milliampsPerLed` value, but was unable to find a way to make that work with the different voltages used for the TM1814 strip types (see comment below).

Related to: #1519