### PR TITLE
wled.cpp: Wrap Serial calls in `#ifdef WLED_ENABLE_ADALIGHT`.

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -389,7 +389,9 @@ void WLED::setup()
     sprintf(mqttClientID + 5, "%*s", 6, escapedMac.c_str() + 6);
   }
 
+#ifdef WLED_ENABLE_ADALIGHT
   if (Serial.available() > 0 && Serial.peek() == 'I') handleImprovPacket();
+#endif
 
   strip.service();
 
@@ -409,7 +411,10 @@ void WLED::setup()
   initDMX();
 #endif
 
+#ifdef WLED_ENABLE_ADALIGHT
   if (Serial.available() > 0 && Serial.peek() == 'I') handleImprovPacket();
+#endif
+
   // HTTP server page init
   initServer();
 


### PR DESCRIPTION
`handleImprovPacket()` unconditionally gobbles serial data which a problem if we want another feature to consume it. 

This patch uses the same guard as the existing call in `handleSerial()`.