### PR TITLE
Added support for raw 16bpp RGB565 images, and added elekstube env to examples in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@
 default_envs = nodemcuv2, esp01_1m_full, esp32dev, esp32_eth
 
 # Single binaries (uncomment your board)
+; default_envs = elekstube_ips
 ; default_envs = nodemcuv2
 ; default_envs = esp01_1m_full
 ; default_envs = esp07


### PR DESCRIPTION
Added support for raw 16bpp RGB565 images. Upload /0.bin etc.
See https://github.com/neptune2/EleksTube-IPS-Retro-Nixie-Digits for
how to get the original digits.