### PR TITLE
Per-bus current calculation

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -680,6 +680,8 @@ class WS2812FX {
       ablMilliampsMax,
       currentMilliamps,
       triwave16(uint16_t),
+      getLengthTotal(void),
+      getLengthPhysical(void),
       getFps();
 
     uint32_t
@@ -839,9 +841,6 @@ class WS2812FX {
 
     uint16_t _cumulativeFps = 2;
 
-    void load_gradient_palette(uint8_t);
-    void handle_palette(void);
-
     bool
       _triggered;
 
@@ -875,7 +874,10 @@ class WS2812FX {
 
     void
       blendPixelColor(uint16_t n, uint32_t color, uint8_t blend),
-      startTransition(uint8_t oldBri, uint32_t oldCol, uint16_t dur, uint8_t segn, uint8_t slot);
+      startTransition(uint8_t oldBri, uint32_t oldCol, uint16_t dur, uint8_t segn, uint8_t slot),
+      estimateCurrentAndLimitBri(void),
+      load_gradient_palette(uint8_t),
+      handle_palette(void);
 
     uint16_t* customMappingTable = nullptr;
     uint16_t  customMappingSize  = 0;


### PR DESCRIPTION
This changes current estimation from total length to per-bus (note - setting per bus max. current or LED characteristics is not yet added). This has the benefit that virtual network busses do not count toward the current limit.
Bus configurations like 2x100 LEDs mirrored (100 total, 200 physical) should now provide accurate estimations.