### PR TITLE
Avoid redundant localIP calls, each call takes 0.700 us on ESP32 240Mhz

### DIFF
--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -2,18 +2,18 @@
 
 IPAddress NetworkClass::localIP()
 {
-  IPAddress ipAddress;
+  IPAddress localIP;
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_ETHERNET)
-  ipAddress = ETH.localIP();
-  if (ipAddress[0] != 0) {
-    return ipAddress;
+  localIP = ETH.localIP();
+  if (localIP[0] != 0) {
+    return localIP;
   }
 #endif
-  ipAddress = WiFi.localIP();
-  if (ipAddress[0] != 0) {
-    return ipAddress;
+  localIP = WiFi.localIP();
+  if (localIP[0] != 0) {
+    return localIP;
   }
-  
+
   return INADDR_NONE;
 }
 

--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -2,14 +2,18 @@
 
 IPAddress NetworkClass::localIP()
 {
+  IPAddress ipAddress;
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_ETHERNET)
-  IPAddress ipAddress = ETH.localIP();
-#else
-  IPAddress ipAddress = WiFi.localIP();
-#endif
+  ipAddress = ETH.localIP();
   if (ipAddress[0] != 0) {
     return ipAddress;
   }
+#endif
+  ipAddress = WiFi.localIP();
+  if (ipAddress[0] != 0) {
+    return ipAddress;
+  }
+  
   return INADDR_NONE;
 }
 

--- a/wled00/src/dependencies/network/Network.cpp
+++ b/wled00/src/dependencies/network/Network.cpp
@@ -3,12 +3,12 @@
 IPAddress NetworkClass::localIP()
 {
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_ETHERNET)
-  if (ETH.localIP()[0] != 0) {
-    return ETH.localIP();
-  }
+  IPAddress ipAddress = ETH.localIP();
+#else
+  IPAddress ipAddress = WiFi.localIP();
 #endif
-  if (WiFi.localIP()[0] != 0) {
-    return WiFi.localIP();
+  if (ipAddress[0] != 0) {
+    return ipAddress;
   }
   return INADDR_NONE;
 }

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -120,6 +120,8 @@ void sendTPM2Ack() {
 
 void handleNotifications()
 {
+  IPAddress localIP;
+
   //send second notification if enabled
   if(udpConnected && notificationTwoRequired && millis()-notificationSentTime > 250){
     notify(notificationSentCallMode,true);
@@ -175,9 +177,10 @@ void handleNotifications()
 
   if (!(receiveNotifications || receiveDirect)) return;
   
+  localIP = Network.localIP();
   //notifier and UDP realtime
   if (!packetSize || packetSize > UDP_IN_MAXSIZE) return;
-  if (!isSupp && notifierUdp.remoteIP() == Network.localIP()) return; //don't process broadcasts we send ourselves
+  if (!isSupp && notifierUdp.remoteIP() == localIP) return; //don't process broadcasts we send ourselves
 
   uint8_t udpIn[packetSize +1];
   uint16_t len;
@@ -186,7 +189,7 @@ void handleNotifications()
 
   // WLED nodes info notifications
   if (isSupp && udpIn[0] == 255 && udpIn[1] == 1 && len >= 40) {
-    if (!nodeListEnabled || notifier2Udp.remoteIP() == Network.localIP()) return;
+    if (!nodeListEnabled || notifier2Udp.remoteIP() == localIP) return;
 
     uint8_t unit = udpIn[39];
     NodesMap::iterator it = Nodes.find(unit);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -591,13 +591,14 @@ void WLED::initConnection()
 
 void WLED::initInterfaces()
 {
+  IPAddress ipAddress = Network.localIP();
   DEBUG_PRINTLN(F("Init STA interfaces"));
 
 #ifndef WLED_DISABLE_HUESYNC
   if (hueIP[0] == 0) {
-    hueIP[0] = Network.localIP()[0];
-    hueIP[1] = Network.localIP()[1];
-    hueIP[2] = Network.localIP()[2];
+    hueIP[0] = ipAddress[0];
+    hueIP[1] = ipAddress[1];
+    hueIP[2] = ipAddress[2];
   }
 #endif
 


### PR DESCRIPTION
Removes redundant localIP calls. Based on benchmarks `WiFi.localIP()` takes 0.700 us on ESP32 240 MHz.  Not super expensive, but why waste 168 clock cycles if we dont need to.