### PR TITLE
Add comment about the TYWE3S controller

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -458,6 +458,7 @@ build_flags = ${common.build_flags_esp32} ${common.debug_flags} ${common.build_f
 
 # ------------------------------------------------------------------------------
 # codm pixel controller board configurations
+# codm-controller-0.6 can also be used for the TYWE3S controller
 # ------------------------------------------------------------------------------
 
 [env:codm-controller-0.6]


### PR DESCRIPTION
The `codm-controller-0.6` env also works for the [`TYWE3S` controller](https://github.com/Aircoookie/WLED/issues/1519#issuecomment-826126116). This PR just adds a note so that folks who search for `TYWE3S` will find the proper env to use.