### PR TITLE
Fix ethernet pin allocation defaults, simplify pinManager usage

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -292,7 +292,7 @@ board = esp32-poe
 platform = espressif32@2.0
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1 -D LEDPIN=4
 lib_deps = ${esp32.lib_deps}
 
 [env:esp32s2_saola]

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -119,10 +119,10 @@ class BusDigital : public Bus {
   public:
   BusDigital(BusConfig &bc, uint8_t nr) : Bus(bc.type, bc.start) {
     if (!IS_DIGITAL(bc.type) || !bc.count) return;
-    if (!pinManager.allocatePin(bc.pins[0])) return;
+    if (!ALLOCATE_PIN(bc.pins[0], true)) return;
     _pins[0] = bc.pins[0];
     if (IS_2PIN(bc.type)) {
-      if (!pinManager.allocatePin(bc.pins[1])) {
+      if (!ALLOCATE_PIN(bc.pins[1], true)) {
         cleanup(); return;
       }
       _pins[1] = bc.pins[1];
@@ -242,7 +242,7 @@ class BusPwm : public Bus {
 
     for (uint8_t i = 0; i < numPins; i++) {
       uint8_t currentPin = bc.pins[i];
-      if (!pinManager.allocatePin(currentPin)) {
+      if (!ALLOCATE_PIN(currentPin, true)) {
         deallocatePins(); return;
       }
       _pins[i] = currentPin; // store only after allocatePin() succeeds

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -130,7 +130,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     for (JsonObject btn : hw_btn_ins) {
       CJSON(buttonType[s], btn["type"]);
       int8_t pin = btn["pin"][0] | -1;
-      if (pin > -1 && pinManager.allocatePin(pin,false)) {
+      if (pin > -1 && ALLOCATE_PIN(pin,false)) {
         btnPin[s] = pin;
         pinMode(btnPin[s], INPUT_PULLUP);
       } else {
@@ -155,7 +155,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     if (fromFS) {
       // relies upon only being called once with fromFS == true, which is currently true.
       uint8_t s = 0;
-      if (pinManager.allocatePin(btnPin[0],false)) { // initialized to #define value BTNPIN, or zero if not defined(!)
+      if (ALLOCATE_PIN(btnPin[0],false)) { // initialized to #define value BTNPIN, or zero if not defined(!)
         ++s; // do not clear default button if allocated successfully 
       }
       for (; s<WLED_MAX_BUTTONS; s++) {
@@ -172,7 +172,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   int hw_ir_pin = hw["ir"]["pin"] | -2; // 4
   if (hw_ir_pin > -2) {
-    if (pinManager.allocatePin(hw_ir_pin,false)) {
+    if (ALLOCATE_PIN(hw_ir_pin,false)) {
       irPin = hw_ir_pin;
     } else {
       irPin = -1;
@@ -183,7 +183,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   JsonObject relay = hw[F("relay")];
   int hw_relay_pin = relay["pin"] | -2;
   if (hw_relay_pin > -2) {
-    if (pinManager.allocatePin(hw_relay_pin,true)) {
+    if (ALLOCATE_PIN(hw_relay_pin,true)) {
       rlyPin = hw_relay_pin;
       pinMode(rlyPin, OUTPUT);
     } else {

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -289,6 +289,8 @@
 #ifndef LEDPIN
 #ifdef ESP8266
   #define LEDPIN 2    // GPIO2 (D4) on Wemod D1 mini compatible boards
+#elif defined(WLED_USE_ETHERNET)
+  #define LEDPIN 32   // Avoids conflict with ethernet pins on all currently supported boards
 #else
   #define LEDPIN 16   // alligns with GPIO2 (D4) on Wemos D1 mini32 compatible boards
 #endif

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -359,7 +359,7 @@ void _drawOverlayCronixie()
 }
 
 #else // WLED_DISABLE_CRONIXIE
-byte getSameCodeLength(char code, int index, char const cronixieDisplay[]) {}
+byte getSameCodeLength(char code, int index, char const cronixieDisplay[]) { return 0; }
 void setCronixie() {}
 void _overlayCronixie() {}
 void _drawOverlayCronixie() {}

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -1,7 +1,7 @@
 #include "pin_manager.h"
 #include "wled.h"
 
-bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount)
+bool PinManagerClass::_allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount)
 {
   // first verify the pins are OK and not already allocated
   for (int i = 0; i < arrayElementCount; i++) {
@@ -41,7 +41,37 @@ void PinManagerClass::deallocatePin(byte gpio)
   bitWrite(pinAlloc[by], bi, false);
 }
 
-bool PinManagerClass::allocatePin(byte gpio, bool output)
+bool PinManagerClass::_allocatePinDebug(byte gpio, bool output, char const * file, int line)
+{
+  if (_allocatePin(gpio, output)) {
+    DEBUG_PRINT(F("PIN ALLOC: IO")); DEBUG_PRINT(gpio);
+    DEBUG_PRINT(F(" allocated from file ")); DEBUG_PRINT(file);
+    DEBUG_PRINT(F(" at line ")); DEBUG_PRINTLN(line);
+    return true;
+  } else {
+    return false;
+  }
+}
+bool PinManagerClass::_allocateMultiplePinsDebug(const managed_pin_type * mptArray, byte arrayElementCount, char const * file, int line)
+{
+  if (_allocateMultiplePins(mptArray, arrayElementCount)) {
+    DEBUG_PRINT(F("PIN ALLOC: Multiple IOs allocated from file ")); DEBUG_PRINT(file);
+    DEBUG_PRINT(F(" at line ")); DEBUG_PRINTLN(line);
+    DEBUG_PRINT(F("           "));
+    for (int i = 0; i < arrayElementCount; i++) {
+      if (i>0) { DEBUG_PRINT(F(", ")); }
+      DEBUG_PRINT(mptArray[i].pin);
+    }
+    DEBUG_PRINTLN();
+    return true;
+  } else {
+    return false;
+  }
+
+}
+
+
+bool PinManagerClass::_allocatePin(byte gpio, bool output)
 {
   if (!isPinOk(gpio, output)) return false;
   if (isPinAllocated(gpio)) {

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -1,6 +1,37 @@
 #include "pin_manager.h"
 #include "wled.h"
 
+bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount)
+{
+  // first verify the pins are OK and not already allocated
+  for (int i = 0; i < arrayElementCount; i++) {
+    if (mptArray[i].pin == 0xFF) {
+      // allow callers to include -1 value as non-requested pin
+      // as this can greatly simplify configuration arrays
+      continue;
+    }
+    if (!isPinOk(mptArray[i].pin, mptArray[i].isOutput)) {
+      return false;
+    }
+    if (isPinAllocated(mptArray[i].pin)) {
+      return false;
+    }
+  }
+
+  // all pins are available .. track each one
+  for (int i = 0; i < arrayElementCount; i++) {
+    if (mptArray[i].pin == 0xFF) {
+      // allow callers to include -1 value as non-requested pin
+      // as this can greatly simplify configuration arrays
+      continue;
+    }
+    byte by = mptArray[i].pin >> 3;
+    byte bi = mptArray[i].pin - 8*by;
+    bitWrite(pinAlloc[by], bi, true);
+  }
+  return true;
+}
+
 void PinManagerClass::deallocatePin(byte gpio)
 {
   if (!isPinOk(gpio, false)) return;

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -5,6 +5,11 @@
  */
 #include <Arduino.h>
 
+typedef struct PinManagerPinType {
+  byte pin;
+  byte isOutput;
+} managed_pin_type;
+
 class PinManagerClass {
   private:
   #ifdef ESP8266
@@ -23,6 +28,22 @@ class PinManagerClass {
   byte allocateLedc(byte channels);
   void deallocateLedc(byte pos, byte channels);
   #endif
+  inline void PinManagerClass::deallocatePin(managed_pin_type mpt)
+  {
+    deallocatePin(mpt.pin);
+  }
+  inline bool PinManagerClass::allocatePin(managed_pin_type mpt)
+  {
+    return allocatePin(mpt.pin, mpt.isOutput);
+  }
+  inline bool PinManagerClass::isPinAllocated(managed_pin_type mpt)
+  {
+    return isPinAllocated(mpt.pin);
+  }
+  inline bool PinManagerClass::isPinOk(managed_pin_type mpt)
+  {
+    return isPinOk(mpt.pin);
+  }
 };
 
 extern PinManagerClass pinManager;

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -28,6 +28,7 @@ class PinManagerClass {
   byte allocateLedc(byte channels);
   void deallocateLedc(byte pos, byte channels);
   #endif
+  bool allocateMultiplePins(const managed_pin_type * mpt, byte arrayElementCount);
   inline void deallocatePin(managed_pin_type mpt)
   {
     deallocatePin(mpt.pin);

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -28,6 +28,10 @@ class PinManagerClass {
   byte allocateLedc(byte channels);
   void deallocateLedc(byte pos, byte channels);
   #endif
+  // Allocates all pins, or none of the pins, in the array
+  // This should simplify error condition handling in clients
+  // that need more than one pin to work correctly, such as
+  // ethernet, rotary encoders, and the like.
   bool allocateMultiplePins(const managed_pin_type * mpt, byte arrayElementCount);
   inline void deallocatePin(managed_pin_type mpt)
   {

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -28,19 +28,19 @@ class PinManagerClass {
   byte allocateLedc(byte channels);
   void deallocateLedc(byte pos, byte channels);
   #endif
-  inline void PinManagerClass::deallocatePin(managed_pin_type mpt)
+  inline void deallocatePin(managed_pin_type mpt)
   {
     deallocatePin(mpt.pin);
   }
-  inline bool PinManagerClass::allocatePin(managed_pin_type mpt)
+  inline bool allocatePin(managed_pin_type mpt)
   {
     return allocatePin(mpt.pin, mpt.isOutput);
   }
-  inline bool PinManagerClass::isPinAllocated(managed_pin_type mpt)
+  inline bool isPinAllocated(managed_pin_type mpt)
   {
     return isPinAllocated(mpt.pin);
   }
-  inline bool PinManagerClass::isPinOk(managed_pin_type mpt)
+  inline bool isPinOk(managed_pin_type mpt)
   {
     return isPinOk(mpt.pin);
   }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -127,7 +127,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 
     // upate other pins
     int hw_ir_pin = request->arg(F("IR")).toInt();
-    if (pinManager.allocatePin(hw_ir_pin,false)) {
+    if (ALLOCATE_PIN(hw_ir_pin,false)) {
       irPin = hw_ir_pin;
     } else {
       irPin = -1;
@@ -135,7 +135,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     irEnabled = request->arg(F("IT")).toInt();
 
     int hw_rly_pin = request->arg(F("RL")).toInt();
-    if (pinManager.allocatePin(hw_rly_pin,true)) {
+    if (ALLOCATE_PIN(hw_rly_pin,true)) {
       rlyPin = hw_rly_pin;
     } else {
       rlyPin = -1;
@@ -146,7 +146,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       char bt[4] = "BT"; bt[2] = 48+i; bt[3] = 0; // button pin
       char be[4] = "BE"; be[2] = 48+i; be[3] = 0; // button type
       int hw_btn_pin = request->arg(bt).toInt();
-      if (pinManager.allocatePin(hw_btn_pin,false)) {
+      if (ALLOCATE_PIN(hw_btn_pin,false)) {
         btnPin[i] = hw_btn_pin;
         pinMode(btnPin[i], INPUT_PULLUP);
         buttonType[i] = request->arg(be).toInt();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -447,20 +447,6 @@ void WLED::initConnection()
   if (ethernetType != WLED_ETH_NONE && ethernetType < WLED_NUM_ETH_TYPES) {
     ethernet_settings es = ethernetBoards[ethernetType];
 
-    // actual array of pins is larger than those listed in ethernet_settings:
-    typedef struct Esp32EthernetPinDetail {
-      byte pin;
-      byte isOutput;
-    } esp32_ethernet_pin_detail;
-    const esp32_ethernet_pin_detail constantPinsForESP32[6] = {
-      { 21, true  }, // Constant for ESP32, RMII_EMAC_TX_EN
-      { 19, true  }, // Constant for ESP32, RMII_EMAC_TXD0
-      { 22, true  }, // Constant for ESP32, RMII_EMAC_TXD1
-      { 25, false }, // Constant for ESP32, RMII_EMAC_RXD0
-      { 26, false }, // Constant for ESP32, RMII_EMAC_RXD1
-      { 27, true  }, // Constant for ESP32, RMII_EMAC_CRS_DV
-    };
-
     // Use PinManager to ensure pins are available for
     // ethernet AND to prevent other uses of these pins.
     bool s = true;
@@ -470,9 +456,9 @@ void WLED::initConnection()
     byte pinsAllocated[12] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 };
 
     // First ensure the non-configurable pins can be reserved...
-    for (esp32_ethernet_pin_detail details : constantPinsForESP32) {
-      if (s && (s = pinManager.allocatePin(details.pin, details.isOutput))) { 
-        pinsAllocated[idx] = 21;
+    for (managed_pin_type mpt : esp32_nonconfigurable_ethernet_pins) {
+      if (s && (s = pinManager.allocatePin(mpt))) { 
+        pinsAllocated[idx] = mpt.pin;
         idx++;
       }
     }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -452,7 +452,7 @@ void WLED::initConnection()
     bool s = true;
     int idx = 0;
     
-    // This must be large enough for both constant and configurable pins
+    // This must be large enough for both constant (6) and configurable (5) pins
     byte pinsAllocated[12] { 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 };
 
     // First ensure the non-configurable pins can be reserved...

--- a/wled00/wled_ethernet.h
+++ b/wled00/wled_ethernet.h
@@ -2,7 +2,25 @@
 #define WLED_ETHERNET_H
 
 #ifdef WLED_USE_ETHERNET
+#include "pin_manager.h"
 // settings for various ethernet boards
+// typedef struct PinManagerPinType {
+//   byte pin;
+//   byte isOutput;
+// } managed_pin_type;
+
+// The following pins are neither configurable nor
+// can they be re-assigned through IOMUX / GPIO matrix.
+// See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html#ip101gri-phy-interface
+const managed_pin_type esp32_nonconfigurable_ethernet_pins[6] = {
+    { 21, true  }, // RMII EMAC TX EN
+    { 19, true  }, // RMII EMAC TXD0
+    { 22, true  }, // RMII EMAC TXD1
+    { 25, false }, // RMII EMAC RXD0
+    { 26, false }, // RMII EMAC RXD1
+    { 27, true  }, // RMII EMAC CRS_DV
+};
+
 typedef struct EthernetSettings {
   uint8_t        eth_address;
   int            eth_power;
@@ -11,6 +29,9 @@ typedef struct EthernetSettings {
   eth_phy_type_t eth_type;
   eth_clock_mode_t eth_clk_mode;
 } ethernet_settings;
+
+
+
 
 ethernet_settings ethernetBoards[] = {
   // None

--- a/wled00/wled_ethernet.h
+++ b/wled00/wled_ethernet.h
@@ -4,18 +4,30 @@
 #ifdef WLED_USE_ETHERNET
 #include "pin_manager.h"
 
-// The following pins are neither configurable nor
+// The following six pins are neither configurable nor
 // can they be re-assigned through IOMUX / GPIO matrix.
 // See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html#ip101gri-phy-interface
 const managed_pin_type esp32_nonconfigurable_ethernet_pins[6] = {
-    { 21, true  }, // RMII EMAC TX EN
-    { 19, true  }, // RMII EMAC TXD0
-    { 22, true  }, // RMII EMAC TXD1
-    { 25, false }, // RMII EMAC RXD0
-    { 26, false }, // RMII EMAC RXD1
-    { 27, true  }, // RMII EMAC CRS_DV
+    { 21, true  }, // RMII EMAC TX EN  == When high, clocks the data on TXD0 and TXD1 to transmitter
+    { 19, true  }, // RMII EMAC TXD0   == First bit of transmitted data
+    { 22, true  }, // RMII EMAC TXD1   == Second bit of transmitted data
+    { 25, false }, // RMII EMAC RXD0   == First bit of received data
+    { 26, false }, // RMII EMAC RXD1   == Second bit of received data
+    { 27, true  }, // RMII EMAC CRS_DV == Carrier Sense and RX Data Valid
 };
 
+// For ESP32, the remaining five pins are at least somewhat configurable.
+// eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
+// eth_power    is an output GPIO pin used to enable/disable the ethernet port (and/or external oscillator)
+// eth_mdc      is an output GPIO pin used to provide the clock for the management data
+// eth_mdio     is an input/output GPIO pin used to transfer management data
+// eth_type     is the physical ethernet module's type (ETH_PHY_LAN8720, ETH_PHY_TLK110)
+// eth_clk_mode defines the GPIO pin and GPIO mode for the clock signal
+//              However, there are really only four configurable options on ESP32:
+//              ETH_CLOCK_GPIO0_IN    == External oscillator, clock input  via GPIO0
+//              ETH_CLOCK_GPIO0_OUT   == ESP32 provides 50MHz clock output via GPIO0
+//              ETH_CLOCK_GPIO16_OUT  == ESP32 provides 50MHz clock output via GPIO16
+//              ETH_CLOCK_GPIO17_OUT  == ESP32 provides 50MHz clock output via GPIO17
 typedef struct EthernetSettings {
   uint8_t        eth_address;
   int            eth_power;
@@ -25,27 +37,15 @@ typedef struct EthernetSettings {
   eth_clock_mode_t eth_clk_mode;
 } ethernet_settings;
 
-
-
-
 ethernet_settings ethernetBoards[] = {
   // None
   {
   },
   
   // WT32-EHT01
-  // Please note, from my testing only these pins work for LED outputs:
-  //   IO2, IO4, IO12, IO14, IO15
-  // Pins IO34 through IO39 are input-only on ESP32, so
-  // the following exposed pins won't work to drive WLEDs
-  //   IO35(*), IO36, IO39
-  // The following pins are also exposed via the headers,
-  // and likely can be used as general purpose IO:
-  //   IO05(*), IO32 (CFG), IO33 (485_EN), IO33 (TXD)
-  //
-  //   (*) silkscreen on board revision v1.2 may be wrong:
-  //       IO5 silkscreen on v1.2 says IO35
-  //       IO35 silkscreen on v1.2 says RXD
+  //   (*) NOTE: silkscreen on board revision v1.2 may be wrong:
+  //       silkscreen on v1.2 says IO35, but appears to be IO5
+  //       silkscreen on v1.2 says RXD,  and appears to be IO35
   {
     1,                 // eth_address, 
     16,                // eth_power, 

--- a/wled00/wled_ethernet.h
+++ b/wled00/wled_ethernet.h
@@ -3,11 +3,6 @@
 
 #ifdef WLED_USE_ETHERNET
 #include "pin_manager.h"
-// settings for various ethernet boards
-// typedef struct PinManagerPinType {
-//   byte pin;
-//   byte isOutput;
-// } managed_pin_type;
 
 // The following pins are neither configurable nor
 // can they be re-assigned through IOMUX / GPIO matrix.


### PR DESCRIPTION
This PR provides the following:
* significantly improved debuggability for pin allocations (in debug builds)
* Default LED pin update for esp32-eth builds (Pin 16 was used by ethernet on WT32-ETH01)
* PinManager functions to allocate multiple pins in an "all-or-nothing" form

The last greatly simplifies error handling logic for any code or user mod that needs more than one pin.  Example hardware that this would apply to includes rotary encoders, I2C, SPI, and of course ethernet.

This builds cleanly.  Ethernet was tested only on WT32-ETH01 boards.
