### PR TITLE
bugfix for outgoing serial TPM2 message length

### DIFF
--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -86,8 +86,8 @@ void handleSerial()
             Serial.write(0xC9); Serial.write(0xDA);
             uint16_t used = strip.getLengthTotal();
             uint16_t len = used*3;
-            Serial.write((len << 8) & 0xFF);
-            Serial.write( len       & 0xFF);
+            Serial.write(highByte(len));
+            Serial.write(lowByte(len));
             for (uint16_t i=0; i < used; i++) {
               uint32_t c = strip.getPixelColor(i);
               Serial.write(qadd8(W(c), R(c))); //R, add white channel to RGB channels as a simple RGBW -> RGB map


### PR DESCRIPTION
Quick fix for a bug in the return serial TPM2 payload size.

Previous method was not correctly sending the high-byte, limiting the amount of LED data able to be sent over serial TPM2 to 85 LEDs before the low-byte rolled over, making the payload size inaccurate for decoding the packet.

