### PR TITLE
Mixed content exception on websocket behind an https backproxy.

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1000,7 +1000,7 @@ function reconnectWS() {
 
 function makeWS() {
 	if (ws) return;
-	ws = new WebSocket('ws://'+(loc?locip:window.location.hostname)+'/ws');
+	ws = new WebSocket((window.location.protocol == 'https:'?'wss':'ws')+'://'+(loc?locip:window.location.hostname)+'/ws');
 	ws.binaryType = "arraybuffer";
 	ws.onmessage = function(event) {
 		if (event.data instanceof ArrayBuffer) return; //liveview packet

--- a/wled00/data/liveviewws.htm
+++ b/wled00/data/liveviewws.htm
@@ -51,7 +51,7 @@
       ws.send("{'lv':true}");
     } else {
       console.info("Peek WS opening");
-      ws = new WebSocket("ws://"+document.location.host+"/ws");
+      ws = new WebSocket((window.location.protocol == "https:"?"wss":"ws")+"://"+document.location.host+"/ws");
       ws.onopen = function () {
         console.info("Peek WS open");
         ws.send("{'lv':true}");


### PR DESCRIPTION
Mixed content exception in web browser in websocket communication on peek behind an https backproxy.

"ws://" must be the change to the "wss://" for encryption


![image](https://user-images.githubusercontent.com/29116097/157053243-3471adcc-1f40-4669-af61-cec627a99ba9.png)
