### PR TITLE
Deprecate usermod mqtt_switch.

### DIFF
--- a/usermods/mqtt_switch_v2/README.md
+++ b/usermods/mqtt_switch_v2/README.md
@@ -1,3 +1,7 @@
+# DEPRECATION NOTICE
+This usermod is deprecated and no longer maintained. It will be removed in a future WLED release. Please use usermod multi_relay which has more features.
+
+
 # MQTT controllable switches
 This usermod allows controlling switches (e.g. relays) via MQTT.
 

--- a/usermods/mqtt_switch_v2/usermod_mqtt_switch.h
+++ b/usermods/mqtt_switch_v2/usermod_mqtt_switch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#warning "This usermod is deprecated and no longer maintained. It will be removed in a future WLED release. Please use usermod multi_relay which has more features."
+
 #include "wled.h"
 #ifndef WLED_ENABLE_MQTT
 #error "This user mod requires MQTT to be enabled."


### PR DESCRIPTION
Deprecate usermod mqtt_switch because with muli_relay a better alternative is available. Therefore I do not plan to maintain this usermod anymore. For now print a warning for existing users. After some time the code can be completely removed.