### PR TITLE
Improved speed and reduced memory usage for Blends effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3783,16 +3783,22 @@ uint16_t WS2812FX::mode_washing_machine(void) {
   Modified, originally by Mark Kriegsman https://gist.github.com/kriegsman/1f7ccbbfa492a73c015e
 */
 uint16_t WS2812FX::mode_blends(void) {
-  uint16_t dataSize = sizeof(uint32_t) * SEGLEN;  // max segment length of 56 pixels on 16 segment ESP8266
+  uint16_t pixelLen = SEGLEN > UINT8_MAX ? UINT8_MAX : SEGLEN;
+  uint16_t dataSize = sizeof(uint32_t) * (pixelLen + 1);  // max segment length of 56 pixels on 16 segment ESP8266
   if (!SEGENV.allocateData(dataSize)) return mode_static(); //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);
   uint8_t blendSpeed = map(SEGMENT.intensity, 0, UINT8_MAX, 10, 128);
-    uint8_t shift = (now * ((SEGMENT.speed >> 3) +1)) >> 8;
+  uint8_t shift = (now * ((SEGMENT.speed >> 3) +1)) >> 8;
 
-  for (int i = 0; i < SEGLEN; i++) {
+  for (int i = 0; i < pixelLen; i++) {
     pixels[i] = color_blend(pixels[i], color_from_palette(shift + quadwave8((i + 1) * 16), false, PALETTE_SOLID_WRAP, 255), blendSpeed);
-    setPixelColor(i, pixels[i]);
     shift += 3;
+  }
+
+  uint16_t offset = 0;
+  for (int i = 0; i < SEGLEN; i++) {
+    setPixelColor(i, pixels[offset++]);
+    if (offset > pixelLen) offset = 0;
   }
 
   return FRAMETIME;


### PR DESCRIPTION
color_blend() function only generates 256 colors from the palette before repeating. Improved the function to use either 256 max or the segment length if shorter.