### PR TITLE
✨ feat(usermod): add `NonVolatile Segments` v2 usermod

### DIFF
--- a/usermods/usermod_v2_nonvolatile_segments/readme.md
+++ b/usermods/usermod_v2_nonvolatile_segments/readme.md
@@ -1,0 +1,31 @@
+# NonVolatile Segments
+
+v2 usermod to automatically save and restore segment configures on reboot
+
+* brightness
+* colors
+* palette
+* CCT
+* name
+* power state
+
+If you have multiple channels and use the `create a segment per channel` featuer
+then on every reboot you'll loose any modifications you made to the segments.
+This is a workaround to the way the WLED initializes that will restore these
+settings and prevent flashing on boot. This will only update the `cfg.json` when
+a change has been detected in the above attributes.
+
+## Installation 
+
+Add `-D USEMOD_NV_SEGMENTS` in your `platformio_override.ini` file.
+To prevent segments flashing on boot please also add `-D DEFAULT_SEGMENT_OPACITY=1`.
+To allow each channel to get to the full brightness add `-D DEFAULT_BRIGHTNESS=255`.
+
+## Build time configuration
+* `USERMOD_NV_SEGMENTS_AUTOSAVE_SECONDS` - The default time between saves (defaults to every 15 minutes)
+* `USERMOD_NV_SEGMENTS_MAX_AUTOSAVE_SECONDS` - The maximum allowed time between saves (defaults to 24 hours)
+
+## Change Log
+
+2022-05
+* First public release

--- a/usermods/usermod_v2_nonvolatile_segments/usermod_v2_nonvolatile_segments.h
+++ b/usermods/usermod_v2_nonvolatile_segments/usermod_v2_nonvolatile_segments.h
@@ -1,0 +1,363 @@
+#pragma once
+
+#include <iterator>
+#include <mbedtls/md.h>
+#include "wled.h"
+
+/*
+ * Usermods that restores the last segment(s) state on boot.
+ * If you have create segments for each output, then on boot
+ * it will trash all of the previous segments and create new
+ * ones. This is nice for the zero-config nature of mutliple
+ * outputs, but makes it harder if you customize the name,
+ * brightness, or segment power state.
+ *
+ * Using a usermod:
+ * 1. Add `-D USEMOD_NV_SEGMENTS` to your build config.
+ */
+
+#define NV_SEG_SHA1_LEN 20
+#ifndef USERMOD_NV_SEGMENTS_AUTOSAVE_SECONDS
+#define USERMOD_NV_SEGMENTS_AUTOSAVE_SECONDS 900
+#endif
+#ifndef USERMOD_NV_SEGMENTS_MAX_AUTOSAVE_SECONDS
+#define USERMOD_NV_SEGMENTS_MAX_AUTOSAVE_SECONDS 86400
+#endif
+
+class UsermodNonvolatileSegments : public Usermod
+{
+private:
+  typedef struct NvSeg
+  {
+    uint8_t id;
+    uint8_t brightness;
+    uint8_t cct;
+    uint32_t colors[NUM_COLORS];
+    char *name;
+    bool power;
+    uint8_t palette;
+  } NvSeg;
+
+  NvSeg knownSegments[MAX_NUM_SEGMENTS];
+  byte knownSegmentsHash[NV_SEG_SHA1_LEN];
+
+  bool enabled = true;
+  bool firstLoop = true;
+
+  // configurable parameters
+  uint16_t autoSaveAfterSec = USERMOD_NV_SEGMENTS_AUTOSAVE_SECONDS;
+  bool applyOnBoot = true;
+
+  // If we've detected the need to auto save, this will be non zero.
+  unsigned long autoSaveAfter = 0;
+
+  static const char _name[];
+  static const char _nvSegments[];
+  static const char _nvSegmentId[];
+  static const char _nvSegmentName[];
+  static const char _nvSegmentPower[];
+  static const char _nvSegmentBrightness[];
+  static const char _nvSegmentCct[];
+  static const char _nvSegmentColors[];
+  static const char _nvSegmentPalette[];
+  static const char _autoSaveEnabled[];
+  static const char _autoSaveAfterSec[];
+  static const char _applyOnBoot[];
+
+  static inline bool isNameSame(const char *name, const char *nvName)
+  {
+    if (name == nullptr && nvName == nullptr)
+    {
+      return true;
+    }
+
+    return (name != nullptr && nvName != nullptr && strcmp(name, nvName) == 0);
+  }
+
+public:
+  // Functions called by WLED
+
+  /*
+   * setup() is called once at boot. WiFi is not yet connected at this point.
+   * You can use it to initialize variables, sensors or similar.
+   */
+  void setup()
+  {
+    if (!applyOnBoot)
+    {
+      DEBUG_PRINTLN(F("NV Segments: Apply on boot disabled"));
+      hasSegmentsUpdated(strip.getSegments());
+      return;
+    }
+
+    for (uint8_t i = 0; i < MAX_NUM_SEGMENTS; i++)
+    {
+      NvSeg nvSeg = knownSegments[i];
+      if (nvSeg.id >= MAX_NUM_SEGMENTS)
+      {
+        DEBUG_PRINTLN(F("Segment id out of range"));
+        continue;
+      }
+      if (!nvSeg.brightness)
+      {
+        continue;
+      }
+
+      DEBUG_PRINT(F("Restoring segment "));
+      DEBUG_PRINTLN(nvSeg.id);
+
+      WS2812FX::Segment &seg = strip.getSegment(nvSeg.id);
+      DEBUG_PRINT(F("  Setting palette to "));
+      DEBUG_PRINTLN(nvSeg.palette);
+      seg.palette = nvSeg.palette;
+
+      DEBUG_PRINT(F("  Setting cct to "));
+      DEBUG_PRINTLN(nvSeg.cct);
+      seg.cct = nvSeg.cct;
+
+      DEBUG_PRINT(F("  Setting colors to"));
+      for (uint8_t i = 0; i < NUM_COLORS; i++)
+      {
+        DEBUG_PRINT(", ");
+        DEBUG_PRINT(nvSeg.colors[i]);
+        seg.colors[i] = nvSeg.colors[i];
+      }
+      DEBUG_PRINTLN(F(""));
+
+      if (!isNameSame(seg.name, nvSeg.name))
+      {
+        DEBUG_PRINT(F("  Setting name to "));
+        DEBUG_PRINTLN(nvSeg.name);
+        if (seg.name)
+        {
+          delete[] seg.name;
+          seg.name = nullptr;
+        }
+        size_t len = 0;
+        if (nvSeg.name != nullptr)
+        {
+          len = strlen(nvSeg.name);
+        }
+        seg.name = new char[len + 1];
+        strlcpy(seg.name, nvSeg.name, len + 1);
+      }
+      if (seg.opacity != nvSeg.brightness)
+      {
+        DEBUG_PRINT(F("  Setting brightness to "));
+        DEBUG_PRINTLN(nvSeg.brightness);
+        seg.setOpacity(nvSeg.brightness, nvSeg.id);
+      }
+      if (seg.getOption(SEG_OPTION_ON) != nvSeg.power)
+      {
+        DEBUG_PRINT(F("  Setting power to "));
+        DEBUG_PRINTLN(nvSeg.power);
+        seg.setOption(SEG_OPTION_ON, nvSeg.power, nvSeg.id);
+      }
+    }
+    DEBUG_PRINTLN("Calculating initial hash");
+    hasSegmentsUpdated(strip.getSegments());
+  }
+
+  void loop()
+  {
+    unsigned long now = millis();
+    if (!autoSaveAfterSec || autoSaveAfter > now || !enabled || strip.isUpdating() || currentPreset > 0)
+    {
+      return; // setting 0 as autosave seconds disables autosave
+    }
+
+    autoSaveAfter = now + autoSaveAfterSec * 1000;
+
+    if (firstLoop)
+    {
+      firstLoop = false;
+      return;
+    }
+
+    if (hasSegmentsUpdated(strip.getSegments()))
+    {
+      // Time to auto save. You may have some flickry?
+      serializeConfig();
+    }
+  }
+
+  NvSeg convertSegmentToNvSeg(WS2812FX::Segment &segment, uint8_t segmentId)
+  {
+    NvSeg seg;
+    if (!segment.stop)
+    {
+      seg.brightness = 0;
+      return seg;
+    }
+    seg.id = segmentId;
+    seg.brightness = segment.opacity;
+    seg.cct = segment.cct;
+    for (uint8_t j = 0; j < NUM_COLORS; j++)
+    {
+      seg.colors[j] = segment.colors[j];
+    }
+    seg.name = segment.name;
+    seg.power = segment.getOption(SEG_OPTION_ON);
+    seg.palette = segment.palette;
+
+    return seg;
+  }
+
+  bool hasSegmentsUpdated(WS2812FX::Segment *segments)
+  {
+    NvSeg segs[MAX_NUM_SEGMENTS];
+    bzero(segs, sizeof(segs));
+    for (size_t i = 0; i < MAX_NUM_SEGMENTS; i++)
+    {
+      segs[i] = convertSegmentToNvSeg(segments[i], i);
+    }
+    byte newHash[NV_SEG_SHA1_LEN];
+    hashSegments(segs, newHash);
+
+    if (memcmp(knownSegmentsHash, newHash, NV_SEG_SHA1_LEN) != 0)
+    {
+      DEBUG_PRINTLN(F("Known segments have chagned"));
+      DEBUG_PRINT(F("  Old hash: "));
+      printHash(knownSegmentsHash, sizeof(knownSegmentsHash));
+      DEBUG_PRINT(F("  New hash: "));
+      printHash(newHash, sizeof(newHash));
+
+      memcpy(knownSegments, segs, sizeof(knownSegments));
+      memcpy(knownSegmentsHash, newHash, NV_SEG_SHA1_LEN);
+      return true;
+    }
+
+    return false;
+  }
+
+  void printHash(byte *hash, size_t len)
+  {
+#ifdef WLED_DEBUG
+    for (int i = 0; i < len; i++)
+    {
+      char str[3];
+
+      sprintf(str, "%02x", (int)hash[i]);
+      DEBUG_PRINT(str);
+    }
+    DEBUG_PRINTLN(F(""));
+#endif
+  }
+
+  void hashSegments(NvSeg *segments, byte *calculatedHash)
+  {
+    DEBUG_PRINTLN("NV Segments: Calculating hash");
+    mbedtls_md_context_t ctx;
+    mbedtls_md_type_t md_type = MBEDTLS_MD_SHA1;
+
+    mbedtls_md_init(&ctx);
+    mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(md_type), 0);
+    mbedtls_md_starts(&ctx);
+    for (uint8_t i = 0; i < MAX_NUM_SEGMENTS; i++)
+    {
+      mbedtls_md_update(&ctx, &segments->id, sizeof(uint8_t));
+      if (segments->name != nullptr)
+      {
+        mbedtls_md_update(&ctx, (const unsigned char *)segments->name, strlen(segments->name));
+      }
+      mbedtls_md_update(&ctx, (const unsigned char *)&segments->power, sizeof(bool));
+      mbedtls_md_update(&ctx, &segments->brightness, sizeof(uint8_t));
+      mbedtls_md_update(&ctx, &segments->cct, sizeof(uint8_t));
+      mbedtls_md_update(&ctx, &segments->palette, sizeof(uint8_t));
+      for (uint8_t j = 0; j < NUM_COLORS; j++)
+      {
+        mbedtls_md_update(&ctx, (const unsigned char *)&segments->colors[j], sizeof(uint32_t));
+      }
+    }
+    mbedtls_md_finish(&ctx, calculatedHash);
+    mbedtls_md_free(&ctx);
+    DEBUG_PRINTLN(F("Done calculating hash"));
+  }
+
+  void addToConfig(JsonObject &root)
+  {
+    JsonObject top = root.createNestedObject(FPSTR(_name));
+    JsonArray flashSegments = top.createNestedArray(FPSTR(_nvSegments));
+
+    top[FPSTR(_autoSaveEnabled)] = enabled;
+    top[FPSTR(_autoSaveAfterSec)] = autoSaveAfterSec; // usermodparam
+    top[FPSTR(_applyOnBoot)] = applyOnBoot;
+
+    for (uint8_t i = 0; i < MAX_NUM_SEGMENTS; i++)
+    {
+      if (!knownSegments[i].brightness)
+      {
+        continue;
+      }
+
+      JsonObject seg = flashSegments.createNestedObject();
+      seg[FPSTR(_nvSegmentId)] = knownSegments[i].id;
+      seg[FPSTR(_nvSegmentPower)] = knownSegments[i].power;
+      seg[FPSTR(_nvSegmentCct)] = knownSegments[i].cct;
+      seg[FPSTR(_nvSegmentPalette)] = knownSegments[i].palette;
+      seg[FPSTR(_nvSegmentBrightness)] = knownSegments[i].brightness;
+      if (knownSegments[i].name != nullptr)
+      {
+        seg[FPSTR(_nvSegmentName)] = knownSegments[i].name;
+      }
+      JsonArray colors = seg.createNestedArray(FPSTR(_nvSegmentColors));
+      for (uint8_t j = 0; j < NUM_COLORS; j++)
+      {
+        colors.add(knownSegments[i].colors[j]);
+      }
+    }
+  }
+
+  bool readFromConfig(JsonObject &root)
+  {
+    JsonObject top = root[FPSTR(_name)];
+    if (top.isNull())
+    {
+      DEBUG_PRINT(FPSTR(_name));
+      DEBUG_PRINTLN(F(": No config found, using defaults."));
+      return false;
+    }
+
+    enabled = top[FPSTR(_autoSaveEnabled)] | enabled;
+    autoSaveAfterSec = top[FPSTR(_autoSaveAfterSec)] | autoSaveAfterSec;
+    autoSaveAfterSec = (uint16_t)min(USERMOD_NV_SEGMENTS_MAX_AUTOSAVE_SECONDS, max(10, (int)autoSaveAfterSec)); // bounds checking
+    applyOnBoot = top[FPSTR(_applyOnBoot)] | applyOnBoot;
+
+    JsonArray segments = top[FPSTR(_nvSegments)].as<JsonArray>();
+    if (!segments.isNull())
+    {
+      size_t count = segments.size();
+      for (uint8_t i = 0; i < count; i++)
+      {
+        knownSegments[i].id = segments[i][FPSTR(_nvSegmentId)].as<uint8_t>();
+        knownSegments[i].power = segments[i][FPSTR(_nvSegmentPower)].as<bool>();
+        knownSegments[i].brightness = segments[i][FPSTR(_nvSegmentBrightness)].as<uint8_t>() | 1;
+        const char *name = segments[i][FPSTR(_nvSegmentName)].as<const char *>();
+        knownSegments[i].name = (char *)name;
+        knownSegments[i].cct = segments[i][FPSTR(_nvSegmentCct)].as<uint8_t>();
+        copyArray(segments[i][FPSTR(_nvSegmentColors)], knownSegments[i].colors);
+        knownSegments[i].palette = segments[i][FPSTR(_nvSegmentPalette)].as<uint8_t>();
+      }
+    }
+
+    return true;
+  }
+
+  uint16_t getId()
+  {
+    return USERMOD_ID_NV_SEGMENTS;
+  }
+};
+
+const char UsermodNonvolatileSegments::_name[] PROGMEM = "NvSegments";
+const char UsermodNonvolatileSegments::_nvSegments[] PROGMEM = "seg";
+const char UsermodNonvolatileSegments::_nvSegmentId[] PROGMEM = "id";
+const char UsermodNonvolatileSegments::_nvSegmentName[] PROGMEM = "name";
+const char UsermodNonvolatileSegments::_nvSegmentPower[] PROGMEM = "pwr";
+const char UsermodNonvolatileSegments::_nvSegmentBrightness[] PROGMEM = "bri";
+const char UsermodNonvolatileSegments::_nvSegmentCct[] PROGMEM = "cct";
+const char UsermodNonvolatileSegments::_nvSegmentColors[] PROGMEM = "colors";
+const char UsermodNonvolatileSegments::_nvSegmentPalette[] PROGMEM = "palette";
+const char UsermodNonvolatileSegments::_autoSaveEnabled[] PROGMEM = "enabled";
+const char UsermodNonvolatileSegments::_autoSaveAfterSec[] PROGMEM = "autoSaveAfterSec";
+const char UsermodNonvolatileSegments::_applyOnBoot[] PROGMEM = "applyOnBoot";

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -33,7 +33,13 @@
 #define USE_GET_MILLISECOND_TIMER
 #include "FastLED.h"
 
-#define DEFAULT_BRIGHTNESS (uint8_t)127
+#ifndef DEFAULT_BRIGHTNESS
+#define DEFAULT_BRIGHTNESS      (uint8_t)127
+#endif
+#ifndef DEFAULT_SEGMENT_OPACITY
+#define DEFAULT_SEGMENT_OPACITY (uint8_t)255
+#endif
+
 #define DEFAULT_MODE       (uint8_t)0
 #define DEFAULT_SPEED      (uint8_t)128
 #define DEFAULT_INTENSITY  (uint8_t)128

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -707,7 +707,7 @@ void WS2812FX::resetSegments() {
   _segments[0].grouping = 1;
   _segments[0].setOption(SEG_OPTION_SELECTED, 1);
   _segments[0].setOption(SEG_OPTION_ON, 1);
-  _segments[0].opacity = 255;
+  _segments[0].opacity = DEFAULT_SEGMENT_OPACITY;
   _segments[0].cct = 127;
 
   for (uint16_t i = 1; i < MAX_NUM_SEGMENTS; i++)
@@ -715,7 +715,7 @@ void WS2812FX::resetSegments() {
     _segments[i].colors[0] = color_wheel(i*51);
     _segments[i].grouping = 1;
     _segments[i].setOption(SEG_OPTION_ON, 1);
-    _segments[i].opacity = 255;
+    _segments[i].opacity = DEFAULT_SEGMENT_OPACITY;
     _segments[i].cct = 127;
     _segments[i].speed = DEFAULT_SPEED;
     _segments[i].intensity = DEFAULT_INTENSITY;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -76,6 +76,7 @@
 #define USERMOD_ID_WORDCLOCK             27     //Usermod "usermod_v2_word_clock.h"
 #define USERMOD_ID_MY9291                28     //Usermod "usermod_MY9291.h"
 #define USERMOD_ID_SI7021_MQTT_HA        29     //Usermod "usermod_si7021_mqtt_ha.h"
+#define USERMOD_ID_NV_SEGMENTS           30     //Usermod "usermod_v2_nonvolatile_segments.h"
 
 //Access point behavior
 #define AP_BEHAVIOR_BOOT_NO_CONN          0     //Open AP when no connection after boot

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -128,6 +128,10 @@
 #include "../usermods/Si7021_MQTT_HA/usermod_si7021_mqtt_ha.h"
 #endif
 
+#ifdef USEMOD_NV_SEGMENTS
+#include "../usermods/usermod_v2_nonvolatile_segments/usermod_v2_nonvolatile_segments.h"
+#endif
+
 void registerUsermods()
 {
 /*
@@ -242,5 +246,9 @@ void registerUsermods()
   
   #ifdef USERMOD_SI7021_MQTT_HA
   usermods.add(new Si7021_MQTT_HA());
+  #endif
+
+  #ifdef USEMOD_NV_SEGMENTS
+  usermods.add(new UsermodNonvolatileSegments());
   #endif
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -434,7 +434,7 @@ void WLED::beginStrip()
 
   if (turnOnAtBoot) {
     if (briS > 0) bri = briS;
-    else if (bri == 0) bri = 128;
+    else if (bri == 0) bri = DEFAULT_BRIGHTNESS;
   } else {
     briLast = briS; bri = 0;
   }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -286,7 +286,7 @@ WLED_GLOBAL bool cctFromRgb _INIT(false); //CCT is calculated from RGB instead o
 
 WLED_GLOBAL byte col[]    _INIT_N(({ 255, 160, 0, 0 }));  // current RGB(W) primary color. col[] should be updated if you want to change the color.
 WLED_GLOBAL byte colSec[] _INIT_N(({ 0, 0, 0, 0 }));      // current RGB(W) secondary color
-WLED_GLOBAL byte briS     _INIT(128);                     // default brightness
+WLED_GLOBAL byte briS     _INIT(DEFAULT_BRIGHTNESS);      // default brightness
 
 WLED_GLOBAL byte nightlightTargetBri _INIT(0);      // brightness after nightlight is over
 WLED_GLOBAL byte nightlightDelayMins _INIT(60);


### PR DESCRIPTION
When using a board like a Quinled Dig Quad with multiple channels along with the `Make a segment for each output` option, the segments all get reset on each boot due to the initialization sequence.  This is a usermod workaround that restores the segment basic settings and a few additional build defs to prevent flashing the strips on boot.

The following are the build defs that I am using to create a better experience when used in a multizone environment:
```
  -D DEFAULT_BRIGHTNESS=255
  -D DEFAULT_SEGMENT_OPACITY=1

; User mods
  -D USEMOD_NV_SEGMENTS
  -D USERMOD_NV_SEGMENTS_AUTOSAVE_SECONDS=21600 ; Default to saving every quarter of a day
  -D USERMOD_NV_SEGMENTS_MAX_AUTOSAVE_SECONDS=86400 ; Max save timeframe of once per day
```

The settings looks something like this:
![image](https://user-images.githubusercontent.com/5356206/167523132-9550517b-449d-45a8-9465-5a210930b184.png)
![image](https://user-images.githubusercontent.com/5356206/167523375-cc358f13-f1f9-4c78-a155-de3d720eba26.png)
