### PR TITLE
Fix error 12 issues

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -215,6 +215,7 @@
 #define ERR_FS_BEGIN    10  // Could not init filesystem (no partition?)
 #define ERR_FS_QUOTA    11  // The FS is full or the maximum file size is reached
 #define ERR_FS_PLOAD    12  // It was attempted to load a preset that does not exist
+#define ERR_FS_IRLOAD   13  // It was attempted to load an IR JSON cmd, but the "ir.json" file does not exist
 #define ERR_FS_GENERAL  19  // A general unspecified filesystem error occured
 #define ERR_OVERTEMP    30  // An attached temperature sensor has measured above threshold temperature (not implemented)
 #define ERR_OVERCURRENT 31  // An attached current sensor has measured a current above the threshold (not implemented)

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -71,9 +71,11 @@ void decBrightness()
 // apply preset or fallback to a effect and palette if it doesn't exist
 void presetFallback(uint8_t presetID, uint8_t effectID, uint8_t paletteID) 
 {
+  byte prevError = errorFlag;
   if (!applyPreset(presetID, CALL_MODE_BUTTON)) { 
     effectCurrent = effectID;      
     effectPalette = paletteID;
+    errorFlag = prevError; //clear error 12 from non-existent preset
   }
 }
 
@@ -566,16 +568,17 @@ void decodeIRJson(uint32_t code)
   char objKey[10];
   const char* cmd;
   String cmdStr;
+  byte irError;
   DynamicJsonDocument irDoc(JSON_BUFFER_SIZE);
   JsonObject fdo;
   JsonObject jsonCmdObj;
 
   sprintf(objKey, "\"0x%X\":", code);
 
-  errorFlag = readObjectFromFile("/ir.json", objKey, &irDoc) ? ERR_NONE : ERR_FS_PLOAD;
+  irError = readObjectFromFile("/ir.json", objKey, &irDoc) ? ERR_NONE : ERR_FS_PLOAD;
   fdo = irDoc.as<JsonObject>();
   lastValidCode = 0;
-  if (!errorFlag) 
+  if (!irError) 
   {
     cmd = fdo["cmd"];
     cmdStr = String(cmd);

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -595,7 +595,7 @@ void decodeIRJson(uint32_t code)
           decBrightness();
         } else if (cmdStr.startsWith(F("!presetF"))) { //!presetFallback
           uint8_t p1 = fdo["PL"] ? fdo["PL"] : 1;
-          uint8_t p2 = fdo["FX"] ? fdo["FX"] : random8(100);
+          uint8_t p2 = fdo["FX"] ? fdo["FX"] : random8(MODE_COUNT);
           uint8_t p3 = fdo["FP"] ? fdo["FP"] : 0;
           presetFallback(p1, p2, p3);
         }


### PR DESCRIPTION
Store error flag from readObjectFromFile in new variable to prevent error 12 when IR code is not found or ir.json does not exist.
Fix presetFallback so error is not thrown if preset does not exist.