### PR TITLE
Usermod wordclock: support for upfront LEDs

### DIFF
--- a/usermods/usermod_v2_word_clock/readme.md
+++ b/usermods/usermod_v2_word_clock/readme.md
@@ -1,11 +1,12 @@
 # Word Clock Usermod V2
 
 This usermod can be used to drive a wordclock with a 11x10 pixel matrix with WLED. There are also 4 additional dots for the minutes. 
-The visualisation is desribed in 4 mask with LED numbers (single dots for minutes, minutes, hours and "clock/Uhr").
-There are 2 parameters to chnage the behaviour:
+The visualisation is desribed in 4 mask with LED numbers (single dots for minutes, minutes, hours and "clock/Uhr"). The index of the LEDs in the masks always starts with the index 0, even if the ledOffset is not 0.
+There are 3 parameters to change the behaviour:
  
 active: enable/disable usermod
-diplayItIs: enable/disable display of "Es ist" on the clock.
+diplayItIs: enable/disable display of "Es ist" on the clock
+ledOffset: number of LEDs before the wordclock LEDs
 
 ## Installation
 

--- a/usermods/usermod_v2_word_clock/usermod_v2_word_clock.h
+++ b/usermods/usermod_v2_word_clock/usermod_v2_word_clock.h
@@ -23,6 +23,7 @@ class WordClockUsermod : public Usermod
     // set your config variables to their boot default value (this can also be done in readFromConfig() or a constructor if you prefer)
     bool usermodActive = false;
     bool displayItIs = false;
+    int ledOffset = 100;
     
     // defines for mask sizes
     #define maskSizeLeds        114
@@ -358,6 +359,7 @@ class WordClockUsermod : public Usermod
       JsonObject top = root.createNestedObject("WordClockUsermod");
       top["active"] = usermodActive;
       top["displayItIs"] = displayItIs;
+      top["ledOffset"] = ledOffset;
     }
 
     /*
@@ -386,6 +388,7 @@ class WordClockUsermod : public Usermod
 
       configComplete &= getJsonValue(top["active"], usermodActive);
       configComplete &= getJsonValue(top["displayItIs"], displayItIs);
+      configComplete &= getJsonValue(top["ledOffset"], ledOffset);
 
       return configComplete;
     }
@@ -407,7 +410,7 @@ class WordClockUsermod : public Usermod
           if (maskLedsOn[x] == 0)
           {
             // set pixel off
-            strip.setPixelColor(x, RGBW32(0,0,0,0));
+            strip.setPixelColor(x + ledOffset, RGBW32(0,0,0,0));
           }
         }
       }


### PR DESCRIPTION
- add ledOffset to support LEDs that are not effected by the usermode before the wordclock LEDs