### PR TITLE
Fix settings JS buffer too small

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -265,7 +265,11 @@
 #endif
 
 // string temp buffer (now stored in stack locally)
-#define OMAX 2048
+#ifdef ESP8266
+#define SETTINGS_STACK_BUF_SIZE 2048
+#else
+#define SETTINGS_STACK_BUF_SIZE 3096 
+#endif
 
 #ifdef WLED_USE_ETHERNET
 #define E131_MAX_UNIVERSE_COUNT 20

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -42,7 +42,7 @@ bool oappendi(int i)
 bool oappend(const char* txt)
 {
   uint16_t len = strlen(txt);
-  if (olen + len >= OMAX)
+  if (olen + len >= SETTINGS_STACK_BUF_SIZE)
     return false;        // buffer full
   strcpy(obuf + olen, txt);
   olen += len;

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -362,9 +362,10 @@ void serveMessage(AsyncWebServerRequest* request, uint16_t code, const String& h
 String settingsProcessor(const String& var)
 {
   if (var == "CSS") {
-    char buf[2048];
+    char buf[SETTINGS_STACK_BUF_SIZE];
     buf[0] = 0;
     getSettingsJS(optionType, buf);
+    //Serial.println(uxTaskGetStackHighWaterMark(NULL));
     return String(buf);
   }
   


### PR DESCRIPTION
The previous buffer size was 2048b. This was not enough for the LED settings page with 10 busses.
This increases it to 3096b for ESP32 (issue should not be present on ESP8266 due to the 3 bus limit).
Measured free stack remaining before the change is 4k, after the change 3k, which should be enough leeway to not cause a stack overflow.

Likely fixes #2303 