### PR TITLE
Add initial support for ESP32-C3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -162,8 +162,8 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    fastled/FastLED @ 3.4.0
-    IRremoteESP8266 @ 2.7.18
+    fastled/FastLED @ 3.5.0
+    https://github.com/crankyoldgit/IRremoteESP8266
     https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.4
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
@@ -224,6 +224,19 @@ build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32S2
   -DCONFIG_IDF_TARGET_ESP32S2
+  -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -DCO
+
+lib_deps =
+  ${env.lib_deps}
+  makuna/NeoPixelBus @ 2.6.7
+  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
+
+[esp32c3]
+build_flags = -g
+  -DARDUINO_ARCH_ESP32
+  -DARDUINO_ARCH_ESP32C3
+  -DCONFIG_IDF_TARGET_ESP32C3
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -DCO
 
@@ -327,6 +340,17 @@ board_build.flash_mode = qio
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 lib_deps = ${esp32s2.lib_deps}
+
+[env:esp32c3]
+board = esp32-c3-devkitm-1
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2/platform-tasmota-espressif32-2.0.2.zip
+platform_packages =
+    framework-arduinoespressif32 @ https://github.com/misery/arduino-esp32.git#esp32_adc2gpio
+framework = arduino
+board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+upload_speed = 460800
+build_unflags = ${common.build_unflags}
+lib_deps = ${esp32c3.lib_deps}
 
 [env:esp8285_4CH_MagicHome]
 board = esp8285

--- a/platformio.ini
+++ b/platformio.ini
@@ -163,7 +163,7 @@ upload_speed = 115200
 lib_compat_mode = strict
 lib_deps =
     fastled/FastLED @ 3.5.0
-    https://github.com/crankyoldgit/IRremoteESP8266
+    IRremoteESP8266 @ 2.8.1
     https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.4
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 ; default_envs = travis_esp8266, travis_esp32
 
 # Release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32s2_saola
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32s2_saola, esp32c3
 
 # Build everything
 ; default_envs = esp32dev, esp8285_4CH_MagicHome, esp8285_4CH_H801, codm-controller-0.6-rev2, codm-controller-0.6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, travis_esp8266, travis_esp32, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_5CH_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips

--- a/platformio.ini
+++ b/platformio.ini
@@ -343,9 +343,8 @@ lib_deps = ${esp32s2.lib_deps}
 
 [env:esp32c3]
 board = esp32-c3-devkitm-1
-platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2/platform-tasmota-espressif32-2.0.2.zip
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.1/platform-tasmota-espressif32-2.0.2.1.zip
 platform_packages =
-    framework-arduinoespressif32 @ https://github.com/misery/arduino-esp32.git#esp32_adc2gpio
 framework = arduino
 board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 upload_speed = 460800

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -98,26 +98,34 @@
 #ifdef ARDUINO_ARCH_ESP32
 //RGB
 #define B_32_RN_NEO_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32RmtNWs2812xMethod>
+#ifndef CONFIG_IDF_TARGET_ESP32C3
 #define B_32_I0_NEO_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32I2s0800KbpsMethod>
-#ifndef CONFIG_IDF_TARGET_ESP32S2
+#endif
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 #define B_32_I1_NEO_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32I2s1800KbpsMethod>
 #endif
 //RGBW
 #define B_32_RN_NEO_4 NeoPixelBrightnessBus<NeoGrbwFeature, NeoEsp32RmtNWs2812xMethod>
+#ifndef CONFIG_IDF_TARGET_ESP32C3
 #define B_32_I0_NEO_4 NeoPixelBrightnessBus<NeoGrbwFeature, NeoEsp32I2s0800KbpsMethod>
-#ifndef CONFIG_IDF_TARGET_ESP32S2
+#endif
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 #define B_32_I1_NEO_4 NeoPixelBrightnessBus<NeoGrbwFeature, NeoEsp32I2s1800KbpsMethod>
 #endif
 //400Kbps
 #define B_32_RN_400_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32RmtN400KbpsMethod>
+#ifndef CONFIG_IDF_TARGET_ESP32C3
 #define B_32_I0_400_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32I2s0400KbpsMethod>
-#ifndef CONFIG_IDF_TARGET_ESP32S2
+#endif
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 #define B_32_I1_400_3 NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp32I2s1400KbpsMethod>
 #endif
 //TM1814 (RGBW)
 #define B_32_RN_TM1_4 NeoPixelBrightnessBus<NeoWrgbTm1814Feature, NeoEsp32RmtNTm1814Method>
+#ifndef CONFIG_IDF_TARGET_ESP32C3
 #define B_32_I0_TM1_4 NeoPixelBrightnessBus<NeoWrgbTm1814Feature, NeoEsp32I2s0Tm1814Method>
-#ifndef CONFIG_IDF_TARGET_ESP32S2
+#endif
+#if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
 #define B_32_I1_TM1_4 NeoPixelBrightnessBus<NeoWrgbTm1814Feature, NeoEsp32I2s1Tm1814Method>
 #endif
 //Bit Bang theoratically possible, but very undesirable and not needed (no pin restrictions on RMT and I2S)
@@ -181,23 +189,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->Begin(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->Begin(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->Begin(); break;
       #endif
       case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->Begin(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->Begin(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->Begin(); break;
       #endif
       case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->Begin(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->Begin(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->Begin(); break;
       #endif
       case I_32_RN_TM1_4: beginTM1814<B_32_RN_TM1_4*>(busPtr); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: beginTM1814<B_32_I0_TM1_4*>(busPtr); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: beginTM1814<B_32_I1_TM1_4*>(busPtr); break;
       #endif
       // ESP32 can (and should, to avoid inadvertantly driving the chip select signal) specify the pins used for SPI, but only in begin()
@@ -236,23 +252,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: busPtr = new B_32_RN_NEO_3(len, pins[0], (NeoBusChannel)channel); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: busPtr = new B_32_I0_NEO_3(len, pins[0]); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: busPtr = new B_32_I1_NEO_3(len, pins[0]); break;
       #endif
       case I_32_RN_NEO_4: busPtr = new B_32_RN_NEO_4(len, pins[0], (NeoBusChannel)channel); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: busPtr = new B_32_I0_NEO_4(len, pins[0]); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: busPtr = new B_32_I1_NEO_4(len, pins[0]); break;
       #endif
       case I_32_RN_400_3: busPtr = new B_32_RN_400_3(len, pins[0], (NeoBusChannel)channel); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: busPtr = new B_32_I0_400_3(len, pins[0]); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: busPtr = new B_32_I1_400_3(len, pins[0]); break;
       #endif
       case I_32_RN_TM1_4: busPtr = new B_32_RN_TM1_4(len, pins[0], (NeoBusChannel)channel); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: busPtr = new B_32_I0_TM1_4(len, pins[0]); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: busPtr = new B_32_I1_TM1_4(len, pins[0]); break;
       #endif
     #endif
@@ -292,23 +316,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->Show(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->Show(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->Show(); break;
       #endif
       case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->Show(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->Show(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->Show(); break;
       #endif
       case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->Show(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->Show(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->Show(); break;
       #endif
       case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->Show(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->Show(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->Show(); break;
       #endif
     #endif
@@ -345,23 +377,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: return (static_cast<B_32_RN_NEO_3*>(busPtr))->CanShow(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: return (static_cast<B_32_I0_NEO_3*>(busPtr))->CanShow(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: return (static_cast<B_32_I1_NEO_3*>(busPtr))->CanShow(); break;
       #endif
       case I_32_RN_NEO_4: return (static_cast<B_32_RN_NEO_4*>(busPtr))->CanShow(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: return (static_cast<B_32_I0_NEO_4*>(busPtr))->CanShow(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: return (static_cast<B_32_I1_NEO_4*>(busPtr))->CanShow(); break;
       #endif
       case I_32_RN_400_3: return (static_cast<B_32_RN_400_3*>(busPtr))->CanShow(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: return (static_cast<B_32_I0_400_3*>(busPtr))->CanShow(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: return (static_cast<B_32_I1_400_3*>(busPtr))->CanShow(); break;
       #endif
       case I_32_RN_TM1_4: return (static_cast<B_32_RN_TM1_4*>(busPtr))->CanShow(); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: return (static_cast<B_32_I0_TM1_4*>(busPtr))->CanShow(); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: return (static_cast<B_32_I1_TM1_4*>(busPtr))->CanShow(); break;
       #endif
     #endif
@@ -422,23 +462,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
       #endif
       case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetPixelColor(pix, col); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetPixelColor(pix, col); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetPixelColor(pix, col); break;
       #endif
       case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetPixelColor(pix, RgbColor(col.R,col.G,col.B)); break;
       #endif
       case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetPixelColor(pix, col); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetPixelColor(pix, col); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetPixelColor(pix, col); break;
       #endif
     #endif
@@ -475,23 +523,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetBrightness(b); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetBrightness(b); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetBrightness(b); break;
       #endif
       case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetBrightness(b); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetBrightness(b); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetBrightness(b); break;
       #endif
       case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetBrightness(b); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetBrightness(b); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetBrightness(b); break;
       #endif
       case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetBrightness(b); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetBrightness(b); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetBrightness(b); break;
       #endif
     #endif
@@ -529,23 +585,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: col = (static_cast<B_32_RN_NEO_3*>(busPtr))->GetPixelColor(pix); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: col = (static_cast<B_32_I0_NEO_3*>(busPtr))->GetPixelColor(pix); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: col = (static_cast<B_32_I1_NEO_3*>(busPtr))->GetPixelColor(pix); break;
       #endif
       case I_32_RN_NEO_4: col = (static_cast<B_32_RN_NEO_4*>(busPtr))->GetPixelColor(pix); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: col = (static_cast<B_32_I0_NEO_4*>(busPtr))->GetPixelColor(pix); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: col = (static_cast<B_32_I1_NEO_4*>(busPtr))->GetPixelColor(pix); break;
       #endif
       case I_32_RN_400_3: col = (static_cast<B_32_RN_400_3*>(busPtr))->GetPixelColor(pix); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: col = (static_cast<B_32_I0_400_3*>(busPtr))->GetPixelColor(pix); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: col = (static_cast<B_32_I1_400_3*>(busPtr))->GetPixelColor(pix); break;
       #endif
       case I_32_RN_TM1_4: col = (static_cast<B_32_RN_TM1_4*>(busPtr))->GetPixelColor(pix); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: col = (static_cast<B_32_I0_TM1_4*>(busPtr))->GetPixelColor(pix); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: col = (static_cast<B_32_I1_TM1_4*>(busPtr))->GetPixelColor(pix); break;
       #endif
     #endif
@@ -600,23 +664,31 @@ class PolyBus {
     #endif
     #ifdef ARDUINO_ARCH_ESP32
       case I_32_RN_NEO_3: delete (static_cast<B_32_RN_NEO_3*>(busPtr)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_3: delete (static_cast<B_32_I0_NEO_3*>(busPtr)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_3: delete (static_cast<B_32_I1_NEO_3*>(busPtr)); break;
       #endif
       case I_32_RN_NEO_4: delete (static_cast<B_32_RN_NEO_4*>(busPtr)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_NEO_4: delete (static_cast<B_32_I0_NEO_4*>(busPtr)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_NEO_4: delete (static_cast<B_32_I1_NEO_4*>(busPtr)); break;
       #endif
       case I_32_RN_400_3: delete (static_cast<B_32_RN_400_3*>(busPtr)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_400_3: delete (static_cast<B_32_I0_400_3*>(busPtr)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_400_3: delete (static_cast<B_32_I1_400_3*>(busPtr)); break;
       #endif
       case I_32_RN_TM1_4: delete (static_cast<B_32_RN_TM1_4*>(busPtr)); break;
+      #ifndef CONFIG_IDF_TARGET_ESP32C3
       case I_32_I0_TM1_4: delete (static_cast<B_32_I0_TM1_4*>(busPtr)); break;
-      #ifndef CONFIG_IDF_TARGET_ESP32S2
+      #endif
+      #if !defined(CONFIG_IDF_TARGET_ESP32S2) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       case I_32_I1_TM1_4: delete (static_cast<B_32_I1_TM1_4*>(busPtr)); break;
       #endif
     #endif

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -85,7 +85,7 @@ bool isButtonPressed(uint8_t i)
       if (digitalRead(btnPin[i]) == HIGH) return true;
       break;
     case BTN_TYPE_TOUCH:
-      #ifdef ARDUINO_ARCH_ESP32
+      #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
       if (touchRead(btnPin[i]) <= touchThreshold) return true;
       #endif
       break;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -573,7 +573,7 @@ void WLED::initConnection()
   if (staticIP[0] != 0 && staticGateway[0] != 0) {
     WiFi.config(staticIP, staticGateway, staticSubnet, IPAddress(1, 1, 1, 1));
   } else {
-    WiFi.config(0U, 0U, 0U);
+    WiFi.config(IPAddress((uint32_t)0), IPAddress((uint32_t)0), IPAddress((uint32_t)0));
   }
 
   lastReconnectAttempt = millis();


### PR DESCRIPTION
This is based on my other pull request for ESP32-S2: https://github.com/Aircoookie/WLED/pull/2452
Once it is merged I will rebase this PR as it requires same changes in ESPAsyncWebServer: https://github.com/Aircoookie/ESPAsyncWebServer/pull/4

Also this change requires ~~current master branch~~ version bump of:
- FastLED (3.5.0) because of: https://github.com/FastLED/FastLED/pull/1320
- IRremoteESP8266 (2.8.1) because of: https://github.com/crankyoldgit/IRremoteESP8266/commit/3f871e4b7989789fa0093548b4d7b7eb240f7908


**TODO**

https://github.com/espressif/arduino-esp32/issues/5502
```
Linking .pio/build/esp32c3/firmware.elf
/home/andre/.platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld: .pio/build/esp32c3/src/blynk.cpp.o: in function `BlynkApi<BlynkProtocol<BlynkArduinoClientGen<Client> > >::processCmd(void const*, unsigned int)':
/home/andre/git/WLED/wled00/src/dependencies/blynk/Blynk/BlynkApiArduino.h:93: undefined reference to `esp32_adc2gpio'
/home/andre/.platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld: /home/andre/git/WLED/wled00/src/dependencies/blynk/Blynk/BlynkApiArduino.h:93: undefined reference to `esp32_adc2gpio'
/home/andre/.platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld: /home/andre/git/WLED/wled00/src/dependencies/blynk/Blynk/BlynkApiArduino.h:95: undefined reference to `esp32_adc2gpio'
/home/andre/.platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld: /home/andre/git/WLED/wled00/src/dependencies/blynk/Blynk/BlynkApiArduino.h:101: undefined reference to `esp32_adc2gpio'
/home/andre/.platformio/packages/toolchain-riscv32-esp/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld: .pio/build/esp32c3/src/button.cpp.o: in function `isButtonPressed(unsigned char)':
/home/andre/git/WLED/wled00/button.cpp:89: undefined reference to `touchRead'
collect2: error: ld returned 1 exit status
*** [.pio/build/esp32c3/firmware.elf] Error 1
```