### PR TITLE
🐛 fix(json): allow for using `~-16` or `~16` when setting a segments brightness though the JSON api

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -95,7 +95,7 @@ void deserializeSegment(JsonObject elem, byte it, byte presetId)
   if (stop > start && of > len -1) of = len -1;
   strip.setSegment(id, start, stop, grp, spc, of);
 
-  byte segbri = 0;
+  byte segbri = seg.opacity;
   if (getVal(elem["bri"], &segbri)) {
     if (segbri > 0) seg.setOpacity(segbri, id);
     seg.setOption(SEG_OPTION_ON, segbri, id);


### PR DESCRIPTION
I was trying to customize a remote and noticed that you couldn't change the brightness of a segment via the `~##` or  `~-##` commands.  When looking in a saw that the base brightness was always set to `0` instead of the current segment opacity.