### PR TITLE
Change Default Relay Pin to -1

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -225,7 +225,7 @@ WLED_GLOBAL int8_t btnPin[WLED_MAX_BUTTONS] _INIT({0});
 WLED_GLOBAL int8_t btnPin[WLED_MAX_BUTTONS] _INIT({BTNPIN});
 #endif
 #ifndef RLYPIN
-WLED_GLOBAL int8_t rlyPin _INIT(12);
+WLED_GLOBAL int8_t rlyPin _INIT(-1);
 #else
 WLED_GLOBAL int8_t rlyPin _INIT(RLYPIN);
 #endif


### PR DESCRIPTION
By default, relay pin is asigned to GPIO12. This may bring unwanted side-effects for WLED users. 
A few examples:
- debugging is not possible as JTAG uses GPIO12 for TDI
- using this pin for relay prevents booting of WLED on ESP32C3
- regardless of if you have a relay or not, this PIN will be initialised and therefore not usable until reassigned in settings

This PR changes default relay pin assignment to -1 resulting in better future stability, compatibility and allowing debuging. Of course it is possible to define RLYPIN when compiling own firmware, but given that PIN12 already caused problems in two use cases, it might be prefered to let users that actually use relay set their preferred pin explicitly.

Disclaimer: I am aware that default assigment of pins has been discussed before and this PR has no intention to re-start the discussion about general principles.
