### PR TITLE
remove unused flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -114,9 +114,6 @@ build_unflags =
 
 # enables all features for travis CI
 build_flags_all_features =
-  -D WLED_USE_ANALOG_LED
-  -D WLED_USE_H801
-  -D WLED_ENABLE_5CH_LEDS
   -D WLED_ENABLE_ADALIGHT
   -D WLED_ENABLE_DMX
   -D WLED_ENABLE_MQTT
@@ -283,7 +280,7 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA -D WLED_USE_ANALOG_LEDS
+build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA
 
 [env:esp8285_4CH_H801]
 board = esp8285
@@ -291,7 +288,7 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA -D WLED_USE_ANALOG_LEDS -D WLED_USE_H801
+build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA
 
 [env:esp8285_5CH_H801]
 board = esp8285
@@ -299,7 +296,7 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA -D WLED_USE_ANALOG_LEDS -D WLED_USE_H801 -D WLED_ENABLE_5CH_LEDS
+build_flags = ${common.build_flags_esp8266} -D WLED_DISABLE_OTA
 
 [env:d1_mini_5CH_Shojo_PCB]
 board = d1_mini
@@ -307,7 +304,7 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_USE_ANALOG_LEDS -D WLED_USE_SHOJO_PCB -D WLED_ENABLE_5CH_LEDS
+build_flags = ${common.build_flags_esp8266} -D WLED_USE_SHOJO_PCB
 
 # ------------------------------------------------------------------------------
 # DEVELOPMENT BOARDS

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -39,12 +39,8 @@ build_flags = ${common.build_flags_esp8266}
 ; PIN defines for 2 wire LEDs
    -D CLKPIN=0
    -D DATAPIN=2
-; to drive analog LED strips (aka 5050), uncomment the following
-; PWM pins 5,12,13,15 are used with Magic Home LED Controller (default)
-   -D WLED_USE_ANALOG_LEDS
-; for the H801 controller (PINs 15,13,12,14 (W2 = 04)) uncomment this
-;   -D WLED_USE_H801
-; for the BW-LT11 controller (PINs 12,4,14,5 ) uncomment this
-;   -D WLED_USE_BWLT11
-; and to enable channel 5 for RGBW-CT led strips this
-;   -D WLED_USE_5CH_LEDS
+; to drive analog LED strips (aka 5050) hardware configuration is no longer necessary
+; configure the settings in the UI as follows (hard):
+;   for the Magic Home LED Controller use PWM pins 5,12,13,15
+;   for the H801 controller use PINs 15,13,12,14 (W2 = 04)
+;   for the BW-LT11 controller use PINs 12,4,14,5 


### PR DESCRIPTION
This change removes unused build flags that were rendered no longer used in the code by multichannel support in 0.12.