### PR TITLE
Fix a bug which prevents DMX Output channel mappings from loading correctly

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -396,11 +396,9 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(DMXStartLED,dmx[F("start-led")]);
 
   JsonArray dmx_fixmap = dmx[F("fixmap")];
-  it = 0;
-  for (int i : dmx_fixmap) {
-    if (it > 14) break;
+  for (int i = 0; i < dmx_fixmap.size(); i++) {
+    if (i > 14) break;
     CJSON(DMXFixtureMap[i],dmx_fixmap[i]);
-    it++;
   }
   #endif
 


### PR DESCRIPTION
This fixes #1525.

As far as I can tell, this bug has existed since the introduction of DMX output. It was likely hard to manifest because the common mapping
```
channel 1 -> red
channel 2 -> green
channel 3 -> blue
```
just happens to work. Any other mapping would not load properly.