### PR TITLE
Improvements to usermod "MQTT switch"

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -65,6 +65,7 @@
 #define USERMOD_RGB_ROTARY_ENCODER       22     //Usermod "rgb-rotary-encoder.h"
 #define USERMOD_ID_QUINLED_AN_PENTA      23     //Usermod "quinled-an-penta.h"
 #define USERMOD_ID_SSDR                  24     //Usermod "usermod_v2_seven_segment_display_reloaded.h"
+#define USERMOD_ID_MQTT_SWITCH           25     //Usermod "usermod_mqtt_switch.h"
 
 //Access point behavior
 #define AP_BEHAVIOR_BOOT_NO_CONN          0     //Open AP when no connection after boot

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -53,7 +53,8 @@ enum struct PinOwner : uint8_t {
   // #define USERMOD_ID_ELEKSTUBE_IPS                   // 0x10 // Usermod "usermod_elekstube_ips.h" -- Uses quite a few pins ... see Hardware.h and User_Setup.h
   // #define USERMOD_ID_SN_PHOTORESISTOR                // 0x11 // Usermod "usermod_sn_photoresistor.h" -- Uses hard-coded pin (PHOTORESISTOR_PIN == A0), but could be easily updated to use pinManager
   UM_RGBRotaryEncoder  = USERMOD_RGB_ROTARY_ENCODER,    // 0x16 // Usermod "rgb-rotary-encoder.h"
-  UM_QuinLEDAnPenta    = USERMOD_ID_QUINLED_AN_PENTA    // 0x17 // Usermod "quinled-an-penta.h"
+  UM_QuinLEDAnPenta    = USERMOD_ID_QUINLED_AN_PENTA,   // 0x17 // Usermod "quinled-an-penta.h"
+  UM_MqttSwitch        = USERMOD_ID_MQTT_SWITCH,        // 0x19 // Usermod "usermod-mqtt-switch.h"
 };
 static_assert(0u == static_cast<uint8_t>(PinOwner::None), "PinOwner::None must be zero, so default array initialization works as expected");
 

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -108,6 +108,10 @@
 #include "../usermods/quinled-an-penta/quinled-an-penta.h"
 #endif
 
+#ifdef MQTTSWITCHPINS
+#include "../usermods/mqtt_switch_v2/usermod_mqtt_switch.h"
+#endif
+
 void registerUsermods()
 {
 /*
@@ -202,5 +206,9 @@ void registerUsermods()
 
   #ifdef QUINLED_AN_PENTA
   usermods.add(new QuinLEDAnPentaUsermod());
+  #endif
+
+  #ifdef MQTTSWITCHPINS
+  usermods.add(new UsermodMqttSwitch());
   #endif
 }


### PR DESCRIPTION
1) Automatically load this user mod when it is configured.
2) Use pin manager to track allocated pins.