### PR TITLE
Add IP Address to JsonInfo

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -549,13 +549,13 @@ void serializeInfo(JsonObject root)
   root[F("brand")] = "WLED";
   root[F("product")] = F("FOSS");
   root["mac"] = escapedMac;
+  char s[16] = "";
   if (Network.isConnected())
   {
-    char s[16];
     IPAddress localIP = Network.localIP();
     sprintf(s, "%d.%d.%d.%d", localIP[0], localIP[1], localIP[2], localIP[3]);
-    root[F("sip")] = s;
   }
+  root["ip"] = s;
 }
 
 void setPaletteColors(JsonArray json, CRGBPalette16 palette)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -549,6 +549,13 @@ void serializeInfo(JsonObject root)
   root[F("brand")] = "WLED";
   root[F("product")] = F("FOSS");
   root["mac"] = escapedMac;
+  if (Network.isConnected())
+  {
+    char s[16];
+    IPAddress localIP = Network.localIP();
+    sprintf(s, "%d.%d.%d.%d", localIP[0], localIP[1], localIP[2], localIP[3]);
+    root[F("sip")] = s;
+  }
 }
 
 void setPaletteColors(JsonArray json, CRGBPalette16 palette)


### PR DESCRIPTION
The value is added to the JSON only if the device is connected to the network, and uses the JSON key `"sip"` to match [wled00/xml.cpp](wled00/xml.cpp#L249). The overarching goal of this is to expose the IP Address to the Home Assistant WLED Integration, so that Home Assistant can provide a link to the WLED device (either directly through the Integration/Device page 🤞 or *ad hoc* in Lovelace).

Note: The WLED wiki would need to be updated to reflect this addition.