### PR TITLE
Adding support for WAN networks in LED syncing

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -278,6 +278,14 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   JsonObject if_nodes = interfaces["nodes"];
   CJSON(nodeListEnabled, if_nodes[F("list")]);
   CJSON(nodeBroadcastEnabled, if_nodes[F("bcast")]);
+  JsonArray if_node_list = if_nodes["cusnodes"]; // not sure if I should be using F here, couldn't understand what it does
+  for (uint8_t i = 0; i < 10; i++) { // 10 is arbitrary defined in settings
+    JsonArray if_node_ip = if_node_list[i];
+    CJSON(specialSearchNodes[i][0], if_node_ip[0]);
+    CJSON(specialSearchNodes[i][1], if_node_ip[1]);
+    CJSON(specialSearchNodes[i][2], if_node_ip[2]);
+    CJSON(specialSearchNodes[i][3], if_node_ip[3]);
+  }
 
   JsonObject if_live = interfaces["live"];
   CJSON(receiveDirect, if_live["en"]);
@@ -689,6 +697,14 @@ void serializeConfig() {
   JsonObject if_nodes = interfaces.createNestedObject("nodes");
   if_nodes[F("list")] = nodeListEnabled;
   if_nodes[F("bcast")] = nodeBroadcastEnabled;
+  JsonArray if_node_list = if_nodes.createNestedArray("cusnodes");
+  for (uint8_t i=0; i<10; i++) { //10 is kinda arbitrary, defined in settings
+    JsonArray if_node_ips = if_node_list.createNestedArray();
+    if_node_ips.add(specialSearchNodes[i][0]);
+    if_node_ips.add(specialSearchNodes[i][1]);
+    if_node_ips.add(specialSearchNodes[i][2]);
+    if_node_ips.add(specialSearchNodes[i][3]);
+  }
 
   JsonObject if_live = interfaces.createNestedObject("live");
   if_live["en"] = receiveDirect;

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -90,6 +90,17 @@ Send Alexa notifications: <input type="checkbox" name="SA"><br>
 Send Philips Hue change notifications: <input type="checkbox" name="SH"><br>
 Send Macro notifications: <input type="checkbox" name="SM"><br>
 Send notifications twice: <input type="checkbox" name="S2"><br>
+10 optional IPs of other WLED devices to specifically search for when syncing: <br>
+<input name="N0A" type="number" min="0" max="255"> . <input name="N0B" type="number" min="0" max="255"> . <input name="N0C" type="number" min="0" max="255"> . <input name="N0D" type="number" min="0" max="255"><br>
+<input name="N1A" type="number" min="0" max="255"> . <input name="N1B" type="number" min="0" max="255"> . <input name="N1C" type="number" min="0" max="255"> . <input name="N1D" type="number" min="0" max="255"><br>
+<input name="N2A" type="number" min="0" max="255"> . <input name="N2B" type="number" min="0" max="255"> . <input name="N2C" type="number" min="0" max="255"> . <input name="N2D" type="number" min="0" max="255"><br>
+<input name="N3A" type="number" min="0" max="255"> . <input name="N3B" type="number" min="0" max="255"> . <input name="N3C" type="number" min="0" max="255"> . <input name="N3D" type="number" min="0" max="255"><br>
+<input name="N4A" type="number" min="0" max="255"> . <input name="N4B" type="number" min="0" max="255"> . <input name="N4C" type="number" min="0" max="255"> . <input name="N4D" type="number" min="0" max="255"><br>
+<input name="N5A" type="number" min="0" max="255"> . <input name="N5B" type="number" min="0" max="255"> . <input name="N5C" type="number" min="0" max="255"> . <input name="N5D" type="number" min="0" max="255"><br>
+<input name="N6A" type="number" min="0" max="255"> . <input name="N6B" type="number" min="0" max="255"> . <input name="N6C" type="number" min="0" max="255"> . <input name="N6D" type="number" min="0" max="255"><br>
+<input name="N7A" type="number" min="0" max="255"> . <input name="N7B" type="number" min="0" max="255"> . <input name="N7C" type="number" min="0" max="255"> . <input name="N7D" type="number" min="0" max="255"><br>
+<input name="N8A" type="number" min="0" max="255"> . <input name="N8B" type="number" min="0" max="255"> . <input name="N8C" type="number" min="0" max="255"> . <input name="N8D" type="number" min="0" max="255"><br>
+<input name="N9A" type="number" min="0" max="255"> . <input name="N9B" type="number" min="0" max="255"> . <input name="N9C" type="number" min="0" max="255"> . <input name="N9D" type="number" min="0" max="255"><br>
 <i>Reboot required to apply changes. </i>
 <h3>Instance List</h3>
 Enable instance list: <input type="checkbox" name="NL"><br>

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -216,7 +216,7 @@ void realtimeLock(uint32_t timeoutMs, byte md = REALTIME_MODE_GENERIC);
 void handleNotifications();
 void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w);
 void refreshNodeList();
-void sendSysInfoUDP();
+void sendSysInfoUDP(IPAddress targAddr = INADDR_NONE); // INADDR_NONE may not necessarily be safe
 
 //util.cpp
 //bool oappend(const char* txt); // append new c string to temp buffer efficiently

--- a/wled00/html_settings.h
+++ b/wled00/html_settings.h
@@ -274,15 +274,51 @@ type="checkbox" id="R4" name="R4"></td><td><input type="checkbox" id="R5"
 name="R5"></td><td><input type="checkbox" id="R6" name="R6"></td><td><input 
 type="checkbox" id="R7" name="R7"></td><td><input type="checkbox" id="R8" 
 name="R8"></td></tr></table><br>Receive: <input type="checkbox" name="RB">
- Brightness, <input type="checkbox" name="RC"> Color, and <input 
-type="checkbox" name="RX"> Effects<br><input type="checkbox" name="SO">
- Segment options<br>Send notifications on direct change: <input type="checkbox" 
-name="SD"><br>Send notifications on button press or IR: <input type="checkbox" 
-name="SB"><br>Send Alexa notifications: <input type="checkbox" name="SA"><br>
-Send Philips Hue change notifications: <input type="checkbox" name="SH"><br>
-Send Macro notifications: <input type="checkbox" name="SM"><br>
-Send notifications twice: <input type="checkbox" name="S2"><br><i>
-Reboot required to apply changes.</i><h3>Instance List</h3>
+Brightness, <input type="checkbox" name="RC">Color, and <input type="checkbox" 
+name="RX">Effects<br><input type="checkbox" name="SO"> Segment options<br>
+Send notifications on direct change: <input 
+type="checkbox" name="SD"><br>Send notifications on button press or IR: <input 
+type="checkbox" name="SB"><br>Send Alexa notifications: <input type="checkbox" 
+name="SA"><br>Send Philips Hue change notifications: <input type="checkbox" 
+name="SH"><br>Send Macro notifications: <input type="checkbox" name="SM"><br>
+Send notifications twice: <input type="checkbox" name="S2"><br>10 optional 
+IPs of other WLED devices to specifically search for when syncing: <br><input 
+name="N0A" type="number" min="0" max="255"> . <input name="N0B" 
+type="number" min="0" max="255"> . <input name="N0C" type="number" 
+min="0" max="255"> . <input name="N0D" type="number" 
+min="0" max="255"><br><input name="N1A" type="number" min="0" 
+max="255"> . <input name="N1B" type="number" min="0" 
+max="255"> . <input name="N1C" type="number" min="0" 
+max="255"> . <input name="N1D" type="number" min="0" max="255"><br>
+<input name="N2A" type="number" min="0" max="255"> . <input name="N2B"
+ type="number" min="0" max="255"> . <input name="N2C" type="number" 
+min="0" max="255"> . <input name="N2D" type="number" 
+min="0" max="255"><br><input name="N3A" type="number" min="0" 
+max="255"> . <input name="N3B" type="number" min="0" 
+max="255"> . <input name="N3C" type="number" min="0" 
+max="255"> . <input name="N3D" type="number" min="0" max="255"><br>
+<input name="N4A" type="number" min="0" max="255"> . <input name="N4B"
+ type="number" min="0" max="255"> . <input name="N4C" type="number" 
+min="0" max="255"> . <input name="N4D" type="number" 
+min="0" max="255"><br><input name="N5A" type="number" min="0" 
+max="255"> . <input name="N5B" type="number" min="0" 
+max="255"> . <input name="N5C" type="number" min="0" 
+max="255"> . <input name="N5D" type="number" min="0" max="255"><br>
+<input name="N6A" type="number" min="0" max="255"> . <input name="N6B"
+ type="number" min="0" max="255"> . <input name="N6C" type="number" 
+min="0" max="255"> . <input name="N6D" type="number" 
+min="0" max="255"><br><input name="N7A" type="number" min="0" 
+max="255"> . <input name="N7B" type="number" min="0" 
+max="255"> . <input name="N7C" type="number" min="0" 
+max="255"> . <input name="N7D" type="number" min="0" max="255"><br>
+<input name="N8A" type="number" min="0" max="255"> . <input name="N8B"
+ type="number" min="0" max="255"> . <input name="N8C" type="number" 
+min="0" max="255"> . <input name="N8D" type="number" 
+min="0" max="255"><br><input name="N9A" type="number" min="0" 
+max="255"> . <input name="N9B" type="number" min="0" 
+max="255"> . <input name="N9C" type="number" min="0" 
+max="255"> . <input name="N9D" type="number" min="0" max="255"><br>
+<i>Reboot required to apply changes.</i><h3>Instance List</h3>
 Enable instance list: <input type="checkbox" name="NL"><br>
 Make this instance discoverable: <input type="checkbox" name="NB"><h3>Realtime
 </h3>Receive UDP realtime: <input type="checkbox" name="RD"><br><br><i>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -246,6 +246,23 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     if (!nodeListEnabled) Nodes.clear();
     nodeBroadcastEnabled = request->hasArg(F("NB"));
 
+    char k[4]; k[0] = 'N'; k[2] = '\0'; // the id to store ip part in
+    for (int i = 0; i < 10; i++) {
+      k[1] = 48+i; //ascii 0,1,2,3,4,5,6,7,8,9
+      
+      k[2] = 'A'; // first octet
+      specialSearchNodes[i][0] = request->arg(k).toInt();
+
+      k[2] = 'B'; // second octet
+      specialSearchNodes[i][1] = request->arg(k).toInt();
+
+      k[2] = 'C'; // third octet
+      specialSearchNodes[i][2] = request->arg(k).toInt();
+
+      k[2] = 'D'; // fourth octet
+      specialSearchNodes[i][3] = request->arg(k).toInt();
+    }
+
     receiveDirect = request->hasArg(F("RD"));
     e131SkipOutOfSequence = request->hasArg(F("ES"));
     e131Multicast = request->hasArg(F("EM"));

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -131,6 +131,13 @@ void notify(byte callMode, bool followUp)
   notifierUdp.beginPacket(broadcastIp, udpPort);
   notifierUdp.write(udpOut, WLEDPACKETSIZE);
   notifierUdp.endPacket();
+
+  for (auto const& indice : Nodes) {
+    notifierUdp.beginPacket(indice.second.ip, udpPort);
+    notifierUdp.write(udpOut, WLEDPACKETSIZE);
+    notifierUdp.endPacket();
+  }
+
   notificationSentCallMode = callMode;
   notificationSentTime = millis();
   notificationTwoRequired = (followUp)? false:notifyTwice;
@@ -564,7 +571,7 @@ void refreshNodeList()
 /*********************************************************************************************\
    Broadcast system info to other nodes. (to update node lists)
 \*********************************************************************************************/
-void sendSysInfoUDP()
+void sendSysInfoUDP(IPAddress targAddr) /* defaults all args to 255, in theory, using INADDR_NONE is safe in theory */
 {
   if (!udp2Connected) return;
 
@@ -603,7 +610,7 @@ void sendSysInfoUDP()
   for (byte i=0; i<sizeof(uint32_t); i++)
     data[40+i] = (build>>(8*i)) & 0xFF;
 
-  IPAddress broadcastIP(255, 255, 255, 255);
+  IPAddress broadcastIP(targAddr[0], targAddr[1], targAddr[2], targAddr[3]);
   notifier2Udp.beginPacket(broadcastIP, udpPort2);
   notifier2Udp.write(data, sizeof(data));
   notifier2Udp.endPacket();

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -202,7 +202,16 @@ void WLED::loop()
     yield();
     // refresh WLED nodes list
     refreshNodeList();
-    if (nodeBroadcastEnabled) sendSysInfoUDP();
+    if (nodeBroadcastEnabled) {
+      sendSysInfoUDP();
+      
+      for (uint8_t i = 0; i < 10; i++) {
+        // check that ips are valid (these checks may not be valid as unsure of when ip should not be 255)
+        if (specialSearchNodes[i] != INADDR_NONE) { // check that ip is not 255s
+          sendSysInfoUDP(specialSearchNodes[i]);
+        }
+      }
+    }
     yield();
   }
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -299,8 +299,9 @@ WLED_GLOBAL bool syncToggleReceive     _INIT(false);   // UIs which only have a 
 
 // Sync CONFIG
 WLED_GLOBAL NodesMap Nodes;
-WLED_GLOBAL bool nodeListEnabled _INIT(true);
-WLED_GLOBAL bool nodeBroadcastEnabled _INIT(true);
+WLED_GLOBAL bool nodeListEnabled          _INIT(true);
+WLED_GLOBAL bool nodeBroadcastEnabled     _INIT(true);
+WLED_GLOBAL IPAddress specialSearchNodes[10] _INIT_N(({IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255), IPAddress(255, 255, 255, 255)}));
 
 WLED_GLOBAL byte buttonType[WLED_MAX_BUTTONS]  _INIT({BTN_TYPE_PUSH});
 WLED_GLOBAL byte irEnabled      _INIT(0);     // Infrared receiver

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -489,6 +489,18 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('c',SET_F("NL"),nodeListEnabled);
     sappend('c',SET_F("NB"),nodeBroadcastEnabled);
 
+    // a loop for specialSearchNodes (based on staticIP loop)
+    char k[4]; k[0] = 'N'; k[3] = '\0'; // id to save at
+    for (int i = 0; i < 10; i++) 
+    {
+      k[1] = 48+i; //ascii 0,1,2,3,4,5,6,7,8,9
+      k[2] = 'A'; sappend('v', k, specialSearchNodes[i][0]);
+      DEBUG_PRINTLN(k);
+      k[2] = 'B'; sappend('v', k, specialSearchNodes[i][1]);
+      k[2] = 'C'; sappend('v', k, specialSearchNodes[i][2]);
+      k[2] = 'D'; sappend('v', k, specialSearchNodes[i][3]);
+    }
+
     sappend('c',SET_F("RD"),receiveDirect);
     sappend('v',SET_F("EP"),e131Port);
     sappend('c',SET_F("ES"),e131SkipOutOfSequence);


### PR DESCRIPTION
So as of present, different WLED modules will not find each other when broadcasting to all network connections. This is due to how WAN emulates LAN networks and only certain devices can be found during a search. With this PR I have reworked some functions to allow them to target specific IP addresses. This reworking allowed me to add new settings to sync settings being 10 different IPs which can be targeted across the WAN to allow WLEDs to discover each other if the IP of each device is known. If you have any problems with my code or would prefer me to rework my implementation please let me know below and I will address these changes.