### PR TITLE
Enable ESP watchdog by default

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -287,6 +287,35 @@ void WLED::loop()
 #endif
 }
 
+void WLED::enableWatchdog() {
+#if WLED_WATCHDOG_TIMEOUT > 0
+#ifdef ARDUINO_ARCH_ESP32
+  esp_err_t watchdog = esp_task_wdt_init(WLED_WATCHDOG_TIMEOUT, true);
+  DEBUG_PRINT(F("Watchdog enabled: "));
+  if (watchdog == ESP_OK) {
+    DEBUG_PRINTLN(F("OK"));
+  } else {
+    DEBUG_PRINTLN(watchdog);
+    return;
+  }
+  esp_task_wdt_add(NULL);
+#else
+  ESP.wdtEnable(WLED_WATCHDOG_TIMEOUT * 1000);
+#endif
+#endif
+}
+
+void WLED::disableWatchdog() {
+#if WLED_WATCHDOG_TIMEOUT > 0
+DEBUG_PRINTLN(F("Watchdog: disabled"));
+#ifdef ARDUINO_ARCH_ESP32
+  esp_task_wdt_delete(NULL);
+#else
+  ESP.wdtDisable();
+#endif
+#endif
+}
+
 void WLED::setup()
 {
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
@@ -311,21 +340,7 @@ void WLED::setup()
   DEBUG_PRINT(F("heap "));
   DEBUG_PRINTLN(ESP.getFreeHeap());
 
-#if WLED_WATCHDOG_TIMEOUT > 0
-#ifdef ARDUINO_ARCH_ESP32
-  esp_err_t watchdog = esp_task_wdt_init(WLED_WATCHDOG_TIMEOUT, true);
-  DEBUG_PRINT(F("Enable watchdog "));
-  if (watchdog == ESP_OK) {
-    DEBUG_PRINTLN(F(" OK"));
-  } else {
-    DEBUG_PRINTLN(watchdog);
-  }
-  esp_task_wdt_add(NULL);
-#else
-  // any timeout possible ?
-  ESP.wdtEnable(WLED_WATCHDOG_TIMEOUT * 1000);
-#endif
-#endif
+  enableWatchdog();
 
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_PSRAM)
   if (psramFound()) {
@@ -426,7 +441,12 @@ void WLED::setup()
 #ifdef ESP8266
       wifi_set_sleep_type(NONE_SLEEP_T);
 #endif
+      WLED::instance().disableWatchdog();
       DEBUG_PRINTLN(F("Start ArduinoOTA"));
+    });
+    ArduinoOTA.onError([](ota_error_t error) {
+      // reenable watchdog on failed update
+      WLED::instance().enableWatchdog();
     });
     if (strlen(cmDNS) > 0)
       ArduinoOTA.setHostname(cmDNS);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -49,6 +49,12 @@
 // filesystem specific debugging
 //#define WLED_DEBUG_FS
 
+#ifndef WLED_WATCHDOG_TIMEOUT
+  // 3 seconds should be enough to detect a lockup
+  // define WLED_WATCHDOG_TIMEOUT=0 to disable watchdog
+  #define WLED_WATCHDOG_TIMEOUT 3
+#endif
+
 //optionally disable brownout detector on ESP32.
 //This is generally a terrible idea, but improves boot success on boards with a 3.3v regulator + cap setup that can't provide 400mA peaks
 //#define WLED_DISABLE_BROWNOUT_DET
@@ -78,6 +84,7 @@
   #else
     #include <LittleFS.h>
   #endif
+  #include "esp_task_wdt.h"
 #endif
 
 #include "src/dependencies/network/Network.h"

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -703,5 +703,7 @@ public:
   void initConnection();
   void initInterfaces();
   void handleStatusLED();
+  void enableWatchdog();
+  void disableWatchdog();
 };
 #endif        // WLED_H

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -203,6 +203,7 @@ void initServer()
     },[](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final){
       if(!index){
         DEBUG_PRINTLN(F("OTA Update Start"));
+        WLED::instance().disableWatchdog();
         #ifdef ESP8266
         Update.runAsync(true);
         #endif
@@ -214,6 +215,7 @@ void initServer()
           DEBUG_PRINTLN(F("Update Success"));
         } else {
           DEBUG_PRINTLN(F("Update Failed"));
+          WLED::instance().enableWatchdog();
         }
       }
     });


### PR DESCRIPTION
Use the ESP watchdog to detect hanging ESP and reset the firmware.
Can be disable by defining WLED_WATCHDOG_TIMOUT 0
Default timeout is 3 seconds on ESP32 and something on ESP8266 (currently ignored)

This will at least help with cases of some locked up controllers, but does not fix the underlaying problem.