### PR TITLE
Add MX-CST/CDT Time Zone

### DIFF
--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -130,6 +130,7 @@
 			<option value="18">HST (Hawaii)</option>
 			<option value="19">NOVT (Novosibirsk)</option>
 			<option value="20">AKST/AKDT (Anchorage)</option>
+			<option value="21">MX-CST/CDT</option>
 		</select><br>
 		UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 		Current local time is <span class="times">unknown</span>.<br>

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -353,6 +353,7 @@ North Korea</option><option value="14">IST (India)</option><option value="15">
 CA-Saskatchewan</option><option value="16">ACST</option><option value="17">
 ACST/ACDT</option><option value="18">HST (Hawaii)</option><option value="19">
 NOVT (Novosibirsk)</option><option value="20">AKST/AKDT (Anchorage)</option>
+<option value="21">MX-CST/CDT</option>
 </select><br>UTC offset: <input name="UO" type="number" min="-65500" 
 max="65500" required> seconds (max. 18 hours)<br>Current local time is <span 
 class="times">unknown</span>.<br>Latitude (N): <input name="LT" type="number" 

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -31,6 +31,7 @@ Timezone* tz;
 #define TZ_HAWAII              18
 #define TZ_NOVOSIBIRSK         19
 #define TZ_ANCHORAGE           20
+#define TZ_MX_CENTRAL          21  
 #define TZ_INIT               255
 
 byte tzCurrent = TZ_INIT; //uninitialized
@@ -139,6 +140,11 @@ void updateTimezone() {
     case TZ_ANCHORAGE : {
       tcrDaylight = {Second, Sun, Mar, 2, -480};  //AKDT = UTC - 8 hours
       tcrStandard = {First, Sun, Nov, 2, -540};   //AKST = UTC - 9 hours
+      break;
+    }
+     case TZ_MX_CENTRAL : {
+      tcrDaylight = {First, Sun, Apr, 2, -300};  //CDT = UTC - 5 hours
+      tcrStandard = {Last,  Sun, Oct, 2, -360};  //CST = UTC - 6 hours
       break;
     }
   }


### PR DESCRIPTION
Add the Mexico City CST/CDT timezone.
The start and finish date for DLS differs with the US-CST/CDT rules.