### PR TITLE
Remove ledCount

### DIFF
--- a/usermods/Artemis_reciever/usermod.cpp
+++ b/usermods/Artemis_reciever/usermod.cpp
@@ -24,7 +24,7 @@ void RGBNET_readValues() {
     int channel = UDP.read();
 
     //channel data is not used we only supports one channel
-    int len = UDP.read(RGBNET_packet, ledCount*3);
+    int len = UDP.read(RGBNET_packet, strip.getLengthTotal()*3);
     if(len==0){
       return;
     }
@@ -50,7 +50,7 @@ void handleConfig(AsyncWebServerRequest *request)
   \"channels\": [\
     {\
       \"channel\": 1,\
-      \"leds\": " + ledCount + "\
+      \"leds\": " + strip.getLengthTotal() + "\
     },\
     {\
       \"channel\": 2,\

--- a/usermods/project_cars_shiftlight/wled06_usermod.ino
+++ b/usermods/project_cars_shiftlight/wled06_usermod.ino
@@ -5,6 +5,8 @@
  * I've had good results with settings around 5 (20 fps).
  * 
  */
+#include "wled.h"
+
 const uint8_t PCARS_dimcolor = 20;
 WiFiUDP UDP;
 const unsigned int PCARS_localUdpPort = 5606; // local port to listen on
@@ -49,11 +51,12 @@ void PCARS_readValues() {
 void PCARS_buildcolorbars() {
   boolean activated = false;
   float ledratio = 0;
+  uint16_t totalLen = strip.getLengthTotal();
 
-  for (uint16_t i = 0; i < ledCount; i++) {
+  for (uint16_t i = 0; i < totalLen; i++) {
     if (PCARS_rpmRatio < .95 || (millis() % 100 > 70 )) {
 
-      ledratio = (float)i / (float)ledCount;
+      ledratio = (float)i / (float)totalLen;
       if (ledratio < PCARS_rpmRatio) {
         activated = true;
       } else {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -108,7 +108,6 @@ void WS2812FX::finalizeInit(void)
     if (pins[0] == 3) bd->reinit();
     #endif
   }
-  ledCount = _length;
 
   //segments are created in makeAutoSegments();
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -78,17 +78,12 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   // initialize LED pins and lengths prior to other HW (except for ethernet)
   JsonObject hw_led = hw[F("led")];
 
-  CJSON(ledCount, hw_led[F("total")]);
-  if (ledCount > MAX_LEDS) ledCount = MAX_LEDS;
-
   CJSON(strip.ablMilliampsMax, hw_led[F("maxpwr")]);
   CJSON(strip.milliampsPerLed, hw_led[F("ledma")]);
   CJSON(strip.rgbwMode, hw_led[F("rgbwm")]);
 
   JsonArray ins = hw_led["ins"];
-
-  uint16_t lC = 0;
-
+  
   if (fromFS || !ins.isNull()) {
     uint8_t s = 0;  // bus iterator
     busses.removeAll();
@@ -115,15 +110,12 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       bool refresh = elm["ref"] | false;
       ledType |= refresh << 7;  // hack bit 7 to indicate strip requires off refresh
       s++;
-      uint16_t busEnd = start + length;
-      if (busEnd > lC) lC = busEnd;
       BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst);
       mem += BusManager::memUsage(bc);
       if (mem <= MAX_LED_MEMORY && busses.getNumBusses() <= WLED_MAX_BUSSES) busses.add(bc);  // finalization will be done in WLED::beginStrip()
     }
     // finalization done in beginStrip()
   }
-  if (lC > ledCount) ledCount = lC; // fix incorrect total length (honour analog setup)
   if (hw_led["rev"]) busses.getBus(0)->reversed = true; //set 0.11 global reversed setting for first bus
 
   // read multiple button configuration
@@ -526,7 +518,7 @@ void serializeConfig() {
   JsonObject hw = doc.createNestedObject("hw");
 
   JsonObject hw_led = hw.createNestedObject("led");
-  hw_led[F("total")] = ledCount;
+  hw_led[F("total")] = strip.getLengthTotal(); //no longer read, but provided for compatibility on downgrade
   hw_led[F("maxpwr")] = strip.ablMilliampsMax;
   hw_led[F("ledma")] = strip.milliampsPerLed;
   hw_led[F("rgbwm")] = strip.rgbwMode;

--- a/wled00/dmx.cpp
+++ b/wled00/dmx.cpp
@@ -18,7 +18,8 @@ void handleDMX()
 
   uint8_t brightness = strip.getBrightness();
 
-  for (int i = DMXStartLED; i < ledCount; i++) {        // uses the amount of LEDs as fixture count
+  uint16_t len = strip.getLengthTotal();
+  for (int i = DMXStartLED; i < len; i++) {        // uses the amount of LEDs as fixture count
 
     uint32_t in = strip.getPixelColor(i);     // get the colors for the individual fixtures as suggested by Aircoookie in issue #462
     byte w = in >> 24 & 0xFF;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -102,6 +102,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
   // update status info
   realtimeIP = clientIP;
   byte wChannel = 0;
+  uint16_t totalLen = strip.getLengthTotal();
 
   switch (DMXMode) {
     case DMX_MODE_DISABLED:
@@ -114,7 +115,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
       realtimeLock(realtimeTimeoutMs, mde);
       if (realtimeOverride) return;
       wChannel = (dmxChannels-DMXAddress+1 > 3) ? e131_data[DMXAddress+3] : 0;
-      for (uint16_t i = 0; i < ledCount; i++)
+      for (uint16_t i = 0; i < totalLen; i++)
         setRealtimePixel(i, e131_data[DMXAddress+0], e131_data[DMXAddress+1], e131_data[DMXAddress+2], wChannel);
       break;
 
@@ -129,7 +130,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
         bri = e131_data[DMXAddress+0];
         strip.setBrightness(bri);
       }
-      for (uint16_t i = 0; i < ledCount; i++)
+      for (uint16_t i = 0; i < totalLen; i++)
         setRealtimePixel(i, e131_data[DMXAddress+1], e131_data[DMXAddress+2], e131_data[DMXAddress+3], wChannel);
       break;
 

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -490,7 +490,7 @@ void serializeInfo(JsonObject root)
   //root[F("cn")] = WLED_CODENAME;
 
   JsonObject leds = root.createNestedObject("leds");
-  leds[F("count")] = ledCount;
+  leds[F("count")] = strip.getLengthTotal();
   leds[F("rgbw")] = strip.isRgbw;
   leds[F("wv")] = strip.isRgbw && (strip.rgbwMode == RGBW_MODE_MANUAL_ONLY || strip.rgbwMode == RGBW_MODE_DUAL); //should a white channel slider be displayed?
   leds[F("pwr")] = strip.currentMilliamps;
@@ -853,7 +853,7 @@ bool serveLiveLeds(AsyncWebServerRequest* request, uint32_t wsClient)
     #endif
   }
 
-  uint16_t used = ledCount;
+  uint16_t used = strip.getLengthTotal();
   uint16_t n = (used -1) /MAX_LIVE_LEDS +1; //only serve every n'th LED if count over MAX_LIVE_LEDS
   char buffer[2000];
   strcpy_P(buffer, PSTR("{\"leds\":["));

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -92,7 +92,8 @@ void notify(byte callMode, bool followUp)
 void realtimeLock(uint32_t timeoutMs, byte md)
 {
   if (!realtimeMode && !realtimeOverride){
-    for (uint16_t i = 0; i < ledCount; i++)
+    uint16_t totalLen = strip.getLengthTotal();
+    for (uint16_t i = 0; i < totalLen; i++)
     {
       strip.setPixelColor(i,0,0,0,0);
     }
@@ -168,10 +169,11 @@ void handleNotifications()
       realtimeLock(realtimeTimeoutMs, REALTIME_MODE_HYPERION);
       if (realtimeOverride) return;
       uint16_t id = 0;
+      uint16_t totalLen = strip.getLengthTotal();
       for (uint16_t i = 0; i < packetSize -2; i += 3)
       {
         setRealtimePixel(id, lbuf[i], lbuf[i+1], lbuf[i+2], 0);
-        id++; if (id >= ledCount) break;
+        id++; if (id >= totalLen) break;
       }
       strip.show();
       return;
@@ -339,9 +341,10 @@ void handleNotifications()
     byte numPackets = udpIn[5];
 
     uint16_t id = (tpmPayloadFrameSize/3)*(packetNum-1); //start LED
+    uint16_t totalLen = strip.getLengthTotal();
     for (uint16_t i = 6; i < tpmPayloadFrameSize + 4; i += 3)
     {
-      if (id < ledCount)
+      if (id < totalLen)
       {
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
         id++;
@@ -372,6 +375,7 @@ void handleNotifications()
     }
     if (realtimeOverride) return;
 
+    uint16_t totalLen = strip.getLengthTotal();
     if (udpIn[0] == 1) //warls
     {
       for (uint16_t i = 2; i < packetSize -3; i += 4)
@@ -385,7 +389,7 @@ void handleNotifications()
       {
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
 
-        id++; if (id >= ledCount) break;
+        id++; if (id >= totalLen) break;
       }
     } else if (udpIn[0] == 3) //drgbw
     {
@@ -394,14 +398,14 @@ void handleNotifications()
       {
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
         
-        id++; if (id >= ledCount) break;
+        id++; if (id >= totalLen) break;
       }
     } else if (udpIn[0] == 4) //dnrgb
     {
       uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
       for (uint16_t i = 4; i < packetSize -2; i += 3)
       {
-        if (id >= ledCount) break;
+        if (id >= totalLen) break;
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], 0);
         id++;
       }
@@ -410,7 +414,7 @@ void handleNotifications()
       uint16_t id = ((udpIn[3] << 0) & 0xFF) + ((udpIn[2] << 8) & 0xFF00);
       for (uint16_t i = 4; i < packetSize -2; i += 4)
       {
-        if (id >= ledCount) break;
+        if (id >= totalLen) break;
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
         id++;
       }
@@ -438,7 +442,7 @@ void handleNotifications()
 void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
 {
   uint16_t pix = i + arlsOffset;
-  if (pix < ledCount)
+  if (pix < strip.getLengthTotal())
   {
     if (!arlsDisableGammaCorrection && strip.gammaCorrectCol)
     {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -212,13 +212,10 @@ void WLED::loop()
     bool aligned = strip.checkSegmentAlignment(); //see if old segments match old bus(ses)
     busses.removeAll();
     uint32_t mem = 0;
-    ledCount = 1;
     for (uint8_t i = 0; i < WLED_MAX_BUSSES; i++) {
       if (busConfigs[i] == nullptr) break;
       mem += BusManager::memUsage(*busConfigs[i]);
       if (mem <= MAX_LED_MEMORY) {
-        uint16_t totalNew = busConfigs[i]->start + busConfigs[i]->count;
-        if (totalNew > ledCount && totalNew <= MAX_LEDS) ledCount = totalNew; //total is end of last bus (where start + len is max.)
         busses.add(*busConfigs[i]);
       }
       delete busConfigs[i]; busConfigs[i] = nullptr;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -262,7 +262,6 @@ WLED_GLOBAL bool noWifiSleep _INIT(false);
 #endif
 
 // LED CONFIG
-WLED_GLOBAL uint16_t ledCount _INIT(DEFAULT_LED_COUNT);   // overcurrent prevented by ABL
 WLED_GLOBAL bool turnOnAtBoot _INIT(true);                // turn on LEDs at power-up
 WLED_GLOBAL byte bootPreset   _INIT(0);                   // save preset to load after power-up
 

--- a/wled00/wled_eeprom.cpp
+++ b/wled00/wled_eeprom.cpp
@@ -89,7 +89,16 @@ void loadSettingsFromEEPROM()
   if (apChannel > 13 || apChannel < 1) apChannel = 1;
   apHide = EEPROM.read(228);
   if (apHide > 1) apHide = 1;
-  ledCount = EEPROM.read(229) + ((EEPROM.read(398) << 8) & 0xFF00); if (ledCount > MAX_LEDS || ledCount == 0) ledCount = 30;
+  uint16_t length = EEPROM.read(229) + ((EEPROM.read(398) << 8) & 0xFF00); //was ledCount
+  if (length > MAX_LEDS || length == 0) length = 30;
+  uint8_t pins[5] = {2, 255, 255, 255, 255};
+  uint8_t colorOrder = COL_ORDER_GRB;
+  if (lastEEPROMversion > 9) colorOrder = EEPROM.read(383);
+  if (colorOrder > COL_ORDER_GBR) colorOrder = COL_ORDER_GRB;
+  bool skipFirst = EEPROM.read(2204);
+  bool reversed = EEPROM.read(252);
+  BusConfig bc = BusConfig(EEPROM.read(372) ? TYPE_SK6812_RGBW : TYPE_WS2812_RGB, pins, 0, length, colorOrder, reversed, skipFirst);
+  busses.add(bc);
 
   notifyButton = EEPROM.read(230);
   notifyTwice = EEPROM.read(231);
@@ -143,7 +152,7 @@ void loadSettingsFromEEPROM()
   arlsOffset = EEPROM.read(368);
   if (!EEPROM.read(367)) arlsOffset = -arlsOffset;
   turnOnAtBoot = EEPROM.read(369);
-  strip.isRgbw = EEPROM.read(372);
+  //strip.isRgbw = EEPROM.read(372);
   //374 - strip.paletteFade
   
   apBehavior = EEPROM.read(376);

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -387,7 +387,7 @@ String dmxProcessor(const String& var)
       mapJS += "\nCN=" + String(DMXChannels) + ";\n";
       mapJS += "CS=" + String(DMXStart) + ";\n";
       mapJS += "CG=" + String(DMXGap) + ";\n";
-      mapJS += "LC=" + String(ledCount) + ";\n";
+      mapJS += "LC=" + String(strip.getLengthTotal()) + ";\n";
       mapJS += "var CH=[";
       for (int i=0;i<15;i++) {
         mapJS += String(DMXFixtureMap[i]) + ",";


### PR DESCRIPTION
ledCount was basically just mirroring `strip._length`, removing it reduces complexity and memory usage by a small amount.

Bus initialization is now performed on reading from eeprom (if upgrading from pre-0.11), this will ensure correct RGBW mode, length and color order is carried over and _may_ fix #2293.
