### PR TITLE
Corrected WLED_USE_DMX to WLED_ENABLE_DMX

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -303,7 +303,7 @@ void WLED::setup()
 #ifdef WLED_DEBUG
   pinManager.allocatePin(1, true, PinOwner::DebugOut); // GPIO1 reserved for debug output
 #endif
-#ifdef WLED_USE_DMX //reserve GPIO2 as hardcoded DMX pin
+#ifdef WLED_ENABLE_DMX //reserve GPIO2 as hardcoded DMX pin
   pinManager.allocatePin(2, true, PinOwner::DMX);
 #endif
 


### PR DESCRIPTION
"WLED_USE_DMX" preprocessor constant reference is wrong, changed it to the correct string: WLED_ENABLE_DMX. I don't think it's a problem as long as GPIO2 is not used for other things, but should be corrected anyways. (this is my first pr ever, hope I did it right :) )