### PR TITLE
CRONIXIE check in json.cpp

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -263,9 +263,11 @@ bool deserializeState(JsonObject root)
     }
   }
 
-  if (root["nx"].is<const char*>()) {
-    strncpy(cronixieDisplay, root["nx"], 6);
-  }
+  #ifndef WLED_DISABLE_CRONIXIE
+    if (root["nx"].is<const char*>()) {
+      strncpy(cronixieDisplay, root["nx"], 6);
+    }
+  #endif
 
   usermods.readFromJsonState(root);
 


### PR DESCRIPTION
If you use a **-WLED_DISABLE_CRONIXIE** flag in the my_config.h or platformio.ini then the compiler throws an error after building in the **json.cpp** file because there is no check if the flag is used.