### PR TITLE
Fixed buffer overflow in HA autodiscovery. #2538

### DIFF
--- a/usermods/multi_relay/usermod_multi_relay.h
+++ b/usermods/multi_relay/usermod_multi_relay.h
@@ -272,7 +272,7 @@ class MultiRelay : public Usermod {
 
     void publishHomeAssistantAutodiscovery() {
       for (uint8_t i = 0; i < MULTI_RELAY_MAX_RELAYS; i++) {
-        char uid[16], json_str[1024], buf[128];
+        char uid[24], json_str[1024], buf[128];
         size_t payload_size;
         sprintf_P(uid, PSTR("%s_sw%d"), escapedMac.c_str(), i);
 


### PR DESCRIPTION
Resized buffer from 16 to 24 char's. 

Maybe @blazoncek could have a look at the change.

If you think resize by 8 bytes is too much, feel free to change the size to anything > 16 chars.

As mentioned in the issue: this is my first PR. So hints and help is very welcome.