### PR TITLE
Ir code formatting, and IP address, on Serial

### DIFF
--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -654,9 +654,7 @@ void handleIR()
       {
         if (results.value != 0) // only print results if anything is received ( != 0 )
         {
-          Serial.print("IR recv\r\n0x");
-          Serial.println((uint32_t)results.value, HEX);
-          Serial.println();
+          Serial.printf("IR recv: 0x%X\n", (uint32_t)results.value);
         }
         decodeIR(results.value);
         irrecv->resume();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -610,6 +610,9 @@ void WLED::initInterfaces()
 {
   DEBUG_PRINTLN(F("Init STA interfaces"));
 
+  Serial.print("IP address: ");
+  Serial.println(Network.localIP());
+
 #ifndef WLED_DISABLE_HUESYNC
   IPAddress ipAddress = Network.localIP();
   if (hueIP[0] == 0) {


### PR DESCRIPTION
Even though I cut/paste my codes from the serial output, my JSON failed to work because it wasn't the right format.  It would be great to make the whole lookup less fragile but in the meantime this easy fix to print it in upper-case hex in the right format might help avoid problems.

There may be some reason why printing the IP on serial is a bad idea, but it seems like a good one to me (?).  Perhaps I should put this in two PRs, as they're very independent.