### PR TITLE
Add option to set module name at runtime, and add extra examples in platformio_overrides.ini

### DIFF
--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -44,3 +44,6 @@ build_flags = ${common.build_flags_esp8266}
 ;   for the Magic Home LED Controller use PWM pins 5,12,13,15
 ;   for the H801 controller use PINs 15,13,12,14 (W2 = 04)
 ;   for the BW-LT11 controller use PINs 12,4,14,5
+;   
+; set the name of the module - make sure there is a quote-backslash-quote before the name and a backslash-quote-quote after the name
+;   -D SERVERNAME="\"WLED\""

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -55,6 +55,9 @@ build_flags = ${common.build_flags_esp8266}
 ;   
 ; set the number of LEDs
 ;   -DEFAULT_LED_COUNT=30
+;   
+; set milliampere limit when using ESP pin to power leds
+;   -D ABL_MILLIAMPS_DEFAULT =850
 ;
 ; enable IR by setting remote type
 ;   -D IRTYPE=0 //0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -19,6 +19,11 @@ build_flags = ${common.build_flags_esp8266}
 ; *** Use custom settings from file my_config.h
    -DWLED_USE_MY_CONFIG
 ; *********************************************************************
+;
+;
+; *** To use the below defines/overrides, copy and paste each onto it's own line just below build_flags in the section above.
+; 
+; disable specific features
 ;  -D WLED_DISABLE_OTA
 ;  -D WLED_DISABLE_ALEXA
 ;  -D WLED_DISABLE_BLYNK

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -50,3 +50,6 @@ build_flags = ${common.build_flags_esp8266}
 ;   
 ; set the number of LEDs
 ;   -DEFAULT_LED_COUNT=30
+;
+; enable IR by setting remote type
+;   -D IRTYPE=0 //0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -54,7 +54,7 @@ build_flags = ${common.build_flags_esp8266}
 ;   -D SERVERNAME="\"WLED\""
 ;   
 ; set the number of LEDs
-;   -DEFAULT_LED_COUNT=30
+;   -D DEFAULT_LED_COUNT=30
 ;   
 ; set milliampere limit when using ESP pin to power leds
 ;   -D ABL_MILLIAMPS_DEFAULT =850

--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -47,3 +47,6 @@ build_flags = ${common.build_flags_esp8266}
 ;   
 ; set the name of the module - make sure there is a quote-backslash-quote before the name and a backslash-quote-quote after the name
 ;   -D SERVERNAME="\"WLED\""
+;   
+; set the number of LEDs
+;   -DEFAULT_LED_COUNT=30

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -293,7 +293,11 @@ WLED_GLOBAL uint16_t transitionDelay _INIT(750);    // default crossfade duratio
 WLED_GLOBAL byte briMultiplier _INIT(100);          // % of brightness to set (to limit power, if you set it to 50 and set bri to 255, actual brightness will be 127)
 
 // User Interface CONFIG
-WLED_GLOBAL char serverDescription[33] _INIT("WLED");  // Name of module
+#ifndef SERVERNAME
+WLED_GLOBAL char serverDescription[33] _INIT("WLED");  // Name of module - use default
+#else
+WLED_GLOBAL char serverDescription[33] _INIT(SERVERNAME);  // use predefined name
+#endif
 WLED_GLOBAL bool syncToggleReceive     _INIT(false);   // UIs which only have a single button for sync should toggle send+receive if this is true, only send otherwise
 
 // Sync CONFIG


### PR DESCRIPTION
This modifies wled.h to allow for defining a name at runtime that will be used for the module name.

Also adds some examples to platformio_overrides.ini for some handy defines that can be used to set up your light at runtime.
This also has the added benefit that when you use the "Factory reset" in Security & Updates, WLED stays properly configured for the hardware it's attached to.