### PR TITLE
Old style multicolor christmas lights

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -780,6 +780,29 @@ uint16_t WS2812FX::mode_chase_random(void) {
   return chase(SEGCOLOR(1), (SEGCOLOR(2)) ? SEGCOLOR(2) : SEGCOLOR(0), SEGCOLOR(0), false);
 }
 
+/*
+ * Special chase which sets up like an old school multicolor light string.
+ */
+uint16_t WS2812FX::mode_chase_christmas(void) {
+  uint32_t cycleTime = 50 + ((255 - SEGMENT.speed)<<1);
+  uint32_t it = now / cycleTime;  // iterator
+  uint8_t width = (1 + (SEGMENT.intensity>>4)); // value of 1-16 for each colour
+  // static when speed is zero
+  uint8_t index = (SEGMENT.speed==0) ? width*5 : it % (width*5);
+  
+  for (uint16_t i = 0; i < SEGLEN; i++, index++) {
+    if (index > (width*5)-1) index = 0;
+
+    uint32_t color = RED;
+    if (index > 4*width-1) color = BLUE;
+    else if (index > 3*width-1) color = GREEN;
+    else if (index > 2*width-1) color = 0xFFC400;
+    else if (index > width-1) color = 0x9900FF;
+
+    setPixelColor(SEGLEN - i -1, color);
+  }
+  return FRAMETIME;
+}
 
 /*
  * Primary, secondary running on rainbow.

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1011,14 +1011,6 @@ uint16_t WS2812FX::mode_candy_cane(void) {
 }
 
 /*
- * Alternating orange/purple pixels running.
- */
-uint16_t WS2812FX::mode_halloween(void) {
-  return running(PURPLE, ORANGE);
-}
-
-
-/*
  * Random colored pixels running.
  */
 uint16_t WS2812FX::mode_running_random(void) {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -116,7 +116,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  118
+#define MODE_COUNT  119
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -236,6 +236,7 @@
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
 #define FX_MODE_DYNAMIC_SMOOTH         117
+#define FX_MODE_CHASE_CHRISTMAS        119
 
 
 class WS2812FX {
@@ -622,6 +623,7 @@ class WS2812FX {
       _mode[FX_MODE_BLENDS]                  = &WS2812FX::mode_blends;
       _mode[FX_MODE_TV_SIMULATOR]            = &WS2812FX::mode_tv_simulator;
       _mode[FX_MODE_DYNAMIC_SMOOTH]          = &WS2812FX::mode_dynamic_smooth;
+      _mode[FX_MODE_CHASE_CHRISTMAS]         = &WS2812FX::mode_chase_christmas;
 
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
@@ -820,6 +822,7 @@ class WS2812FX {
       mode_starburst(void),
       mode_exploding_fireworks(void),
       mode_bouncing_balls(void),
+      mode_chase_christmas(void),
       mode_sinelon(void),
       mode_sinelon_dual(void),
       mode_sinelon_rainbow(void),
@@ -940,7 +943,7 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
 "Heartbeat","Pacifica","Candle Multi", "Solid Glitter","Sunrise","Phased","Twinkleup","Noise Pal", "Sine","Phased Noise",
-"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth"
+"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth","Chase Christmas"
 ])=====";
 
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -116,7 +116,7 @@
 #define IS_REVERSE      ((SEGMENT.options & REVERSE     ) == REVERSE     )
 #define IS_SELECTED     ((SEGMENT.options & SELECTED    ) == SELECTED    )
 
-#define MODE_COUNT  119
+#define MODE_COUNT  118
 
 #define FX_MODE_STATIC                   0
 #define FX_MODE_BLINK                    1
@@ -171,7 +171,7 @@
 #define FX_MODE_TWO_DOTS                50
 #define FX_MODE_FAIRYTWINKLE            51  //was Two Areas prior to 0.13.0-b6 (use "Two Dots" with full intensity)
 #define FX_MODE_RUNNING_DUAL            52
-#define FX_MODE_HALLOWEEN               53  // candidate for removal
+#define FX_MODE_CHASE_CHRISTMAS         53  // was Halloween (now use Chase 2 with purple and orange)
 #define FX_MODE_TRICOLOR_CHASE          54
 #define FX_MODE_TRICOLOR_WIPE           55
 #define FX_MODE_TRICOLOR_FADE           56
@@ -236,7 +236,6 @@
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
 #define FX_MODE_DYNAMIC_SMOOTH         117
-#define FX_MODE_CHASE_CHRISTMAS        118
 
 
 class WS2812FX {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -555,7 +555,6 @@ class WS2812FX {
       _mode[FX_MODE_TWO_DOTS]                = &WS2812FX::mode_two_dots;
       _mode[FX_MODE_FAIRYTWINKLE]            = &WS2812FX::mode_fairytwinkle;
       _mode[FX_MODE_RUNNING_DUAL]            = &WS2812FX::mode_running_dual;
-      _mode[FX_MODE_HALLOWEEN]               = &WS2812FX::mode_halloween;
       _mode[FX_MODE_TRICOLOR_CHASE]          = &WS2812FX::mode_tricolor_chase;
       _mode[FX_MODE_TRICOLOR_WIPE]           = &WS2812FX::mode_tricolor_wipe;
       _mode[FX_MODE_TRICOLOR_FADE]           = &WS2812FX::mode_tricolor_fade;
@@ -773,7 +772,6 @@ class WS2812FX {
       mode_fireworks(void),
       mode_rain(void),
       mode_tetrix(void),
-      mode_halloween(void),
       mode_fire_flicker(void),
       mode_gradient(void),
       mode_loading(void),
@@ -936,13 +934,13 @@ const char JSON_mode_names[] PROGMEM = R"=====([
 "Sparkle","Sparkle Dark","Sparkle+","Strobe","Strobe Rainbow","Strobe Mega","Blink Rainbow","Android","Chase","Chase Random",
 "Chase Rainbow","Chase Flash","Chase Flash Rnd","Rainbow Runner","Colorful","Traffic Light","Sweep Random","Chase 2","Aurora","Stream",
 "Scanner","Lighthouse","Fireworks","Rain","Tetrix","Fire Flicker","Gradient","Loading","Police","Fairy",
-"Two Dots","Fairytwinkle","Running Dual","Halloween","Chase 3","Tri Wipe","Tri Fade","Lightning","ICU","Multi Comet",
+"Two Dots","Fairytwinkle","Running Dual","Chase Christmas","Chase 3","Tri Wipe","Tri Fade","Lightning","ICU","Multi Comet",
 "Scanner Dual","Stream 2","Oscillate","Pride 2015","Juggle","Palette","Fire 2012","Colorwaves","Bpm","Fill Noise",
 "Noise 1","Noise 2","Noise 3","Noise 4","Colortwinkles","Lake","Meteor","Meteor Smooth","Railway","Ripple",
 "Twinklefox","Twinklecat","Halloween Eyes","Solid Pattern","Solid Pattern Tri","Spots","Spots Fade","Glitter","Candle","Fireworks Starburst",
 "Fireworks 1D","Bouncing Balls","Sinelon","Sinelon Dual","Sinelon Rainbow","Popcorn","Drip","Plasma","Percent","Ripple Rainbow",
 "Heartbeat","Pacifica","Candle Multi", "Solid Glitter","Sunrise","Phased","Twinkleup","Noise Pal", "Sine","Phased Noise",
-"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth","Chase Christmas"
+"Flow","Chunchun","Dancing Shadows","Washing Machine","Candy Cane","Blends","TV Simulator","Dynamic Smooth"
 ])=====";
 
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -236,7 +236,7 @@
 #define FX_MODE_BLENDS                 115
 #define FX_MODE_TV_SIMULATOR           116
 #define FX_MODE_DYNAMIC_SMOOTH         117
-#define FX_MODE_CHASE_CHRISTMAS        119
+#define FX_MODE_CHASE_CHRISTMAS        118
 
 
 class WS2812FX {


### PR DESCRIPTION
One for later on.  This replicates old style multicolor christmas strings with 5 colours, either static (speed=0) or in a chase.  This is meant optimally for strings, but strips can look good with some spacing set.