### PR TITLE
New usermod: Support for RGB Rotary Encoder Board

### DIFF
--- a/usermods/rgb-rotary-encoder/readme.md
+++ b/usermods/rgb-rotary-encoder/readme.md
@@ -18,18 +18,18 @@ ESP32:
 ```
 [env:custom_esp32dev_usermod_rgb_encoder_board]
 extends = env:esp32dev
-build_flags = ${common.build_flags_esp32} -D RGB_ROTARY_ENCODER
-lib_deps = ${env.lib_deps}
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 -D RGB_ROTARY_ENCODER
+lib_deps = ${esp32.lib_deps}
     lennarthennigs/ESP Rotary@^1.5.0
 ```
 
 ESP8266 / D1 Mini:
 ```
-[env:custom_d1_mini_usermod_dallas_temperature_C_multi_relay]
+[env:custom_d1_mini_usermod_rgb_encoder_board]
 extends = env:d1_mini
 build_flags = ${common.build_flags_esp8266} -D RGB_ROTARY_ENCODER
-lib_deps = ${env.lib_deps}
-    lennarthennigs/ESP Rotary@^1.5.0    
+lib_deps = ${esp8266.lib_deps}
+    lennarthennigs/ESP Rotary@^1.5.0
 ```
 
 ## How to connect the board to your ESP

--- a/usermods/rgb-rotary-encoder/readme.md
+++ b/usermods/rgb-rotary-encoder/readme.md
@@ -2,6 +2,8 @@
 
 This usermod-v2 adds support for the awesome RGB Rotary Encoder Board by Adam Zeloof / "Isotope Engineering" to control the overall brightness of your WLED instance: https://github.com/isotope-engineering/RGB-Encoder-Board. A great DIY rotary encoder with 20 tiny SK6805 / "NeoPixel Nano" LEDs.
 
+https://user-images.githubusercontent.com/3090131/124680599-0180ab80-dec7-11eb-9065-a6d08ebe0287.mp4
+
 ## Credits
 The actual / original code that does the different LED modes is from Adam Zeloof. So I don't take credit for these. But I ported it to WLED, which involved replacing the LED library he used (because, guess what, WLED already has one; so no need to add another one, but use whatever WLED uses), plus the rotary encoder library, because that one was not compatible with ESP, only Arduino.
 So it was quite more work than I hoped, but I got there eventually :)

--- a/usermods/rgb-rotary-encoder/readme.md
+++ b/usermods/rgb-rotary-encoder/readme.md
@@ -1,0 +1,84 @@
+# RGB Encoder Board
+
+This usermod-v2 adds support for the awesome RGB Rotary Encoder Board by Adam Zeloof / "Isotope Engineering" to control the overall brightness of your WLED instance: https://github.com/isotope-engineering/RGB-Encoder-Board. A great DIY rotary encoder with 20 tiny SK6805 / "NeoPixel Nano" LEDs.
+
+## Credits
+The actual / original code that does the different LED modes is from Adam Zeloof. So I don't take credit for these. But I ported it to WLED, which involved replacing the LED library he used (because, guess what, WLED already has one; so no need to add another one, but use whatever WLED uses), plus the rotary encoder library, because that one was not compatible with ESP, only Arduino.
+So it was quite more work than I hoped, but I got there eventually :)
+
+## Requirements
+* "ESP Rotary" by Lennart Hennigs, v1.5.0 or higher: https://github.com/LennartHennigs/ESPRotary
+
+## Usermod installation
+Simply copy the below block (build task) to your `platformio_override.ini` and compile WLED using this new build task. Or use an existing one and add the buildflag `-D RGB_ROTARY_ENCODER`.
+
+ESP32:
+```
+[env:custom_esp32dev_usermod_rgb_encoder_board]
+extends = env:esp32dev
+build_flags = ${common.build_flags_esp32} -D RGB_ROTARY_ENCODER
+lib_deps = ${env.lib_deps}
+    lennarthennigs/ESP Rotary@^1.5.0
+```
+
+ESP8266 / D1 Mini:
+```
+[env:custom_d1_mini_usermod_dallas_temperature_C_multi_relay]
+extends = env:d1_mini
+build_flags = ${common.build_flags_esp8266} -D RGB_ROTARY_ENCODER
+lib_deps = ${env.lib_deps}
+    lennarthennigs/ESP Rotary@^1.5.0    
+```
+
+## How to connect the board to your ESP
+We gonna need (minimum) three or (maximum) four GPIOs for the board:
+* "ea": Basically tells if the encoder goes into one or the other direction
+* "eb": Same thing, but the other direction
+* "di": LED data in. To actually control the LEDs
+* *(optional)* "sw": The integrated switch in the rotary encoder. Can be omitted for the bare functionality of just controlling the brightness
+
+We also gonna need some power, so:
+
+* "vdd": Needs to be connected to **+5V**.
+* "gnd": Well, it's GND.
+
+You can freely pick the GPIOs, it doesn't matter. Those will be configured in the "Usermods" section in the WLED web panel:
+
+## Configuration
+Navigate to the "Config" and then to the "Usermods" section. If you compiled WLED with `-D RGB_ROTARY_ENCODER`, you will see the config for it there. The settings there are the GPIOs we mentioned before (*Note: The switch pin is not there, as this can just be configured the "normal" button on the "LED Preferences" page*), plus a few more:
+* LED pin:
+  * Possible values: Any valid and available GPIO
+  * Default: 3
+  * What it does: Pin to control the LED ring
+* ea pin:
+  * Possible values: Any valid and available GPIO
+  * Default: 15
+  * What it does: First of the two rotary encoder pins
+* eb pin:
+  * Possible values: Any valid and available GPIO
+  * Default: 32
+  * What it does: Second of the two rotary encoder pins
+* LED Mode:
+  * Possible values: 1-3
+  * Default: 3
+  * What it does: The usermod provides three different modes of how the LEDs can look like. Here's an example: https://github.com/isotope-engineering/RGB-Encoder-Board/blob/master/images/rgb-encoder-animations.gif
+    * Up left is "1"
+    * Up right is not supported / doesn't make sense for brightness control
+    * Bottom left is "2"
+    * Bottom right is "3"
+* LED Brightness:
+  * Possible values: 1-255
+  * Default: 64
+  * What it does: Brightness of the LED ring
+* Steps per click:
+  * Possible values: Any positive number
+  * Default: 4
+  * What it does: With each "click", a rotary encoder actually increments it's "steps". Most rotary encoder do four "steps" per "click". I know this sounds super weird, so just leave this the default value, unless your rotary encoder behaves weirdly, like with one click, it makes two LEDs light up, or you sometimes need two click for one LED. Then you should play around with this value or write a small sketch using the same "ESP Rotary" library and read out the steps it does.
+* Increment per click:
+  * Possible values: Any positive number
+  * Default: 5
+  * What it does: Most rotary encoder have 20 "clicks", so basically 20 positions. This value should be set to 100 / `number of clicks`
+
+## Change log
+2021-07
+* First implementation.

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -332,12 +332,12 @@ class RgbRotaryEncoderUsermod : public Usermod
 
 int RgbRotaryEncoderUsermod::currentPos = 5;
 // strings to reduce flash memory usage (used more than twice)
-const char RgbRotaryEncoderUsermod::_name[]              PROGMEM = "RGB Rotary Encoder";
+const char RgbRotaryEncoderUsermod::_name[]              PROGMEM = "RGB-Rotary-Encoder";
 const char RgbRotaryEncoderUsermod::_enabled[]           PROGMEM = "Enabled";
-const char RgbRotaryEncoderUsermod::_ledIo[]             PROGMEM = "LED pin";
-const char RgbRotaryEncoderUsermod::_eaIo[]              PROGMEM = "ea pin";
-const char RgbRotaryEncoderUsermod::_ebIo[]              PROGMEM = "eb pin";
-const char RgbRotaryEncoderUsermod::_ledMode[]           PROGMEM = "LED Mode";
-const char RgbRotaryEncoderUsermod::_ledBrightness[]     PROGMEM = "LED Brightness";
-const char RgbRotaryEncoderUsermod::_stepsPerClick[]     PROGMEM = "Steps per Click";
-const char RgbRotaryEncoderUsermod::_incrementPerClick[] PROGMEM = "Increment per Click";
+const char RgbRotaryEncoderUsermod::_ledIo[]             PROGMEM = "LED-pin";
+const char RgbRotaryEncoderUsermod::_eaIo[]              PROGMEM = "ea-pin";
+const char RgbRotaryEncoderUsermod::_ebIo[]              PROGMEM = "eb-pin";
+const char RgbRotaryEncoderUsermod::_ledMode[]           PROGMEM = "LED-Mode";
+const char RgbRotaryEncoderUsermod::_ledBrightness[]     PROGMEM = "LED-Brightness";
+const char RgbRotaryEncoderUsermod::_stepsPerClick[]     PROGMEM = "Steps-per-Click";
+const char RgbRotaryEncoderUsermod::_incrementPerClick[] PROGMEM = "Increment-per-Click";

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -116,7 +116,6 @@ class RgbRotaryEncoderUsermod : public Usermod
       if (ebIo != -1) {
         pinManager.deallocatePin(ebIo);
       }
-      ledIo = -1;
 
       delete rotaryEncoder;
       delete ledBus;
@@ -255,6 +254,7 @@ class RgbRotaryEncoderUsermod : public Usermod
         return false;
       }
 
+      bool oldEnabled = enabled;
       int8_t oldLedIo = ledIo;
       int8_t oldEaIo =  eaIo;
       int8_t oldEbIo =  ebIo;
@@ -263,7 +263,6 @@ class RgbRotaryEncoderUsermod : public Usermod
       byte oldIncrementPerClick = incrementPerClick;
       byte oldLedBrightness = ledBrightness;
 
-      // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
       getJsonValue(top[FPSTR(_enabled)], enabled);
       getJsonValue(top[FPSTR(_ledIo)], ledIo);
       getJsonValue(top[FPSTR(_eaIo)], eaIo);
@@ -274,8 +273,16 @@ class RgbRotaryEncoderUsermod : public Usermod
       ledBrightness = top[FPSTR(_ledBrightness)] > 0 && top[FPSTR(_ledBrightness)] <= 255 ? top[FPSTR(_ledBrightness)] : ledBrightness;
 
       if (!initDone) {
-        // first run: reading from cfg.json
-      } else {
+        // First run: reading from cfg.json
+        // Nothing to do here, will be all done in setup() 
+      }
+      // Mod was disabled, so run setup()
+      else if (enabled && enabled != oldEnabled) {
+        DEBUG_PRINTF("[%s] Usermod has been re-enabled\n", _name);
+        setup();
+      }
+      // Config has been changed, so adopt to changes
+      else {
         if (!enabled) {
           DEBUG_PRINTF("[%s] Usermod has been disabled\n", _name);
           cleanup();

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -116,6 +116,7 @@ class RgbRotaryEncoderUsermod : public Usermod
       if (ebIo != -1) {
         pinManager.deallocatePin(ebIo);
       }
+      ledIo = -1;
 
       delete rotaryEncoder;
       delete ledBus;
@@ -277,14 +278,7 @@ class RgbRotaryEncoderUsermod : public Usermod
       } else {
         if (!enabled) {
           DEBUG_PRINTF("[%s] Usermod has been disabled\n", _name);
-          delete ledBus;
-          ledIo = -1;
-
-          pinManager.deallocatePin(oldEaIo);
-          eaIo = -1;
-          pinManager.deallocatePin(oldEbIo);
-          ebIo = -1;
-          delete rotaryEncoder;
+          cleanup();
         }
         else {
           DEBUG_PRINTF("[%s] Usermod is enabled\n", _name);

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -263,12 +263,12 @@ class RgbRotaryEncoderUsermod : public Usermod
       uint8_t oldLedBrightness = ledBrightness;
 
       // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
-      getJsonValue(top[FPSTR(_enabled)], enabled, enabled);
-      getJsonValue(top[FPSTR(_ledIo)], ledIo, ledIo);
-      getJsonValue(top[FPSTR(_eaIo)], eaIo, eaIo);
-      getJsonValue(top[FPSTR(_ebIo)], ebIo, ebIo);
-      getJsonValue(top[FPSTR(_stepsPerClick)], stepsPerClick, stepsPerClick);
-      getJsonValue(top[FPSTR(_incrementPerClick)], incrementPerClick, incrementPerClick);
+      getJsonValue(top[FPSTR(_enabled)], enabled);
+      getJsonValue(top[FPSTR(_ledIo)], ledIo);
+      getJsonValue(top[FPSTR(_eaIo)], eaIo);
+      getJsonValue(top[FPSTR(_ebIo)], ebIo);
+      getJsonValue(top[FPSTR(_stepsPerClick)], stepsPerClick);
+      getJsonValue(top[FPSTR(_incrementPerClick)], incrementPerClick);
       ledMode = top[FPSTR(_ledMode)] > 0 && top[FPSTR(_ledMode)] < 4 ? top[FPSTR(_ledMode)] : ledMode;
       ledBrightness = top[FPSTR(_ledBrightness)] > 0 && top[FPSTR(_ledBrightness)] <= 255 ? top[FPSTR(_ledBrightness)] : ledBrightness;
 

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -20,18 +20,18 @@ class RgbRotaryEncoderUsermod : public Usermod
     int8_t ledIo = 3; // GPIO to control the LEDs
     int8_t eaIo = 15; // "ea" from RGB Encoder Board
     int8_t ebIo = 32; // "eb" from RGB Encoder Board
-    uint8_t stepsPerClick = 4; // How many "steps" your rotary encoder does per click. This varies per rotary encoder
+    byte stepsPerClick = 4; // How many "steps" your rotary encoder does per click. This varies per rotary encoder
     /* This could vary per rotary encoder: Usually rotary encoders have 20 "clicks".
       If yours has less/more, adjust this to: 100% = 20 LEDs * incrementPerClick */
-    uint8_t incrementPerClick = 5;
+    byte incrementPerClick = 5;
     byte ledMode = 3;
-    uint8_t ledBrightness = 64;
+    byte ledBrightness = 64;
 
     // This is all needed to calculate the brightness, rotary position, etc.
-    const int minPos = 5; // minPos is not zero, because if we want to turn the LEDs off, we use the built-in button ;)
-    const int maxPos = 100; // maxPos=100, like 100%
-    const int numLeds = 20;
-    int lastKnownPos = 0;
+    const byte minPos = 5; // minPos is not zero, because if we want to turn the LEDs off, we use the built-in button ;)
+    const byte maxPos = 100; // maxPos=100, like 100%
+    const byte numLeds = 20;
+    byte lastKnownPos = 0;
 
     byte currentColors[3];
     byte lastKnownBri = 0;
@@ -59,7 +59,7 @@ class RgbRotaryEncoderUsermod : public Usermod
 
     void initLedBus()
     {
-      uint8_t _pins[5] = {(uint8_t)ledIo, 255, 255, 255, 255};
+      byte _pins[5] = {(byte)ledIo, 255, 255, 255, 255};
       BusConfig busCfg = BusConfig(TYPE_WS2812_RGB, _pins, 0, numLeds, COL_ORDER_GRB, false, 0);
 
       ledBus = new BusDigital(busCfg, WLED_MAX_BUSSES - 1);
@@ -140,7 +140,7 @@ class RgbRotaryEncoderUsermod : public Usermod
     }
 
   public:
-    static int currentPos;
+    static byte currentPos;
 
     // strings to reduce flash memory usage (used more than twice)
     static const char _name[];
@@ -259,9 +259,9 @@ class RgbRotaryEncoderUsermod : public Usermod
       int8_t oldEaIo =  eaIo;
       int8_t oldEbIo =  ebIo;
       byte oldLedMode = ledMode;
-      uint8_t oldStepsPerClick = stepsPerClick;
-      uint8_t oldIncrementPerClick = incrementPerClick;
-      uint8_t oldLedBrightness = ledBrightness;
+      byte oldStepsPerClick = stepsPerClick;
+      byte oldIncrementPerClick = incrementPerClick;
+      byte oldLedBrightness = ledBrightness;
 
       // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
       getJsonValue(top[FPSTR(_enabled)], enabled);
@@ -324,7 +324,7 @@ class RgbRotaryEncoderUsermod : public Usermod
     //Your usermod will remain compatible as it does not need to implement all methods from the Usermod base class!
 };
 
-int RgbRotaryEncoderUsermod::currentPos = 5;
+byte RgbRotaryEncoderUsermod::currentPos = 5;
 // strings to reduce flash memory usage (used more than twice)
 const char RgbRotaryEncoderUsermod::_name[]              PROGMEM = "RGB-Rotary-Encoder";
 const char RgbRotaryEncoderUsermod::_enabled[]           PROGMEM = "Enabled";

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -1,0 +1,343 @@
+#pragma once
+
+#include "ESPRotary.h"
+#include <math.h>
+#include "wled.h"
+
+class RgbRotaryEncoderUsermod : public Usermod
+{
+  private:
+    bool enabled = false;
+    bool initDone = false;
+    bool isDirty = false;
+    BusDigital *ledBus;
+    /*
+    * Green - eb - Q4 - 32
+    * Red - ea - Q1 - 15
+    * Black - sw - Q2 - 12
+    */
+    ESPRotary *rotaryEncoder;
+    int8_t ledIo = 3; // GPIO to control the LEDs
+    int8_t eaIo = 15; // "ea" from RGB Encoder Board
+    int8_t ebIo = 32; // "eb" from RGB Encoder Board
+    uint8_t stepsPerClick = 4; // How many "steps" your rotary encoder does per click. This varies per rotary encoder
+    /* This could vary per rotary encoder: Usually rotary encoders have 20 "clicks".
+      If yours has less/more, adjust this to: 100% = 20 LEDs * incrementPerClick */
+    uint8_t incrementPerClick = 5;
+    byte ledMode = 3;
+    uint8_t ledBrightness = 64;
+
+    // This is all needed to calculate the brightness, rotary position, etc.
+    const int minPos = 5; // minPos is not zero, because if we want to turn the LEDs off, we use the built-in button ;)
+    const int maxPos = 100; // maxPos=100, like 100%
+    const int numLeds = 20;
+    int lastKnownPos = 0;
+
+    byte currentColors[3];
+    byte lastKnownBri = 0;
+
+
+    void initRotaryEncoder()
+    {
+      if (!pinManager.allocatePin(eaIo, false)) {
+        eaIo = -1;
+      }
+      if (!pinManager.allocatePin(ebIo, false)) {
+        ebIo = -1;
+      }
+      if (eaIo == -1 || ebIo == -1) {
+        cleanup();
+        return;
+      }
+
+      // I don't know why, but setting the upper bound here does not work. It results into 1717922932 O_o
+      rotaryEncoder = new ESPRotary(eaIo, ebIo, stepsPerClick, incrementPerClick, maxPos, currentPos, incrementPerClick);
+      rotaryEncoder->setUpperBound(maxPos); // I have to again set it here and then it works / is actually 100...
+
+      rotaryEncoder->setChangedHandler(RgbRotaryEncoderUsermod::cbRotate);
+    }
+
+    void initLedBus()
+    {
+      uint8_t _pins[5] = {(uint8_t)ledIo, 255, 255, 255, 255};
+      BusConfig busCfg = BusConfig(TYPE_WS2812_RGB, _pins, 0, numLeds, COL_ORDER_GRB, false, 0);
+
+      ledBus = new BusDigital(busCfg, WLED_MAX_BUSSES - 1);
+      if (!ledBus->isOk()) {
+        cleanup();
+        return;
+      }
+
+      ledBus->setBrightness(ledBrightness);
+    }
+
+    void updateLeds()
+    {
+      switch (ledMode) {
+        case 2:
+          {
+            currentColors[0] = 255; currentColors[1] = 0; currentColors[2] = 0;
+            for (int i = 0; i < currentPos / incrementPerClick - 1; i++) {
+              ledBus->setPixelColor(i, 0);
+            }
+            ledBus->setPixelColor(currentPos / incrementPerClick - 1, colorFromRgbw(currentColors));
+            for (int i = currentPos / incrementPerClick; i < numLeds; i++) {
+              ledBus->setPixelColor(i, 0);
+            }
+          }
+          break;
+
+        default:
+        case 1:
+        case 3:
+          // WLED orange (of course), which we will use in mode 1
+          currentColors[0] = 255; currentColors[1] = 160; currentColors[2] = 0;
+          for (int i = 0; i < currentPos / incrementPerClick; i++) {
+            if (ledMode == 3) {
+              hsv2rgb((i) / float(numLeds), 1, .25);
+            }
+            ledBus->setPixelColor(i, colorFromRgbw(currentColors));
+          }
+          for (int i = currentPos / incrementPerClick; i < numLeds; i++) {
+            ledBus->setPixelColor(i, 0);
+          }
+          break;
+      }
+
+      isDirty = true;
+    }
+
+    void cleanup()
+    {
+      // Only deallocate pins if we allocated them ;)
+      if (eaIo != -1) {
+        pinManager.deallocatePin(eaIo);
+      }
+      if (ebIo != -1) {
+        pinManager.deallocatePin(ebIo);
+      }
+
+      delete rotaryEncoder;
+      delete ledBus;
+
+      enabled = false;
+    }
+
+    int getPositionForBrightness()
+    {
+      return int(((float)bri / (float)255) * 100);
+    }
+
+    float fract(float x) { return x - int(x); }
+
+    float mix(float a, float b, float t) { return a + (b - a) * t; }
+
+    void hsv2rgb(float h, float s, float v) {
+      currentColors[0] = int((v * mix(1.0, constrain(abs(fract(h + 1.0) * 6.0 - 3.0) - 1.0, 0.0, 1.0), s)) * 255);
+      currentColors[1] = int((v * mix(1.0, constrain(abs(fract(h + 0.6666666) * 6.0 - 3.0) - 1.0, 0.0, 1.0), s)) * 255);
+      currentColors[2] = int((v * mix(1.0, constrain(abs(fract(h + 0.3333333) * 6.0 - 3.0) - 1.0, 0.0, 1.0), s)) * 255);
+    }
+
+  public:
+    static int currentPos;
+
+    // strings to reduce flash memory usage (used more than twice)
+    static const char _name[];
+    static const char _enabled[];
+    static const char _ledIo[];
+    static const char _eaIo[];
+    static const char _ebIo[];
+    static const char _ledMode[];
+    static const char _ledBrightness[];
+    static const char _stepsPerClick[];
+    static const char _incrementPerClick[];
+
+
+    static void cbRotate(ESPRotary& r) {
+      currentPos = r.getPosition();
+    }
+
+    /**
+     * Enable/Disable the usermod
+     */
+    // inline void enable(bool enable) { enabled = enable; }
+    /**
+     * Get usermod enabled/disabled state
+     */
+    // inline bool isEnabled() { return enabled; }
+
+    /*
+      * setup() is called once at boot. WiFi is not yet connected at this point.
+      * You can use it to initialize variables, sensors or similar.
+      */
+    void setup()
+    {
+      if (enabled) {
+        currentPos = getPositionForBrightness();
+        lastKnownBri = bri;
+
+        initRotaryEncoder();
+        initLedBus();
+
+        // No updating of LEDs here, as that's sometimes not working; loop() will take care of that
+
+        initDone = true;
+      }
+    }
+
+    /*
+      * loop() is called continuously. Here you can check for events, read sensors, etc.
+      * 
+      * Tips:
+      * 1. You can use "if (WLED_CONNECTED)" to check for a successful network connection.
+      *    Additionally, "if (WLED_MQTT_CONNECTED)" is available to check for a connection to an MQTT broker.
+      * 
+      * 2. Try to avoid using the delay() function. NEVER use delays longer than 10 milliseconds.
+      *    Instead, use a timer check as shown here.
+      */
+    void loop()
+    {
+      if (!enabled || strip.isUpdating()) return;
+
+      rotaryEncoder->loop();
+
+      // If the rotary was changed
+      if(lastKnownPos != currentPos) {
+        lastKnownPos = currentPos;
+
+        bri = min(int(round((2.55 * currentPos))), 255);
+        lastKnownBri = bri;
+
+        updateLeds();
+        colorUpdated(NOTIFIER_CALL_MODE_DIRECT_CHANGE);
+      }
+
+      // If the brightness is changed not with the rotary, update the rotary
+      if (bri != lastKnownBri) {
+        currentPos = lastKnownPos = getPositionForBrightness();
+        lastKnownBri = bri;
+        rotaryEncoder->resetPosition(currentPos);
+        updateLeds();
+      }
+
+      // Update LEDs here in loop to also validate that we can update/show
+      if (isDirty && ledBus->canShow()) {
+        isDirty = false;
+        ledBus->show();
+      }
+    }
+
+    void addToConfig(JsonObject &root)
+    {
+      JsonObject top = root.createNestedObject(FPSTR(_name)); // usermodname
+
+      top[FPSTR(_enabled)] = enabled;
+      top[FPSTR(_ledIo)] = ledIo;
+      top[FPSTR(_eaIo)] = eaIo;
+      top[FPSTR(_ebIo)] = ebIo;
+      top[FPSTR(_ledMode)] = ledMode;
+      top[FPSTR(_ledBrightness)] = ledBrightness;
+      top[FPSTR(_stepsPerClick)] = stepsPerClick;
+      top[FPSTR(_incrementPerClick)] = incrementPerClick;
+    }
+
+    /**
+     * readFromConfig() is called before setup() to populate properties from values stored in cfg.json
+     *
+     * The function should return true if configuration was successfully loaded or false if there was no configuration.
+     */
+    bool readFromConfig(JsonObject &root)
+    {
+      JsonObject top = root[FPSTR(_name)];
+      if (top.isNull()) {
+        DEBUG_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
+        return false;
+      }
+
+      int8_t oldLedIo = ledIo;
+      int8_t oldEaIo =  eaIo;
+      int8_t oldEbIo =  ebIo;
+      byte oldLedMode = ledMode;
+      uint8_t oldStepsPerClick = stepsPerClick;
+      uint8_t oldIncrementPerClick = incrementPerClick;
+      uint8_t oldLedBrightness = ledBrightness;
+
+      // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
+      getJsonValue(top[FPSTR(_enabled)], enabled, enabled);
+      getJsonValue(top[FPSTR(_ledIo)], ledIo, ledIo);
+      getJsonValue(top[FPSTR(_eaIo)], eaIo, eaIo);
+      getJsonValue(top[FPSTR(_ebIo)], ebIo, ebIo);
+      getJsonValue(top[FPSTR(_stepsPerClick)], stepsPerClick, stepsPerClick);
+      getJsonValue(top[FPSTR(_incrementPerClick)], incrementPerClick, incrementPerClick);
+      ledMode = top[FPSTR(_ledMode)] > 0 && top[FPSTR(_ledMode)] < 4 ? top[FPSTR(_ledMode)] : ledMode;
+      ledBrightness = top[FPSTR(_ledBrightness)] > 0 && top[FPSTR(_ledBrightness)] <= 255 ? top[FPSTR(_ledBrightness)] : ledBrightness;
+
+      if (!initDone) {
+        // first run: reading from cfg.json
+      } else {
+        if (!enabled) {
+          DEBUG_PRINTF("[%s] Usermod has been disabled\n", _name);
+          delete ledBus;
+          ledIo = -1;
+
+          pinManager.deallocatePin(oldEaIo);
+          eaIo = -1;
+          pinManager.deallocatePin(oldEbIo);
+          ebIo = -1;
+          delete rotaryEncoder;
+        }
+        else {
+          DEBUG_PRINTF("[%s] Usermod is enabled\n", _name);
+          if (ledIo != oldLedIo) {
+            delete ledBus;
+            initLedBus();
+          }
+
+          if (ledBrightness != oldLedBrightness) {
+            ledBus->setBrightness(ledBrightness);
+            isDirty = true;
+          }
+
+          if (ledMode != oldLedMode) {
+            updateLeds();
+          }
+
+          if (eaIo != oldEaIo || ebIo != oldEbIo || stepsPerClick != oldStepsPerClick || incrementPerClick != oldIncrementPerClick) {
+            pinManager.deallocatePin(oldEaIo);
+            pinManager.deallocatePin(oldEbIo);
+            
+            delete rotaryEncoder;
+            initRotaryEncoder();
+          }
+        }
+
+        DEBUG_PRINTF("[%s] Config (re)loaded\n", _name);
+      }
+      
+      return true;
+    }
+
+    /*
+      * getId() allows you to optionally give your V2 usermod an unique ID (please define it in const.h!).
+      * This could be used in the future for the system to determine whether your usermod is installed.
+      */
+    uint16_t getId()
+    {
+      return 0x4711;
+    }
+
+    //More methods can be added in the future, this example will then be extended.
+    //Your usermod will remain compatible as it does not need to implement all methods from the Usermod base class!
+};
+
+int RgbRotaryEncoderUsermod::currentPos = 5;
+// strings to reduce flash memory usage (used more than twice)
+const char RgbRotaryEncoderUsermod::_name[]              PROGMEM = "RGB Rotary Encoder";
+const char RgbRotaryEncoderUsermod::_enabled[]           PROGMEM = "Enabled";
+const char RgbRotaryEncoderUsermod::_ledIo[]             PROGMEM = "LED pin";
+const char RgbRotaryEncoderUsermod::_eaIo[]              PROGMEM = "ea pin";
+const char RgbRotaryEncoderUsermod::_ebIo[]              PROGMEM = "eb pin";
+const char RgbRotaryEncoderUsermod::_ledMode[]           PROGMEM = "LED Mode";
+const char RgbRotaryEncoderUsermod::_ledBrightness[]     PROGMEM = "LED Brightness";
+const char RgbRotaryEncoderUsermod::_stepsPerClick[]     PROGMEM = "Steps per Click";
+const char RgbRotaryEncoderUsermod::_incrementPerClick[] PROGMEM = "Increment per Click";

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -78,6 +78,10 @@
 #include "../usermods/usermod_rotary_brightness_color/usermod_rotary_brightness_color.h"
 #endif
 
+#ifdef RGB_ROTARY_ENCODER
+#include "../usermods/rgb-rotary-encoder/rgb-rotary-encoder.h"
+#endif
+
 void registerUsermods()
 {
 /*
@@ -150,5 +154,9 @@ void registerUsermods()
 
   #ifdef USERMOD_ROTARY_ENCODER_BRIGHTNESS_COLOR
   usermods.add(new RotaryEncoderBrightnessColor());
+  #endif
+
+  #ifdef RGB_ROTARY_ENCODER
+  usermods.add(new RgbRotaryEncoderUsermod());
   #endif
 }


### PR DESCRIPTION
Hey there,

I've spent the last days creating my first usermod :) And guess what: **It's another rotary encoder usermod!!** ;) But not a usual one: This mod is for this awesome DIY LED rotary encoder board from Adam Zeloof: https://github.com/isotope-engineering/RGB-Encoder-Board:

https://user-images.githubusercontent.com/3090131/124680599-0180ab80-dec7-11eb-9065-a6d08ebe0287.mp4

So this little PCB has 20 LEDs on it and what my usermod essentially does is:
- It will always reflect the current brightness in basically percentage on the board using the LEDs :) It will of course also update if the brightness is updated from anywhere except the rotary encoder (Web UI, app, API, MQTT...).
- It features three different modes:
  - An awesome rainbow color circle (mode 3)
  - Just a single red LED going around (mode 2)
  - Or like mode 3 but just a single color (obviously I went with WLED orange!)
- Everything can be configured from the WLED Web UI Usermod settings page, incl. pins, brightness, mode, etc...

There's only one known issue which I just can't get fixed:
Sometimes there seems to be a race condition on startup of WLED, where the LED ring will not be updated. I already tried listening to "canShow" of the LED Bus and make sure to update in the loop() and not in setup()... But it's really not happening often and only on boot. And it fixes itself by just making an update, like turning the knob, change the brightness in the web UI, change the settings, ...

Of course, I'm seeking for feedback here but especially around this:

I made use of the `BusDigital` class to control the LEDs. I tried to not mess with the configured outputs / hardware in the LED Preferences, so I went for using the "last" available LED bus possible, using `WLED_MAX_BUSSES` to detect that. It's the first time I'm messing with LEDs in WLED, so I hope I didn't do sth wrong and mess with something somehow. I tested effects, solid colors, changing outputs... All seem to still work fine.
I also decided against using the BusManager, as this would make these 20 LEDs/the board show up under the hardware section, count towards the total LEDs, will be controlled by WLED/effects, users can mess around with the config there, etc. etc. So I thoight that is not the right way to to, but to simply create an instance of the DigitalBus class.

Yeah, hope this can get merge some day soon and happy for your feedback :)

Greetings,

Andy!