### PR TITLE
Updated links in files generated by cdata.js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ A fast and feature-rich implementation of an ESP8266/ESP32 webserver to control 
 
 ## 📲 Quick start guide and documentation
 
-See the [wiki](https://github.com/Aircoookie/WLED/wiki)!
+See the [documentation on our official site](https://kno.wled.ge)!
 
 [On this page](https://github.com/Aircoookie/WLED/wiki/Learning-the-ropes) you can find excellent tutorials made by the community and helpful tools to help you get your new lamp up and running!
 

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -90,7 +90,7 @@ function writeHtmlGzipped(sourceFile, resultFile) {
  * Binary array for the Web UI.
  * gzip is used for smaller size and improved speeds.
  * 
- * Please see https://github.com/Aircoookie/WLED/wiki/Add-own-functionality#web-ui
+ * Please see https://kno.wled.ge/advanced/custom-features/#changing-web-ui
  * to find out how to easily modify the web UI source!
  */
  
@@ -175,7 +175,7 @@ function writeChunks(srcDir, specs, resultFile) {
   let src = `/*
  * More web UI HTML source arrays.
  * This file is auto generated, please don't make any changes manually.
- * Instead, see https://github.com/Aircoookie/WLED/wiki/Add-own-functionality#web-ui
+ * Instead, see https://kno.wled.ge/advanced/custom-features/#changing-web-ui
  * to find out how to easily modify the web UI source!
  */ 
 `;

--- a/wled00/html_other.h
+++ b/wled00/html_other.h
@@ -1,7 +1,7 @@
 /*
  * More web UI HTML source arrays.
  * This file is auto generated, please don't make any changes manually.
- * Instead, see https://github.com/Aircoookie/WLED/wiki/Add-own-functionality#web-ui
+ * Instead, see https://kno.wled.ge/advanced/custom-features/#changing-web-ui
  * to find out how to easily modify the web UI source!
  */ 
 

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -1,7 +1,7 @@
 /*
  * More web UI HTML source arrays.
  * This file is auto generated, please don't make any changes manually.
- * Instead, see https://github.com/Aircoookie/WLED/wiki/Add-own-functionality#web-ui
+ * Instead, see https://kno.wled.ge/advanced/custom-features/#changing-web-ui
  * to find out how to easily modify the web UI source!
  */ 
 

--- a/wled00/html_ui.h
+++ b/wled00/html_ui.h
@@ -2,7 +2,7 @@
  * Binary array for the Web UI.
  * gzip is used for smaller size and improved speeds.
  * 
- * Please see https://github.com/Aircoookie/WLED/wiki/Add-own-functionality#web-ui
+ * Please see https://kno.wled.ge/advanced/custom-features/#changing-web-ui
  * to find out how to easily modify the web UI source!
  */
  


### PR DESCRIPTION
I've updated cdata.js so the links in the generated files point to the relevant page in the new kno.wled.ge site, and ran the script to recompile all the files.
The link to the wiki on the main readme file has also been updated.
