### PR TITLE
Optionally set led strip color order at runtime.

### DIFF
--- a/platformio_override.ini.sample
+++ b/platformio_override.ini.sample
@@ -60,4 +60,7 @@ build_flags = ${common.build_flags_esp8266}
 ;   -D ABL_MILLIAMPS_DEFAULT =850
 ;
 ; enable IR by setting remote type
-;   -D IRTYPE=0 //0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote
+;   -D IRTYPE=0 ;0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote
+;   
+; set default color order of your led strip
+;   -D DEFAULT_LED_COLOR_ORDER=COL_ORDER_GRB

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -60,6 +60,11 @@
   #define DEFAULT_LED_TYPE TYPE_WS2812_RGB
 #endif
 
+#ifndef DEFAULT_LED_COLOR_ORDER
+  #define DEFAULT_LED_COLOR_ORDER COL_ORDER_GRB  //default to GRB
+#endif
+
+
 #if MAX_NUM_SEGMENTS < WLED_MAX_BUSSES
   #error "Max segments must be at least max number of busses!"
 #endif
@@ -87,7 +92,7 @@ void WS2812FX::finalizeInit(void)
       uint16_t start = prevLen;
       uint16_t count = defCounts[(i < defNumCounts) ? i : defNumCounts -1];
       prevLen += count;
-      BusConfig defCfg = BusConfig(DEFAULT_LED_TYPE, defPin, start, count, COL_ORDER_GRB);
+      BusConfig defCfg = BusConfig(DEFAULT_LED_TYPE, defPin, start, count, DEFAULT_LED_COLOR_ORDER);
       busses.add(defCfg);
     }
   }


### PR DESCRIPTION
Added new variable/option so that you can set the color order of your LEDs at runtime.
This allows you to set some of the characteristics of your (often) hardwired lights and other components, and these settings persist after a factory reset. This is good for if you make a light to give as a gift or if you sell lights that use WLED. (A user shouldn't have to know how many LEDs are in the light or what color order they use, or know what pins the controller uses, etc.)