### PR TITLE
move common HTTP constants to separate header file

### DIFF
--- a/wled00/http.h
+++ b/wled00/http.h
@@ -19,7 +19,7 @@
 #define HTTP_HDR_ACCESS_CONTROL_MAX_AGE "Access-Control-Max-Age"
 #define HTTP_HDR_CACHE_CONTROL "Cache-Control"
 #define HTTP_HDR_CONTENT_TYPE "Content-Type"
-#define HTTP_HDR_CONTENT_ENCODING "Content_Encoding"
+#define HTTP_HDR_CONTENT_ENCODING "Content-Encoding"
 #define HTTP_HDR_ETAG "Etag"
 #define HTTP_HDR_IF_NONE_MATCH "If-None-Match"
 #define HTTP_HDR_HOST "Host"

--- a/wled00/http.h
+++ b/wled00/http.h
@@ -1,0 +1,33 @@
+#ifndef HTTP_CONST_H
+#define HTTP_CONST_H
+
+/* HTTP Status Codes */
+#define HTTP_STATUS_OK 200
+#define HTTP_STATUS_BAD_REQUEST 400
+#define HTTP_STATUS_NOT_FOUND 404
+#define HTTP_STATUS_TEAPOT 418
+#define HTTP_STATUS_INTERNAL_ERROR 500
+#define HTTP_STATUS_NOT_IMPL 501
+
+/* Standard HTTP response messages */
+#define HTTP_MSG_NOT_IMPL "Not Implemented"
+
+/* Standard HTTP Headers */
+#define HTTP_HDR_ACCESS_CONTROL_ALLOW_METHODS "Access-Control-Allow-Methods"
+#define HTTP_HDR_ACCESS_CONTROL_ALLOW_ORIGIN "Access-Control-Allow-Origin"
+#define HTTP_HDR_ACCESS_CONTROL_ALLOW_HEADERS "Access-Control-Allow-Headers"
+#define HTTP_HDR_CACHE_CONTROL "Cache-Control"
+#define HTTP_HDR_CONTENT_TYPE "Content-Type"
+#define HTTP_HDR_CONTENT_ENCODING "Content_Encoding"
+#define HTTP_HDR_ETAG "Etag"
+#define HTTP_HDR_IF_NONE_MATCH "If-None-Match"
+#define HTTP_HDR_HOST "Host"
+#define HTTP_HDR_LOCATION "Location"
+
+/* Common MIME types for Content-Type headers */
+#define CT_APPLICATION_JSON "application/json"
+#define CT_TEXT_PLAIN "text/plain"
+#define CT_TEXT_HTML "text/html"
+#define CT_IMAGE_XICON "image/x-icon"
+
+#endif 

--- a/wled00/http.h
+++ b/wled00/http.h
@@ -16,6 +16,7 @@
 #define HTTP_HDR_ACCESS_CONTROL_ALLOW_METHODS "Access-Control-Allow-Methods"
 #define HTTP_HDR_ACCESS_CONTROL_ALLOW_ORIGIN "Access-Control-Allow-Origin"
 #define HTTP_HDR_ACCESS_CONTROL_ALLOW_HEADERS "Access-Control-Allow-Headers"
+#define HTTP_HDR_ACCESS_CONTROL_MAX_AGE "Access-Control-Max-Age"
 #define HTTP_HDR_CACHE_CONTROL "Cache-Control"
 #define HTTP_HDR_CONTENT_TYPE "Content-Type"
 #define HTTP_HDR_CONTENT_ENCODING "Content_Encoding"

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -53,7 +53,6 @@
 // Library inclusions.
 #include <Arduino.h>
 #ifdef ESP8266
-  #include <ESP8266WiFi.h>
   #include <ESP8266mDNS.h>
   #include <ESPAsyncTCP.h>
   #include <LittleFS.h>
@@ -62,8 +61,6 @@
   #include <user_interface.h>
   }
 #else // ESP32
-  #include <WiFi.h>
-  #include <ETH.h>
   #include "esp_wifi.h"
   #include <ESPmDNS.h>
   #include <AsyncTCP.h>

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -226,7 +226,7 @@ void initServer()
     if (request->method() == HTTP_OPTIONS)
     {
       AsyncWebServerResponse *response = request->beginResponse(HTTP_STATUS_OK);
-      response->addHeader(F("Access-Control-Max-Age"), F("7200"));
+      response->addHeader(F(HTTP_HDR_ACCESS_CONTROL_MAX_AGE), F("7200"));
       request->send(response);
       return;
     }


### PR DESCRIPTION
This PR clean up the code by eliminating repetitive hard-coded strings literals in the HTTP code. Compile-time values (in a new file, http.h) are provided for commonly used HTTP status codes, headers and content-types. Misuse of them will result in build time errors instead of difficult to diagnose runtime failures.