### PR TITLE
Use latest Arduino ESP32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -318,9 +318,8 @@ board_build.partitions = ${esp32.default_partitions}
 
 [env:esp32s2_saola]
 board = esp32-s2-saola-1
-platform = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.1/Tasmota-platform-espressif32.zip
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.1/platform-tasmota-espressif32-2.0.2.1.zip
 platform_packages =
-    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2
 framework = arduino
 board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 board_build.flash_mode = qio


### PR DESCRIPTION
build with IDF44-rc1 and Arduino from 21.01.2022. Toolchains updated to 8.4.0 2021r2-patch2
The platform can be used for ESP32, ESP32-S2 and ESP32-C3