### PR TITLE
Add support for LilyGO-T-ETH-POE board

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3783,16 +3783,22 @@ uint16_t WS2812FX::mode_washing_machine(void) {
   Modified, originally by Mark Kriegsman https://gist.github.com/kriegsman/1f7ccbbfa492a73c015e
 */
 uint16_t WS2812FX::mode_blends(void) {
-  uint16_t dataSize = sizeof(uint32_t) * SEGLEN;  // max segment length of 56 pixels on 16 segment ESP8266
+  uint16_t pixelLen = SEGLEN > UINT8_MAX ? UINT8_MAX : SEGLEN;
+  uint16_t dataSize = sizeof(uint32_t) * (pixelLen + 1);  // max segment length of 56 pixels on 16 segment ESP8266
   if (!SEGENV.allocateData(dataSize)) return mode_static(); //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);
   uint8_t blendSpeed = map(SEGMENT.intensity, 0, UINT8_MAX, 10, 128);
     uint8_t shift = (now * ((SEGMENT.speed >> 3) +1)) >> 8;
 
-  for (int i = 0; i < SEGLEN; i++) {
+  for (int i = 0; i < pixelLen; i++) {
     pixels[i] = color_blend(pixels[i], color_from_palette(shift + quadwave8((i + 1) * 16), false, PALETTE_SOLID_WRAP, 255), blendSpeed);
-    setPixelColor(i, pixels[i]);
     shift += 3;
+  }
+
+  uint16_t offset = 0;
+  for (int i = 0; i < SEGLEN; i++) {
+    setPixelColor(i, pixels[offset++]);
+    if (offset > pixelLen) offset = 0;
   }
 
   return FRAMETIME;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3783,22 +3783,16 @@ uint16_t WS2812FX::mode_washing_machine(void) {
   Modified, originally by Mark Kriegsman https://gist.github.com/kriegsman/1f7ccbbfa492a73c015e
 */
 uint16_t WS2812FX::mode_blends(void) {
-  uint16_t pixelLen = SEGLEN > UINT8_MAX ? UINT8_MAX : SEGLEN;
-  uint16_t dataSize = sizeof(uint32_t) * (pixelLen + 1);  // max segment length of 56 pixels on 16 segment ESP8266
+  uint16_t dataSize = sizeof(uint32_t) * SEGLEN;  // max segment length of 56 pixels on 16 segment ESP8266
   if (!SEGENV.allocateData(dataSize)) return mode_static(); //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);
   uint8_t blendSpeed = map(SEGMENT.intensity, 0, UINT8_MAX, 10, 128);
     uint8_t shift = (now * ((SEGMENT.speed >> 3) +1)) >> 8;
 
-  for (int i = 0; i < pixelLen; i++) {
-    pixels[i] = color_blend(pixels[i], color_from_palette(shift + quadwave8((i + 1) * 16), false, PALETTE_SOLID_WRAP, 255), blendSpeed);
-    shift += 3;
-  }
-
-  uint16_t offset = 0;
   for (int i = 0; i < SEGLEN; i++) {
-    setPixelColor(i, pixels[offset++]);
-    if (offset > pixelLen) offset = 0;
+    pixels[i] = color_blend(pixels[i], color_from_palette(shift + quadwave8((i + 1) * 16), false, PALETTE_SOLID_WRAP, 255), blendSpeed);
+    setPixelColor(i, pixels[i]);
+    shift += 3;
   }
 
   return FRAMETIME;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -182,7 +182,7 @@
 #define BTN_TYPE_ANALOG_INVERTED  8
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        7
+#define WLED_NUM_ETH_TYPES        8
 
 #define WLED_ETH_NONE             0
 #define WLED_ETH_WT32_ETH01       1
@@ -191,6 +191,7 @@
 #define WLED_ETH_QUINLED          4
 #define WLED_ETH_TWILIGHTLORD     5
 #define WLED_ETH_ESP32DEUX        6
+#define WLED_ETH_LILYGO           7
 
 //Hue error codes
 #define HUE_ERROR_INACTIVE        0

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -70,6 +70,7 @@
 		<option value="0">None</option>
     <option value="2">ESP32-POE</option>
     <option value="6">ESP32Deux</option>
+    <option value="7">LilyGO-T-ETH-POE</option>
     <option value="4">QuinLED-ESP32</option>
     <option value="5">TwilightLord-ESP32</option>
     <option value="3">WESP32</option>

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -64,7 +64,7 @@ Can help with connectivity issues.<br>
 Do not enable if WiFi is working correctly, increases power consumption.</i><div
  id="ethd"><h3>Ethernet Type</h3><select name="ETH"><option value="0">None
 </option><option value="2">ESP32-POE</option><option value="6">ESP32Deux
-</option><option value="4">QuinLED-ESP32</option><option value="5">
+</option><option value="7">LilyGO-T-ETH-POE</option><option value="4">QuinLED-ESP32</option><option value="5">
 TwilightLord-ESP32</option><option value="3">WESP32</option><option value="1">
 WT32-ETH01</option></select><br><br></div><hr><button type="button" 
 onclick="B()">Back</button><button type="submit">Save & Connect</button></form>

--- a/wled00/wled_ethernet.h
+++ b/wled00/wled_ethernet.h
@@ -92,6 +92,16 @@ const ethernet_settings ethernetBoards[] = {
     18,                   // eth_mdio, 
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
+  },
+
+  // LilyGO-T-ETH-POE
+  {
+    0,                    // eth_address, 
+    -1,                   // eth_power, 
+    23,                   // eth_mdc, 
+    18,                   // eth_mdio, 
+    ETH_PHY_LAN8720,      // eth_type,
+    ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
   }
 };
 #endif


### PR DESCRIPTION
Add support for LilyGO TTGO T-Internet-POE board v1.0. Note, this is only for the version without PSRAM (v1.0 only).

// #define ETH_CLK_MODE    ETH_CLOCK_GPIO0_OUT          // Version with PSRAM
#define ETH_CLK_MODE    ETH_CLOCK_GPIO17_OUT            // Version with not PSRAM

For more details, see GitHub repo.

https://github.com/Xinyuan-LilyGO/LilyGO-T-ETH-POE