### PR TITLE
ABL milliamps no longer hardcoded to 850 at runtime

### DIFF
--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -57,7 +57,7 @@ build_flags = ${common.build_flags_esp8266}
 ;   -D DEFAULT_LED_COUNT=30
 ;   
 ; set milliampere limit when using ESP pin to power leds
-;   -D ABL_MILLIAMPS_DEFAULT =850
+;   -D ABL_MILLIAMPS_DEFAULT=850
 ;
 ; enable IR by setting remote type
 ;   -D IRTYPE=0 //0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -609,7 +609,7 @@ class WS2812FX {
       _brightness = DEFAULT_BRIGHTNESS;
       currentPalette = CRGBPalette16(CRGB::Black);
       targetPalette = CloudColors_p;
-      ablMilliampsMax = 850;
+      ablMilliampsMax = ABL_MILLIAMPS_DEFAULT;
       currentMilliamps = 0;
       timebase = 0;
       resetSegments();

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -292,7 +292,13 @@
   #endif
 #endif
 
-#define ABL_MILLIAMPS_DEFAULT 850  // auto lower brightness to stay close to milliampere limit
+#ifndef ABL_MILLIAMPS_DEFAULT
+  #define ABL_MILLIAMPS_DEFAULT 850  // auto lower brightness to stay close to milliampere limit
+#else
+  #if ABL_MILLIAMPS_DEFAULT < 250  // make sure value is at least 250
+   #define ABL_MILLIAMPS_DEFAULT 250
+  #endif
+#endif
 
 // PWM settings
 #ifndef WLED_PWM_FREQ


### PR DESCRIPTION
In a previous pull request I added "-D ABL_MILLIAMPS_DEFAULT", but it turns out that it didn't actually work because that variable wasn't applied everywhere it should have and was getting hard coded to 850. I also added a little math to make sure that if you use this -D override then it will always be at least 250 (I'm not exactly sure where 250 comes from, but if you try to set it to less than 250 in the GUI it gives a warning and won't let you save).