### PR TITLE
Improve Pin Manager Debugging

### DIFF
--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -132,6 +132,13 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
     byte bi = gpio - 8*by;
     bitWrite(pinAlloc[by], bi, true);
     ownerTag[gpio] = tag;
+    #ifdef WLED_DEBUG
+    DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
+    DEBUG_PRINT(gpio);
+    DEBUG_PRINT(F(" allocated by "));
+    DebugPrintOwnerTag(tag);
+    DEBUG_PRINTLN(F(""));
+    #endif
   }
   return true;
 }
@@ -155,7 +162,14 @@ bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
   byte bi = gpio - 8*by;
   bitWrite(pinAlloc[by], bi, true);
   ownerTag[gpio] = tag;
-  
+  #ifdef WLED_DEBUG
+  DEBUG_PRINT(F("PIN ALLOC: Pin ")); 
+  DEBUG_PRINT(gpio);
+  DEBUG_PRINT(F(" allocated by "));
+  DebugPrintOwnerTag(tag);
+  DEBUG_PRINTLN(F(""));
+  #endif  
+
   return true;
 }
 


### PR DESCRIPTION
When compiled with WLED_DEBUG flag, pin manager will now provide information for each allocated pin.
Output example:
```
PIN ALLOC: Pin 1 allocated by 0x89 (137)
PIN ALLOC: Pin 2 allocated by 0x82 (130)
PIN ALLOC: Pin 0 allocated by 0x85 (133)
...
```