### PR TITLE
Allocated pin serialization

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -426,7 +426,7 @@ lib_deps = ${esp8266.lib_deps}
 extends = env:d1_mini
 build_type = debug
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} ${common.debug_flags} ${common.build_flags_all_features}
+build_flags = ${common.build_flags_esp8266} ${common.debug_flags} ${common.build_flags_all_features} -D LEDPIN=3
 
 [env:travis_esp32]
 extends = env:esp32dev

--- a/usermods/usermod_v2_four_line_display/usermod_v2_four_line_display.h
+++ b/usermods/usermod_v2_four_line_display/usermod_v2_four_line_display.h
@@ -169,8 +169,8 @@ class FourLineDisplayUsermod : public Usermod {
     void setup() {
       if (type == NONE) return;
       PinManagerPinType pins[5];
-      auto pinCount = (type == SSD1306_SPI || type == SSD1306_SPI64) ? 2 : 5;
-      for (auto i = 0; i < pinCount; i++) {
+      uint8_t pinCount = (type == SSD1306_SPI || type == SSD1306_SPI64) ? 2 : 5;
+      for (uint8_t i = 0; i < pinCount; i++) {
         pins[i].pin = ioPin[i];
         pins[i].isOutput = true;
       }

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -728,6 +728,12 @@ void serializeConfig() {
     dmx_fixmap.add(DMXFixtureMap[i]);
   #endif
 
+  JsonArray pinOwners = doc.createNestedArray("pinowners");
+  for (byte pin = 0; pin < TOTAL_GPIO_COUNT; pin++) {
+    PinOwner tag = pinManager.currentPinOwner(pin);
+    pinOwners.add(tag);
+  }
+
   JsonObject usermods_settings = doc.createNestedObject("um");
   usermods.addToConfig(usermods_settings);
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -39,6 +39,16 @@
   #endif
 #endif
 
+#if defined(ARDUINO_ARCH_ESP32S2) // also defines ARDUINO_ARCH_ESP32, so check this first
+#define TOTAL_GPIO_COUNT 40
+#elif defined(ARDUINO_ARCH_ESP32) // also defines ARDUINO_ARCH_ESP32, so check this first
+#define TOTAL_GPIO_COUNT 40
+#elif defined(ESP8266)
+#define TOTAL_GPIO_COUNT 17
+#else
+#error "Must define TOTAL_GPIO_COUNT for platform in const.h"
+#endif
+
 //Usermod IDs
 #define USERMOD_ID_RESERVED               0     //Unused. Might indicate no usermod present
 #define USERMOD_ID_UNSPECIFIED            1     //Default value for a general user mod that does not specify a custom ID

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -11,6 +11,13 @@ static void DebugPrintOwnerTag(PinOwner tag)
   }
 }
 
+// for serialization purposes
+PinOwner PinManagerClass::currentPinOwner(byte gpio)
+{
+  if (gpio >= TOTAL_GPIO_COUNT) return PinOwner::None;
+  return ownerTag[gpio];
+}
+
 /// Actual allocation/deallocation routines
 bool PinManagerClass::deallocatePin(byte gpio, PinOwner tag)
 {

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -56,6 +56,20 @@ enum struct PinOwner : uint8_t {
 };
 static_assert(0u == static_cast<uint8_t>(PinOwner::None), "PinOwner::None must be zero, so default array initialization works as expected");
 
+// wled00/cfg.cpp:734:22:   required from here
+// wled00/src/dependencies/json/ArduinoJson-v6.h:4115:25:
+// error: no matching function for call to 'convertToJson(const PinOwner&, ArduinoJson6181_90::VariantRef&)'
+//      return convertToJson(src, dst); // Error here? See https://arduinojson.org/v6/unsupported-set/
+//
+// PROBLEM: Header problems if I try to include headers to have the ArduinoJson::VariantRef type defined here.
+//   CHEAT: Use a template to avoid this, as it won't be instantiated until later, where it's used and the
+//          ArduinoJson::VariantRef type is already defined.
+template <typename T>
+bool convertToJson(const PinOwner src, /*ArduinoJson*/ T dst) {
+  static_assert(sizeof(int) > sizeof(uint8_t), "PinOwner: Review convertToJson() for potential truncation");
+  return dst.set(static_cast<const int>(src));
+}
+
 class PinManagerClass {
   private:
   static constexpr const size_t BytesForPinAlloc = (TOTAL_GPIO_COUNT / 8) + ((TOTAL_GPIO_COUNT % 8) ? 1 : 0);

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -37,6 +37,7 @@ enum struct PinOwner : uint8_t {
   SPI_RAM       = 0x88,   // 'SpiR' == SPI RAM
   DebugOut      = 0x89,   // 'Dbg'  == debug output always IO1
   DMX           = 0x8A,   // 'DMX'  == hard-coded to IO2
+  AdaLight      = 0x8B,
   // Use UserMod IDs from const.h here
   UM_Unspecified       = USERMOD_ID_UNSPECIFIED,        // 0x01
   UM_RGBRotaryEncoder  = USERMOD_ID_UNSPECIFIED,        // 0x01 // No define in const.h for this user module -- consider adding?

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -39,7 +39,6 @@ enum struct PinOwner : uint8_t {
   DMX           = 0x8A,   // 'DMX'  == hard-coded to IO2
   AdaLight      = 0x8B,
   InternalFlash = 0x8C,   // Pins 6-11 on ESP32, ESP8266 are used for internal flash....
-  Serial        = 0x8D,
   
   // Use UserMod IDs from const.h here
   UM_Unspecified       = USERMOD_ID_UNSPECIFIED,        // 0x01

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -7,8 +7,11 @@
 #include "const.h" // for USERMOD_* values, total gpio count
 
 typedef struct PinManagerPinType {
-  int8_t  pin;
-  uint8_t isOutput;
+  int8_t  pin {-1};
+  uint8_t isOutput {true};
+  PinManagerPinType(int8_t pin, uint8_t isOutput) : pin(pin), isOutput(isOutput) {}
+  PinManagerPinType(int8_t pin) : pin(pin), isOutput(true) {}
+  PinManagerPinType() : pin(-1), isOutput(true) {}
 } managed_pin_type;
 
 /*

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -39,6 +39,7 @@ enum struct PinOwner : uint8_t {
   DMX           = 0x8A,   // 'DMX'  == hard-coded to IO2
   AdaLight      = 0x8B,
   InternalFlash = 0x8C,   // Pins 6-11 on ESP32, ESP8266 are used for internal flash....
+  Serial        = 0x8D,
   
   // Use UserMod IDs from const.h here
   UM_Unspecified       = USERMOD_ID_UNSPECIFIED,        // 0x01

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -78,6 +78,8 @@ class PinManagerClass {
   // using more than one pin, such as I2C, SPI, rotary encoders,
   // ethernet, etc..
   bool allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount, PinOwner tag );
+  // Per request, exposing pin ownership so can output via JSON/XML
+  PinOwner currentPinOwner(byte gpio);
 
   #if !defined(ESP8266) // ESP8266 compiler doesn't understand deprecated attribute
   [[deprecated("Replaced by three-parameter allocatePin(gpio, output, ownerTag), for improved debugging")]]

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -38,6 +38,8 @@ enum struct PinOwner : uint8_t {
   DebugOut      = 0x89,   // 'Dbg'  == debug output always IO1
   DMX           = 0x8A,   // 'DMX'  == hard-coded to IO2
   AdaLight      = 0x8B,
+  InternalFlash = 0x8C,   // Pins 6-11 on ESP32, ESP8266 are used for internal flash....
+  
   // Use UserMod IDs from const.h here
   UM_Unspecified       = USERMOD_ID_UNSPECIFIED,        // 0x01
   UM_RGBRotaryEncoder  = USERMOD_ID_UNSPECIFIED,        // 0x01 // No define in const.h for this user module -- consider adding?

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -277,7 +277,6 @@ void WLED::setup()
 #endif
   DEBUG_PRINT(F("heap "));
   DEBUG_PRINTLN(ESP.getFreeHeap());
-  registerUsermods();
 
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_PSRAM)
   if (psramFound()) {
@@ -287,8 +286,12 @@ void WLED::setup()
   }
   #endif
 
-  //DEBUG_PRINT(F("LEDs inited. heap usage ~"));
-  //DEBUG_PRINTLN(heapPreAlloc - ESP.getFreeHeap());
+  if (true) {
+    // GPIO6 .. GPIO11 reserved for internal flash
+    for (byte pin = 6; pin <= 11; pin++) {
+      pinManager.allocatePin(pin, true, PinOwner::InternalFlash);
+    }
+  }
 
 #ifdef WLED_DEBUG
   pinManager.allocatePin(1, true, PinOwner::DebugOut); // GPIO1 reserved for debug output
@@ -296,6 +299,13 @@ void WLED::setup()
 #ifdef WLED_USE_DMX //reserve GPIO2 as hardcoded DMX pin
   pinManager.allocatePin(2, true, PinOwner::DMX);
 #endif
+
+  registerUsermods();
+
+
+  //DEBUG_PRINT(F("LEDs inited. heap usage ~"));
+  //DEBUG_PRINTLN(heapPreAlloc - ESP.getFreeHeap());
+
 
   for (uint8_t i=1; i<WLED_MAX_BUTTONS; i++) btnPin[i] = -1;
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -338,7 +338,10 @@ void WLED::setup()
 
   #ifdef WLED_ENABLE_ADALIGHT
   if (!pinManager.isPinAllocated(3)) {
-    // TODO: Should this be reserved for Ada?  Serial input pin?  Else, doesn't appear in pin ownership list....
+    // allow failure for pin allocations (may be used by debug)
+    // TODO: consider if/how DEBUG builds should work with AdaLight enabled
+    pinManager.allocatePin(1, true,  PinOwner::AdaLight);
+    pinManager.allocatePin(3, false, PinOwner::AdaLight);
     Serial.println(F("Ada"));
   }
   #endif

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -338,6 +338,7 @@ void WLED::setup()
 
   #ifdef WLED_ENABLE_ADALIGHT
   if (!pinManager.isPinAllocated(3)) {
+    // TODO: Should this be reserved for Ada?  Serial input pin?  Else, doesn't appear in pin ownership list....
     Serial.println(F("Ada"));
   }
   #endif

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -278,6 +278,8 @@ void WLED::setup()
   DEBUG_PRINT(F("heap "));
   DEBUG_PRINTLN(ESP.getFreeHeap());
 
+  pinManager.allocatePin(1, true,  PinOwner::Serial);
+  pinManager.allocatePin(3, false, PinOwner::Serial);
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_PSRAM)
   if (psramFound()) {
     // GPIO16/GPIO17 reserved for SPI RAM
@@ -293,9 +295,6 @@ void WLED::setup()
     }
   }
 
-#ifdef WLED_DEBUG
-  pinManager.allocatePin(1, true, PinOwner::DebugOut); // GPIO1 reserved for debug output
-#endif
 #ifdef WLED_USE_DMX //reserve GPIO2 as hardcoded DMX pin
   pinManager.allocatePin(2, true, PinOwner::DMX);
 #endif
@@ -348,9 +347,7 @@ void WLED::setup()
 
   #ifdef WLED_ENABLE_ADALIGHT
   if (!pinManager.isPinAllocated(3)) {
-    // allow failure for pin allocations (may be used by debug)
-    // TODO: consider if/how DEBUG builds should work with AdaLight enabled
-    pinManager.allocatePin(1, true,  PinOwner::AdaLight);
+    // ??? allow failure for pin allocations (may be used by debug)
     pinManager.allocatePin(3, false, PinOwner::AdaLight);
     Serial.println(F("Ada"));
   }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -278,8 +278,6 @@ void WLED::setup()
   DEBUG_PRINT(F("heap "));
   DEBUG_PRINTLN(ESP.getFreeHeap());
 
-  pinManager.allocatePin(1, true,  PinOwner::Serial);
-  pinManager.allocatePin(3, false, PinOwner::Serial);
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_PSRAM)
   if (psramFound()) {
     // GPIO16/GPIO17 reserved for SPI RAM
@@ -295,6 +293,9 @@ void WLED::setup()
     }
   }
 
+#ifdef WLED_DEBUG
+  pinManager.allocatePin(1, true, PinOwner::DebugOut); // GPIO1 reserved for debug output
+#endif
 #ifdef WLED_USE_DMX //reserve GPIO2 as hardcoded DMX pin
   pinManager.allocatePin(2, true, PinOwner::DMX);
 #endif
@@ -347,7 +348,9 @@ void WLED::setup()
 
   #ifdef WLED_ENABLE_ADALIGHT
   if (!pinManager.isPinAllocated(3)) {
-    // ??? allow failure for pin allocations (may be used by debug)
+    // allow failure for pin allocations (may be used by debug)
+    // TODO: consider if/how DEBUG builds should work with AdaLight enabled
+    pinManager.allocatePin(1, true,  PinOwner::AdaLight);
     pinManager.allocatePin(3, false, PinOwner::AdaLight);
     Serial.println(F("Ada"));
   }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -28,13 +28,24 @@
 //#define WLED_DISABLE_CRONIXIE    // saves 3kb
 //#define WLED_DISABLE_HUESYNC     // saves 4kb
 //#define WLED_DISABLE_INFRARED    // there is no pin left for this on ESP8266-01, saves 12kb
-#ifndef WLED_DISABLE_MQTT
+
+#if defined(WLED_DISABLE_MQTT) && defined(WLED_ENABLE_MQTT)
+  #error "Conflicting configuration: both WLED_DISABLE_MQTT and WLED_ENABLE_MQTT defined"
+#elif !defined(WLED_DISABLE_MQTT) && !defined(WLED_ENABLE_MQTT)
   #define WLED_ENABLE_MQTT         // saves 12kb
 #endif
-#define WLED_ENABLE_ADALIGHT       // saves 500b only
+
+#if !defined(WLED_ENABLE_ADALIGHT)
+  #define WLED_ENABLE_ADALIGHT       // saves 500b only
+#endif
+
 //#define WLED_ENABLE_DMX          // uses 3.5kb (use LEDPIN other than 2)
+
 #define WLED_ENABLE_LOXONE         // uses 1.2kb
-#ifndef WLED_DISABLE_WEBSOCKETS
+
+#if defined(WLED_DISABLE_WEBSOCKETS) && defined(WLED_ENABLE_WEBSOCKETS)
+  #error "Conflicting configuration: both WLED_DISABLE_WEBSOCKETS and WLED_ENABLE_WEBSOCKETS defined"
+#elif !defined(WLED_DISABLE_WEBSOCKETS) && !defined(WLED_ENABLE_WEBSOCKETS)
   #define WLED_ENABLE_WEBSOCKETS
 #endif
 


### PR DESCRIPTION
@blazoncek -- Currently, this PR does the following:

1. Adds an array of pin owners to script of the `LED Preferences` subpage
2. Adds an array of pin owners to script of the `User Module` subpage
3. Adds basic JSON serialization support to `PinOwner` type
4. Added array of pin owners to JSON output

I think this can make the scripts much cleaner than parsing many config pages for a magic string.

Was there any other change needed for the web page scripts to do what they need?

