### PR TITLE
Add define to set data pins to HIGH when relay is off

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -294,11 +294,6 @@ void esp32RMTInvertIdle()
     else if (lvl == RMT_IDLE_LEVEL_LOW) lvl = RMT_IDLE_LEVEL_HIGH;
     else continue;
     rmt_set_idle_level(ch, idle_out, lvl);
-    Serial.print(u);
-    Serial.print(" ");
-    Serial.print(idle_out);
-    Serial.print(" ");
-    Serial.println(lvl == RMT_IDLE_LEVEL_HIGH);
   }
 }
 

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -279,6 +279,7 @@ void handleButton()
   if (analog) lastRead = millis();
 }
 
+#ifdef ESP32_DATA_IDLE_HIGH
 void esp32RMTInvertIdle()
 {
   bool idle_out;
@@ -296,6 +297,7 @@ void esp32RMTInvertIdle()
     rmt_set_idle_level(ch, idle_out, lvl);
   }
 }
+#endif
 
 void handleIO()
 {

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -279,14 +279,17 @@ void handleButton()
   if (analog) lastRead = millis();
 }
 
+// If enabled, RMT idle level is set to HIGH when off
+// to prevent leakage current when using an N-channel MOSFET to toggle LED power
 #ifdef ESP32_DATA_IDLE_HIGH
 void esp32RMTInvertIdle()
 {
   bool idle_out;
   for (uint8_t u = 0; u < busses.getNumBusses(); u++)
   {
+    if (u > 7) return; // only 8 RMT channels, TODO: ESP32 variants have less RMT channels
     Bus *bus = busses.getBus(u);
-    if (!bus || bus->getLength()==0 || !IS_DIGITAL(bus->getType())) continue;
+    if (!bus || bus->getLength()==0 || !IS_DIGITAL(bus->getType()) || IS_2PIN(bus->getType())) continue;
     //assumes that bus number to rmt channel mapping stays 1:1
     rmt_channel_t ch = static_cast<rmt_channel_t>(u);
     rmt_idle_level_t lvl;


### PR DESCRIPTION
I'm using an IRF3708 MOSFET instead of a relay to disconnect the LEDs when WLED is off. Since it only disconnects GND and not +5V a LOW on the data pin creates a small leakage current which I didn't want. On ESP8266 the LED gets turned off so if the pin is shared with data there is no problem.
This PR adds a compile-time define (that one could set in the .ini file) that switches all configured digital data pins on ESP32 to HIGH using rmt_set_idle_level whlie the relay is off.
Tested with 2 SK6812 Strips connected to an esp32