### PR TITLE
Working DMX Libraries

### DIFF
--- a/wled00/dmx.cpp
+++ b/wled00/dmx.cpp
@@ -17,9 +17,15 @@ void handleDMX()
   // don't act, when in DMX Proxy mode
   if (e131ProxyUniverse != 0) return;
 
-  // TODO: calculate brightness manually if no shutter channel is set
-
   uint8_t brightness = strip.getBrightness();
+
+  bool calc_brightness = true;
+
+   // check if no shutter channel is set
+   for (byte i = 0; i < DMXChannels; i++)
+   {
+     if (DMXFixtureMap[i] == 5) calc_brightness = false;
+   }
 
   uint16_t len = strip.getLengthTotal();
   for (int i = DMXStartLED; i < len; i++) {        // uses the amount of LEDs as fixture count
@@ -38,16 +44,16 @@ void handleDMX()
           dmx.write(DMXAddr, 0);
           break;
         case 1:        // Red
-          dmx.write(DMXAddr, r);
+          dmx.write(DMXAddr, calc_brightness ? (r * brightness) / 255 : r);
           break;
         case 2:        // Green
-          dmx.write(DMXAddr, g);
+          dmx.write(DMXAddr, calc_brightness ? (g * brightness) / 255 : g);
           break;
         case 3:        // Blue
-          dmx.write(DMXAddr, b);
+          dmx.write(DMXAddr, calc_brightness ? (b * brightness) / 255 : b);
           break;
         case 4:        // White
-          dmx.write(DMXAddr, w);
+          dmx.write(DMXAddr, calc_brightness ? (w * brightness) / 255 : w);
           break;
         case 5:        // Shutter channel. Controls the brightness.
           dmx.write(DMXAddr, brightness);

--- a/wled00/dmx.cpp
+++ b/wled00/dmx.cpp
@@ -1,10 +1,13 @@
 #include "wled.h"
 
 /*
- * Support for DMX via MAX485.
- * Change the output pin in src/dependencies/ESPDMX.cpp if needed.
- * Library from:
+ * Support for DMX Output via MAX485.
+ * Change the output pin in src/dependencies/ESPDMX.cpp, if needed (ESP8266)
+ * Change the output pin in src/dependencies/SparkFunDMX.cpp, if needed (ESP32)
+ * ESP8266 Library from:
  * https://github.com/Rickgg/ESP-Dmx
+ * ESP32 Library from:
+ * https://github.com/sparkfun/SparkFunDMX
  */
 
 #ifdef WLED_ENABLE_DMX
@@ -60,7 +63,11 @@ void handleDMX()
 }
 
 void initDMX() {
+ #ifdef ESP8266
   dmx.init(512);        // initialize with bus length
+ #else
+  dmx.initWrite(512);  // initialize with bus length
+ #endif  
 }
 
 #else

--- a/wled00/src/dependencies/dmx/ESPDMX.cpp
+++ b/wled00/src/dependencies/dmx/ESPDMX.cpp
@@ -11,6 +11,8 @@
 // - - - - -
 
 /* ----- LIBRARIES ----- */
+#ifdef ESP8266
+
 #include <Arduino.h>
 
 #include "ESPDMX.h"
@@ -103,3 +105,5 @@ void DMXESPSerial::update() {
 }
 
 // Function to update the DMX bus
+
+#endif

--- a/wled00/src/dependencies/dmx/ESPDMX.cpp
+++ b/wled00/src/dependencies/dmx/ESPDMX.cpp
@@ -29,12 +29,12 @@ bool dmxStarted = false;
 int sendPin = 2;		//dafault on ESP8266
 
 //DMX value array and size. Entry 0 will hold startbyte
-uint8_t dmxData[dmxMaxChannel] = {};
-int chanSize;
+uint8_t dmxDataStore[dmxMaxChannel] = {};
+int channelSize;
 
 
 void DMXESPSerial::init() {
-  chanSize = defaultMax;
+  channelSize = defaultMax;
 
   Serial1.begin(DMXSPEED);
   pinMode(sendPin, OUTPUT);
@@ -48,7 +48,7 @@ void DMXESPSerial::init(int chanQuant) {
     chanQuant = defaultMax;
   }
 
-  chanSize = chanQuant;
+  channelSize = chanQuant;
 
   Serial1.begin(DMXSPEED);
   pinMode(sendPin, OUTPUT);
@@ -61,7 +61,7 @@ uint8_t DMXESPSerial::read(int Channel) {
 
   if (Channel < 1) Channel = 1;
   if (Channel > dmxMaxChannel) Channel = dmxMaxChannel;
-  return(dmxData[Channel]);
+  return(dmxDataStore[Channel]);
 }
 
 // Function to send DMX data
@@ -69,15 +69,15 @@ void DMXESPSerial::write(int Channel, uint8_t value) {
   if (dmxStarted == false) init();
 
   if (Channel < 1) Channel = 1;
-  if (Channel > chanSize) Channel = chanSize;
+  if (Channel > channelSize) Channel = channelSize;
   if (value < 0) value = 0;
   if (value > 255) value = 255;
 
-  dmxData[Channel] = value;
+  dmxDataStore[Channel] = value;
 }
 
 void DMXESPSerial::end() {
-  chanSize = 0;
+  channelSize = 0;
   Serial1.end();
   dmxStarted = false;
 }
@@ -96,7 +96,7 @@ void DMXESPSerial::update() {
   //send data
   Serial1.begin(DMXSPEED, DMXFORMAT);
   digitalWrite(sendPin, LOW);
-  Serial1.write(dmxData, chanSize);
+  Serial1.write(dmxDataStore, channelSize);
   Serial1.flush();
   delay(1);
   Serial1.end();

--- a/wled00/src/dependencies/dmx/LICENSE.md
+++ b/wled00/src/dependencies/dmx/LICENSE.md
@@ -1,0 +1,55 @@
+SparkFun License Information
+============================
+
+SparkFun uses two different licenses for our files — one for hardware and one for code.
+
+Hardware
+---------
+
+**SparkFun hardware is released under [Creative Commons Share-alike 4.0 International](http://creativecommons.org/licenses/by-sa/4.0/).**
+
+Note: This is a human-readable summary of (and not a substitute for) the [license](http://creativecommons.org/licenses/by-sa/4.0/legalcode).
+
+You are free to:
+
+Share — copy and redistribute the material in any medium or format
+Adapt — remix, transform, and build upon the material
+for any purpose, even commercially.
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+
+
+Code
+--------
+
+**SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).**
+
+The MIT License (MIT)
+
+Copyright (c) 2016 SparkFun Electronics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -1,0 +1,153 @@
+/******************************************************************************
+SparkFunDMX.h
+Arduino Library for the SparkFun ESP32 LED to DMX Shield
+Andy England @ SparkFun Electronics
+7/22/2019
+
+Development environment specifics:
+Arduino IDE 1.6.4
+
+This code is released under the [MIT License](http://opensource.org/licenses/MIT).
+Please review the LICENSE.md file included with this example. If you have any questions 
+or concerns with licensing, please contact techsupport@sparkfun.com.
+Distributed as-is; no warranty is given.
+******************************************************************************/
+
+/* ----- LIBRARIES ----- */
+#include <Arduino.h>
+
+#include "SparkFunDMX.h"
+#include <HardwareSerial.h>
+
+#define dmxMaxChannel  513
+#define defaultMax 32
+
+#define DMXSPEED       250000
+#define DMXFORMAT      SERIAL_8N2
+
+int enablePin = 26;		// disable the enable pin because it is not needed
+int rxPin = 25;       // disable the receiving pin because it is not needed
+int txPin = 2;        // transmit DMX data over this pin (default is pin 2)
+
+//DMX value array and size. Entry 0 will hold startbyte
+uint8_t dmxData[dmxMaxChannel] = {};
+int chanSize;
+int currentChannel = 0;
+
+HardwareSerial DMXSerial(2);
+
+/* Interrupt Timer for DMX Receive */
+hw_timer_t * timer = NULL;
+portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
+
+volatile int _interruptCounter;
+volatile bool _startCodeDetected = false;
+
+
+/* Start Code is detected by 21 low interrupts */
+void IRAM_ATTR onTimer() {
+	if (digitalRead(rxPin) == 1)
+	{
+		_interruptCounter = 0; //If the RX Pin is high, we are not in an interrupt
+	}
+	else
+	{
+		_interruptCounter++;
+	}
+	if (_interruptCounter > 9)
+	{	
+		portENTER_CRITICAL_ISR(&timerMux);
+		_startCodeDetected = true;
+		DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);
+		portEXIT_CRITICAL_ISR(&timerMux);
+		_interruptCounter = 0;
+	}
+}
+
+void SparkFunDMX::initRead(int chanQuant) {
+	
+  timer = timerBegin(0, 1, true);
+  timerAttachInterrupt(timer, &onTimer, true);
+  timerAlarmWrite(timer, 320, true);
+  timerAlarmEnable(timer);
+  _READWRITE = _READ;
+  if (chanQuant > dmxMaxChannel || chanQuant <= 0) 
+  {
+    chanQuant = defaultMax;
+  }
+  chanSize = chanQuant;
+  pinMode(enablePin, OUTPUT);
+  digitalWrite(enablePin, LOW);
+  pinMode(rxPin, INPUT);
+}
+
+// Set up the DMX-Protocol
+void SparkFunDMX::initWrite (int chanQuant) {
+
+  _READWRITE = _WRITE;
+  if (chanQuant > dmxMaxChannel || chanQuant <= 0) {
+    chanQuant = defaultMax;
+  }
+
+  chanSize = chanQuant + 1; //Add 1 for start code
+
+  DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);
+  pinMode(enablePin, OUTPUT);
+  digitalWrite(enablePin, HIGH);
+}
+
+// Function to read DMX data
+uint8_t SparkFunDMX::read(int Channel) {
+  if (Channel > chanSize) Channel = chanSize;
+  return(dmxData[Channel - 1]); //subtract one to account for start byte
+}
+
+// Function to send DMX data
+void SparkFunDMX::write(int Channel, uint8_t value) {
+  if (Channel < 0) Channel = 0;
+  if (Channel > chanSize) chanSize = Channel;
+  dmxData[0] = 0;
+  dmxData[Channel] = value; //add one to account for start byte
+}
+
+
+
+void SparkFunDMX::update() {
+  if (_READWRITE == _WRITE)
+  {
+	DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
+    pinMatrixOutDetach(txPin, false, false); //Detach our
+    pinMode(txPin, OUTPUT); 
+    digitalWrite(txPin, LOW); //88 uS break
+    delayMicroseconds(88);  
+    digitalWrite(txPin, HIGH); //4 Us Mark After Break
+    delayMicroseconds(1);
+    pinMatrixOutAttach(txPin, U2TXD_OUT_IDX, false, false);
+
+    DMXSerial.write(dmxData, chanSize);
+    DMXSerial.flush();
+    DMXSerial.end();//clear our DMX array, end the Hardware Serial port
+  }
+  else if (_READWRITE == _READ)//In a perfect world, this function ends serial communication upon packet completion and attaches RX to a CHANGE interrupt so the start code can be read again
+  { 
+	if (_startCodeDetected == true)
+	{
+		while (DMXSerial.available())
+		{
+			dmxData[currentChannel++] = DMXSerial.read();
+		}
+	if (currentChannel > chanSize) //Set the channel counter back to 0 if we reach the known end size of our packet
+	{
+		
+      portENTER_CRITICAL(&timerMux);
+	  _startCodeDetected = false;
+	  DMXSerial.flush();
+	  DMXSerial.end();
+      portEXIT_CRITICAL(&timerMux);
+	  currentChannel = 0;
+	}
+	}
+  }
+}
+
+// Function to update the DMX bus

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -14,6 +14,8 @@ Distributed as-is; no warranty is given.
 ******************************************************************************/
 
 /* ----- LIBRARIES ----- */
+#ifdef ESP32
+
 #include <Arduino.h>
 
 #include "SparkFunDMX.h"
@@ -151,3 +153,5 @@ void SparkFunDMX::update() {
 }
 
 // Function to update the DMX bus
+
+#endif

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -21,14 +21,14 @@ Distributed as-is; no warranty is given.
 #include "SparkFunDMX.h"
 #include <HardwareSerial.h>
 
-#define dmxMaxChannel  513
+#define dmxMaxChannel  512
 #define defaultMax 32
 
 #define DMXSPEED       250000
 #define DMXFORMAT      SERIAL_8N2
 
-int enablePin = 26;		// disable the enable pin because it is not needed
-int rxPin = 25;       // disable the receiving pin because it is not needed
+int enablePin = -1;		// disable the enable pin because it is not needed
+int rxPin = -1;       // disable the receiving pin because it is not needed
 int txPin = 2;        // transmit DMX data over this pin (default is pin 2)
 
 //DMX value array and size. Entry 0 will hold startbyte

--- a/wled00/src/dependencies/dmx/SparkFunDMX.cpp
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.cpp
@@ -26,6 +26,8 @@ Distributed as-is; no warranty is given.
 
 #define DMXSPEED       250000
 #define DMXFORMAT      SERIAL_8N2
+#define BREAKSPEED     83333
+#define BREAKFORMAT    SERIAL_8N1
 
 int enablePin = -1;		// disable the enable pin because it is not needed
 int rxPin = -1;       // disable the receiving pin because it is not needed
@@ -117,15 +119,16 @@ void SparkFunDMX::write(int Channel, uint8_t value) {
 void SparkFunDMX::update() {
   if (_READWRITE == _WRITE)
   {
-	DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
-    pinMatrixOutDetach(txPin, false, false); //Detach our
-    pinMode(txPin, OUTPUT); 
-    digitalWrite(txPin, LOW); //88 uS break
-    delayMicroseconds(88);  
-    digitalWrite(txPin, HIGH); //4 Us Mark After Break
-    delayMicroseconds(1);
-    pinMatrixOutAttach(txPin, U2TXD_OUT_IDX, false, false);
-
+    //Send DMX break
+    digitalWrite(txPin, HIGH);
+    DMXSerial.begin(BREAKSPEED, BREAKFORMAT, rxPin, txPin);//Begin the Serial port
+    DMXSerial.write(0);
+    DMXSerial.flush();
+    delay(1);
+    DMXSerial.end();
+    
+    //Send DMX data
+    DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
     DMXSerial.write(dmxData, chanSize);
     DMXSerial.flush();
     DMXSerial.end();//clear our DMX array, end the Hardware Serial port

--- a/wled00/src/dependencies/dmx/SparkFunDMX.h
+++ b/wled00/src/dependencies/dmx/SparkFunDMX.h
@@ -1,0 +1,38 @@
+/******************************************************************************
+SparkFunDMX.h
+Arduino Library for the SparkFun ESP32 LED to DMX Shield
+Andy England @ SparkFun Electronics
+7/22/2019
+
+Development environment specifics:
+Arduino IDE 1.6.4
+
+This code is released under the [MIT License](http://opensource.org/licenses/MIT).
+Please review the LICENSE.md file included with this example. If you have any questions 
+or concerns with licensing, please contact techsupport@sparkfun.com.
+Distributed as-is; no warranty is given.
+******************************************************************************/
+
+#include <inttypes.h>
+
+
+#ifndef SparkFunDMX_h
+#define SparkFunDMX_h
+
+// ---- Methods ----
+
+class SparkFunDMX {
+public:
+  void initRead(int maxChan);
+  void initWrite(int maxChan);
+  uint8_t read(int Channel);
+  void write(int channel, uint8_t value);
+  void update();
+private:
+  uint8_t _startCodeValue = 0xFF;
+  bool _READ = true;
+  bool _WRITE = false;
+  bool _READWRITE;
+};
+
+#endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -111,7 +111,11 @@
 #endif
 
 #ifdef WLED_ENABLE_DMX
+ #ifdef ESP8266
   #include "src/dependencies/dmx/ESPDMX.h"
+ #else //ESP32
+  #include "src/dependencies/dmx/SparkFunDMX.h"
+ #endif  
 #endif
 
 #include "src/dependencies/e131/ESPAsyncE131.h"
@@ -347,7 +351,11 @@ WLED_GLOBAL bool arlsDisableGammaCorrection _INIT(true);          // activate if
 WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to force max brightness if source has very dark colors that would be black
 
 #ifdef WLED_ENABLE_DMX
-WLED_GLOBAL DMXESPSerial dmx;
+ #ifdef ESP8266
+  WLED_GLOBAL DMXESPSerial dmx;
+ #else //ESP32
+  WLED_GLOBAL SparkFunDMX dmx; 
+ #endif 
 WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this E1.31 (sACN) / ArtNet universe via MAX485 (0 = disabled)
 #endif
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)


### PR DESCRIPTION
Since the ESPDMX library doesn't work with ESP32, and the SparkFunDMX library doesn't work on the ESP8266, this PR selects and uses the appropriate library for the given microprocessor.

- Uses ESPDMX library for ESP8266
- Uses SparkFunDMX library for ESP32
- Corrects DMX color brightness when shutter channel is lacking

Tested and working on WT32-ETH01, ESP-WROOM-32, and ESP8266.