### PR TITLE
Add sync settings endpoints to the JSON API

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -97,8 +97,10 @@ void handleIR();
 #include "FX.h"
 
 void deserializeSegment(JsonObject elem, byte it);
+void deserializeSettings(JsonObject root);
 bool deserializeState(JsonObject root);
 void serializeSegment(JsonObject& root, WS2812FX::Segment& seg, byte id, bool forPreset = false, bool segmentBounds = true);
+void serializeSettings(JsonObject root);
 void serializeState(JsonObject root, bool forPreset = false, bool includeBri = true, bool segmentBounds = true);
 void serializeInfo(JsonObject root);
 void serveJson(AsyncWebServerRequest* request);
@@ -128,7 +130,7 @@ void publishMqtt();
 //ntp.cpp
 void handleNetworkTime();
 void sendNTPPacket();
-bool checkNTPResponse();    
+bool checkNTPResponse();
 void updateLocalTime();
 void getTimeString(char* out);
 bool checkCountdown();
@@ -146,7 +148,7 @@ void _overlayAnalogClock();
 
 byte getSameCodeLength(char code, int index, char const cronixieDisplay[]);
 void setCronixie();
-void _overlayCronixie();    
+void _overlayCronixie();
 void _drawOverlayCronixie();
 
 //playlist.cpp

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -673,6 +673,8 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
 
   // SYNC SETTINGS endpoints
   // set sync mode - EP/DI
+  // int t = request->arg(F("EP")).toInt();
+  // if (t > 0) e131Port = t;
   pos = req.indexOf(F("EP="));
   if (pos > 0) {
     e131Port = getNumVal(&req, pos);
@@ -703,7 +705,8 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   // disable gamma correction
   pos = req.indexOf(F("RG="));
   if (pos > 0) arlsDisableGammaCorrection = (req.charAt(pos+3) != '0');
-  
+  // handleSettingsSet(request, 4);
+
 
   //main toggle on/off (parse before nightlight, #1214)
   pos = req.indexOf(F("&T="));

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -107,7 +107,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       type = request->arg(lt).toInt();
       //if (isRgbw(type)) strip.isRgbw = true; //30fps
       //strip.isRgbw = true;
-      
+
       if (request->hasArg(lc) && request->arg(lc).toInt() > 0) {
         length = request->arg(lc).toInt();
       } else {
@@ -155,7 +155,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 
     strip.ablMilliampsMax = request->arg(F("MA")).toInt();
     strip.milliampsPerLed = request->arg(F("LA")).toInt();
-    
+
     strip.rgbwMode = request->arg(F("AW")).toInt();
 
     briS = request->arg(F("CA")).toInt();
@@ -295,7 +295,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     longitude = request->arg(F("LN")).toFloat();
     latitude = request->arg(F("LT")).toFloat();
     // force a sunrise/sunset re-calculation
-    calculateSunriseAndSunset(); 
+    calculateSunriseAndSunset();
 
     if (request->hasArg(F("OL"))) {
       overlayDefault = request->arg(F("OL")).toInt();
@@ -671,6 +671,40 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   pos = req.indexOf(F("RD="));
   if (pos > 0) receiveDirect = (req.charAt(pos+3) != '0');
 
+  // SYNC SETTINGS endpoints
+  // set sync mode - EP/DI
+  pos = req.indexOf(F("EP="));
+  if (pos > 0) {
+    e131Port = getNumVal(&req, pos);
+  }
+  // start universe
+  pos = req.indexOf(F("EU="));
+  if (pos > 0) {
+    e131Universe = getNumVal(&req, pos);
+  }
+  // DMX start address
+  pos = req.indexOf(F("DA="));
+  if (pos > 0) {
+    DMXAddress = getNumVal(&req, pos);
+  }
+  // DMX mode
+  pos = req.indexOf(F("DM="));
+  if (pos > 0) {
+    DMXMode = getNumVal(&req, pos);
+  }
+  // timeout
+  pos = req.indexOf(F("ET="));
+  if (pos > 0) {
+    realtimeTimeoutMs = getNumVal(&req, pos);
+  }
+  // force max brightness
+  pos = req.indexOf(F("FB="));
+  if (pos > 0) arlsForceMaxBri = (req.charAt(pos+3) != '0');
+  // disable gamma correction
+  pos = req.indexOf(F("RG="));
+  if (pos > 0) arlsDisableGammaCorrection = (req.charAt(pos+3) != '0');
+  
+
   //main toggle on/off (parse before nightlight, #1214)
   pos = req.indexOf(F("&T="));
   if (pos > 0) {
@@ -768,7 +802,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   //mode, 1 countdown
   pos = req.indexOf(F("NM="));
   if (pos > 0) countdownMode = (req.charAt(pos+3) != '0');
-  
+
   pos = req.indexOf(F("NX=")); //sets digits to code
   if (pos > 0) {
     strlcpy(cronixieDisplay, req.substring(pos + 3, pos + 9).c_str(), 6);
@@ -837,7 +871,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   //end of temporary fix code
 
   if (!apply) return true; //when called by JSON API, do not call colorUpdated() here
-  
+
   //internal call, does not send XML response
   pos = req.indexOf(F("IN"));
   if (pos < 1) XML_response(request);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -672,10 +672,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   if (pos > 0) receiveDirect = (req.charAt(pos+3) != '0');
 
   // SYNC SETTINGS endpoints
-  // set sync mode - EP/DI
-  // int t = request->arg(F("EP")).toInt();
-  // if (t > 0) e131Port = t;
-  pos = req.indexOf(F("EP="));
+  /*pos = req.indexOf(F("EP="));
   if (pos > 0) {
     e131Port = getNumVal(&req, pos);
   }
@@ -706,6 +703,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   pos = req.indexOf(F("RG="));
   if (pos > 0) arlsDisableGammaCorrection = (req.charAt(pos+3) != '0');
   // handleSettingsSet(request, 4);
+  */
 
 
   //main toggle on/off (parse before nightlight, #1214)


### PR DESCRIPTION
LedFx needs to be able to change certain sync settings when setting up WLED devices. Currently we use a workaround that is far from optimal. This PR adds the settings needed by LedFx to the ~~HTTP~~ JSON API.

I've tested this on a fresh esp8266 and it seems to be working as expected. I wasn't 100% certain how to add this functionality so I'm not sure if I did it correctly. I'm hoping @Aircoookie can take a look at this and see if everything looks ok.

What this PR does:

- Add `deserializeSettings()` and `serializeSettings()`
- Add ability to set common sync settings via JSON API
- Only save sync settings if JSON contains `settsync`