### PR TITLE
Set default relay pin to 11 for ESP32C3

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -223,10 +223,12 @@ WLED_GLOBAL int8_t btnPin[WLED_MAX_BUTTONS] _INIT({0});
 #else
 WLED_GLOBAL int8_t btnPin[WLED_MAX_BUTTONS] _INIT({BTNPIN});
 #endif
-#ifndef RLYPIN
-WLED_GLOBAL int8_t rlyPin _INIT(12);
-#else
+#ifdef RLYPIN
 WLED_GLOBAL int8_t rlyPin _INIT(RLYPIN);
+#elif CONFIG_IDF_TARGET_ESP32C3
+WLED_GLOBAL int8_t rlyPin _INIT(11);
+#else
+WLED_GLOBAL int8_t rlyPin _INIT(12);
 #endif
 //Relay mode (1 = active high, 0 = active low, flipped in cfg.json)
 #ifndef RLYMDE


### PR DESCRIPTION
Pin 12 is by default SPIHD. If set during boot may effectively prevent
system from booting completely, what happened on my custom ESP32C3 based
board with extenal SPI flash.

I've seen multiple successful reports of booting ESP32C3 boards
without this change. My guess would be that those are using chips
with integrated flash which may be behaving differently. It doesn't
change the fact that according to datasheet using of pin 12-17 should
be avoided.