### PR TITLE
BME280 Usermod Enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2067,9 +2067,9 @@
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -1,3 +1,6 @@
+// force the compiler to show a warning to confirm that this file is included
+#warning **** Included USERMOD_BME280 version 2.0 ****
+
 #pragma once
 
 #include "wled.h"
@@ -9,43 +12,30 @@
 class UsermodBME280 : public Usermod
 {
 private:
-// User-defined configuration
-#define Celsius               // Show temperature mesaurement in Celcius. Comment out for Fahrenheit
-#define TemperatureDecimals 1 // Number of decimal places in published temperaure values
-#define HumidityDecimals 2    // Number of decimal places in published humidity values
-#define PressureDecimals 2    // Number of decimal places in published pressure values
-#define TemperatureInterval 5 // Interval to measure temperature (and humidity, dew point if available) in seconds
-#define PressureInterval 300  // Interval to measure pressure in seconds
-#define PublishAlways 0       // Publish values even when they have not changed
+  
+  // NOTE: Do not implement any compile-time variables, anything the user needs to configure
+  // should be configurable from the Usermod menu using the methods below
+  // key settings set via usermod menu
+  unsigned long TemperatureDecimals = 0;  // Number of decimal places in published temperaure values
+  unsigned long  HumidityDecimals = 0;    // Number of decimal places in published humidity values
+  unsigned long  PressureDecimals = 0;    // Number of decimal places in published pressure values
+  unsigned long  TemperatureInterval = 5; // Interval to measure temperature (and humidity, dew point if available) in seconds
+  unsigned long  PressureInterval = 300;  // Interval to measure pressure in seconds
+  bool PublishAlways = false;             // Publish values even when they have not changed
+  bool UseCelsius = true;                 // Use Celsius for Reporting
+  bool HomeAssistantDiscovery = false;    // Publish Home Assistant Device Information
 
-// Sanity checks
-#if !defined(TemperatureDecimals) || TemperatureDecimals < 0
-  #define TemperatureDecimals 0
-#endif
-#if !defined(HumidityDecimals) || HumidityDecimals < 0
-  #define HumidityDecimals 0
-#endif
-#if !defined(PressureDecimals) || PressureDecimals < 0
-  #define PressureDecimals 0
-#endif
-#if !defined(TemperatureInterval) || TemperatureInterval < 0
-  #define TemperatureInterval 1
-#endif
-#if !defined(PressureInterval) || PressureInterval < 0
-  #define PressureInterval TemperatureInterval
-#endif
-#if !defined(PublishAlways)
-  #define PublishAlways 0
-#endif
-
-#ifdef ARDUINO_ARCH_ESP32 // ESP32 boards
-  uint8_t SCL_PIN = 22;
-  uint8_t SDA_PIN = 21;
-#else // ESP8266 boards
-  uint8_t SCL_PIN = 5;
-  uint8_t SDA_PIN = 4;
-  //uint8_t RST_PIN = 16; // Uncoment for Heltec WiFi-Kit-8
-#endif
+  // set the default pins based on the architecture, these get overridden by Usermod menu settings
+  #ifdef ARDUINO_ARCH_ESP32 // ESP32 boards
+    #define HW_PIN_SCL 22
+    #define HW_PIN_SDA 21
+  #else // ESP8266 boards
+    #define HW_PIN_SCL 5
+    #define HW_PIN_SDA 4
+    //uint8_t RST_PIN = 16; // Uncoment for Heltec WiFi-Kit-8
+  #endif
+  int8_t ioPin[2] = {HW_PIN_SCL, HW_PIN_SDA};        // I2C pins: SCL, SDA...defaults to Arch hardware pins but overridden at setup()
+  bool initDone = false;
 
   // BME280 sensor settings
   BME280I2C::Settings settings{
@@ -75,6 +65,7 @@ private:
   float sensorHeatIndex;
   float sensorDewPoint;
   float sensorPressure;
+  String tempScale;
   // Track previous sensor values
   float lastTemperature;
   float lastHumidity;
@@ -82,43 +73,122 @@ private:
   float lastDewPoint;
   float lastPressure;
 
+  // MQTT topic strings for publishing Home Assistant discovery topics
+  bool mqttInitialized = false;
+  String mqttTemperatureTopic = "";
+  String mqttHumidityTopic = "";
+  String mqttPressureTopic = "";
+  String mqttHeatIndexTopic = "";
+  String mqttDewPointTopic = "";
+
   // Store packet IDs of MQTT publications
   uint16_t mqttTemperaturePub = 0;
   uint16_t mqttPressurePub = 0;
 
+  // Read the BME280/BMP280 Sensor (which one runs depends on whether Celsius or Farenheit being set in Usermod Menu)
   void UpdateBME280Data(int SensorType)
   {
     float _temperature, _humidity, _pressure;
-    #ifdef Celsius
+
+    if (UseCelsius) {
       BME280::TempUnit tempUnit(BME280::TempUnit_Celsius);
       EnvironmentCalculations::TempUnit envTempUnit(EnvironmentCalculations::TempUnit_Celsius);
-    #else
+      BME280::PresUnit presUnit(BME280::PresUnit_hPa);
+
+      bme.read(_pressure, _temperature, _humidity, tempUnit, presUnit);
+
+      sensorTemperature = _temperature;
+      sensorHumidity = _humidity;
+      sensorPressure = _pressure;
+      tempScale = "°C";
+      if (sensorType == 1)
+      {
+        sensorHeatIndex = EnvironmentCalculations::HeatIndex(_temperature, _humidity, envTempUnit);
+        sensorDewPoint = EnvironmentCalculations::DewPoint(_temperature, _humidity, envTempUnit);
+      }
+    } else {
       BME280::TempUnit tempUnit(BME280::TempUnit_Fahrenheit);
       EnvironmentCalculations::TempUnit envTempUnit(EnvironmentCalculations::TempUnit_Fahrenheit);
-    #endif
-    BME280::PresUnit presUnit(BME280::PresUnit_hPa);
+      BME280::PresUnit presUnit(BME280::PresUnit_hPa);
 
-    bme.read(_pressure, _temperature, _humidity, tempUnit, presUnit);
+      bme.read(_pressure, _temperature, _humidity, tempUnit, presUnit);
 
-    sensorTemperature = _temperature;
-    sensorHumidity = _humidity;
-    sensorPressure = _pressure;
-    if (sensorType == 1)
-    {
-      sensorHeatIndex = EnvironmentCalculations::HeatIndex(_temperature, _humidity, envTempUnit);
-      sensorDewPoint = EnvironmentCalculations::DewPoint(_temperature, _humidity, envTempUnit);
+      sensorTemperature = _temperature;
+      sensorHumidity = _humidity;
+      sensorPressure = _pressure;
+      tempScale = "°F";
+      if (sensorType == 1)
+      {
+        sensorHeatIndex = EnvironmentCalculations::HeatIndex(_temperature, _humidity, envTempUnit);
+        sensorDewPoint = EnvironmentCalculations::DewPoint(_temperature, _humidity, envTempUnit);
+      }
     }
+  }
+
+  // Procedure to define all MQTT discovery Topics 
+  void _mqttInitialize()
+  {
+    mqttTemperatureTopic = String(mqttDeviceTopic) + "/temperature";
+    mqttPressureTopic = String(mqttDeviceTopic) + "/pressure";
+    mqttHumidityTopic = String(mqttDeviceTopic) + "/humidity";
+    mqttHeatIndexTopic = String(mqttDeviceTopic) + "/heat_index";
+    mqttDewPointTopic = String(mqttDeviceTopic) + "/dew_point";
+
+    if (HomeAssistantDiscovery) {
+      _createMqttSensor(F("Temperature"), mqttTemperatureTopic, F("temperature"), tempScale);
+      _createMqttSensor(F("Pressure"), mqttPressureTopic, F("pressure"), F("hPa"));
+      _createMqttSensor(F("Humidity"), mqttHumidityTopic, F("humidity"), F("%"));
+      _createMqttSensor(F("HeatIndex"), mqttHeatIndexTopic, F("temperature"), tempScale);
+      _createMqttSensor(F("DewPoint"), mqttDewPointTopic, F("temperature"), tempScale);
+    }
+  }
+
+  // Create an MQTT Sensor for Home Assistant Discovery purposes, this includes a pointer to the topic that is published to in the Loop.
+  void _createMqttSensor(const String &name, const String &topic, const String &deviceClass, const String &unitOfMeasurement)
+  {
+    String t = String("homeassistant/sensor/") + mqttClientID + "/" + name + "/config";
+    
+    StaticJsonDocument<600> doc;
+    
+    doc[F("name")] = String(serverDescription) + " " + name;
+    doc[F("state_topic")] = topic;
+    doc[F("unique_id")] = String(mqttClientID) + name;
+    if (unitOfMeasurement != "")
+      doc[F("unit_of_measurement")] = unitOfMeasurement;
+    if (deviceClass != "")
+      doc[F("device_class")] = deviceClass;
+    doc[F("expire_after")] = 1800;
+
+    JsonObject device = doc.createNestedObject(F("device")); // attach the sensor to the same device
+    device[F("name")] = serverDescription;
+    device[F("identifiers")] = "wled-sensor-" + String(mqttClientID);
+    device[F("manufacturer")] = F("WLED");
+    device[F("model")] = F("FOSS");
+    device[F("sw_version")] = versionString;
+
+    String temp;
+    serializeJson(doc, temp);
+    Serial.println(t);
+    Serial.println(temp);
+
+    mqtt->publish(t.c_str(), 0, true, temp.c_str());
   }
 
 public:
   void setup()
   {
-    Wire.begin(SDA_PIN, SCL_PIN);
+    bool HW_Pins_Used = (ioPin[0]==HW_PIN_SCL && ioPin[1]==HW_PIN_SDA); // note whether architecture-based hardware SCL/SDA pins used
+    PinOwner po = PinOwner::UM_BME280; // defaults to being pinowner for SCL/SDA pins
+    PinManagerPinType pins[2] = { { ioPin[0], true }, { ioPin[1], true } };  // allocate pins
+    if (HW_Pins_Used) po = PinOwner::HW_I2C; // allow multiple allocations of HW I2C bus pins
+    if (!pinManager.allocateMultiplePins(pins, 2, po)) { sensorType=0; return; }
+    
+    Wire.begin(ioPin[1], ioPin[0]);
 
     if (!bme.begin())
     {
       sensorType = 0;
-      Serial.println("Could not find BME280I2C sensor!");
+      Serial.println(F("Could not find BME280I2C sensor!"));
     }
     else
     {
@@ -126,24 +196,25 @@ public:
       {
       case BME280::ChipModel_BME280:
         sensorType = 1;
-        Serial.println("Found BME280 sensor! Success.");
+        Serial.println(F("Found BME280 sensor! Success."));
         break;
       case BME280::ChipModel_BMP280:
         sensorType = 2;
-        Serial.println("Found BMP280 sensor! No Humidity available.");
+        Serial.println(F("Found BMP280 sensor! No Humidity available."));
         break;
       default:
         sensorType = 0;
-        Serial.println("Found UNKNOWN sensor! Error!");
+        Serial.println(F("Found UNKNOWN sensor! Error!"));
       }
     }
+    initDone=true;
   }
 
   void loop()
   {
     // BME280 sensor MQTT publishing
     // Check if sensor present and MQTT Connected, otherwise it will crash the MCU
-    if (sensorType != 0 && mqtt != nullptr)
+    if (sensorType != 0 && WLED_MQTT_CONNECTED)
     {
       // Timer to fetch new temperature, humidity and pressure data at intervals
       timer = millis();
@@ -156,6 +227,12 @@ public:
 
         float temperature = roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
         float humidity, heatIndex, dewPoint;
+
+        if (WLED_MQTT_CONNECTED && !mqttInitialized)
+        {
+          _mqttInitialize();
+          mqttInitialized = true;
+        }
 
         // If temperature has changed since last measure, create string populated with device topic
         // from the UI and values read from sensor, then publish to broker
@@ -212,5 +289,174 @@ public:
         lastPressure = pressure;
       }
     }
+  }
+    
+    /*
+     * API calls te enable data exchange between WLED modules
+     */
+    inline float getTemperatureC() {
+      if (UseCelsius) {
+        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      } else {
+        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+      }
+      
+    }
+    inline float getTemperatureF() {
+      if (UseCelsius) {
+        return ((float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+      } else {
+        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      }
+    }
+    inline float getHumidity() {
+      return (float)roundf(sensorHumidity * pow(10, HumidityDecimals));
+    }
+    inline float getPressure() {
+      return (float)roundf(sensorPressure * pow(10, PressureDecimals));
+    }
+    inline float getDewPointC() {
+      if (UseCelsius) {
+        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      } else {
+        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+      }
+    }
+    inline float getDewPointF() {
+      if (UseCelsius) {
+        return ((float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+      } else {
+        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      }
+    }
+    inline float getHeatIndexC() {
+      if (UseCelsius) {
+        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      } else {
+        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+      }
+    }inline float getHeatIndexF() {
+      if (UseCelsius) {
+        return ((float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+      } else {
+        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+      }
+    }
+
+  // Publish Sensor Information to Info Page
+  void addToJsonInfo(JsonObject &root)
+  {
+    JsonObject user = root[F("u")];
+    if (user.isNull()) user = root.createNestedObject(F("u"));
+    
+    if (sensorType==0) //No Sensor
+    {
+      // if we sensor not detected, let the user know
+      JsonArray temperature_json = user.createNestedArray(F("BME/BMP280 Sensor"));
+      temperature_json.add(F("Not Found"));
+    }
+    else if (sensorType==2) //BMP280
+    {
+      
+      JsonArray temperature_json = user.createNestedArray("Temperature");
+      JsonArray pressure_json = user.createNestedArray("Pressure");
+      temperature_json.add(roundf(sensorTemperature * pow(10, TemperatureDecimals)));
+      temperature_json.add(tempScale);
+      pressure_json.add(roundf(sensorPressure * pow(10, PressureDecimals)));
+      pressure_json.add(F("hPa"));
+    }
+    else if (sensorType==1) //BME280
+    {
+      JsonArray temperature_json = user.createNestedArray("Temperature");
+      JsonArray humidity_json = user.createNestedArray("Humidity");
+      JsonArray pressure_json = user.createNestedArray("Pressure");
+      JsonArray heatindex_json = user.createNestedArray("Heat Index");
+      JsonArray dewpoint_json = user.createNestedArray("Dew Point");
+      temperature_json.add(roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      temperature_json.add(tempScale);
+      humidity_json.add(roundf(sensorHumidity * pow(10, HumidityDecimals)));
+      humidity_json.add(F("%"));
+      pressure_json.add(roundf(sensorPressure * pow(10, PressureDecimals)));
+      pressure_json.add(F("hPa"));
+      heatindex_json.add(roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      heatindex_json.add(tempScale);
+      dewpoint_json.add(roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      dewpoint_json.add(tempScale);
+    }
+      return;
+  }
+
+  // Save Usermod Config Settings
+  void addToConfig(JsonObject& root)
+  {
+    JsonObject top = root.createNestedObject(F("BME280/BMP280"));
+    top[F("TemperatureDecimals")] = TemperatureDecimals;
+    top[F("HumidityDecimals")] = HumidityDecimals;
+    top[F("PressureDecimals")] = PressureDecimals;
+    top[F("TemperatureInterval")] = TemperatureInterval;
+    top[F("PressureInterval")] = PressureInterval;
+    top[F("PublishAlways")] = PublishAlways;
+    top[F("UseCelsius")] = UseCelsius;
+    top[F("HomeAssistantDiscovery")] = HomeAssistantDiscovery;
+    JsonArray io_pin = top.createNestedArray(F("pin"));
+    for (byte i=0; i<2; i++) io_pin.add(ioPin[i]);
+    top[F("help4Pins")] = F("SCL,SDA"); // help for Settings page
+    DEBUG_PRINTLN(F("BME280 config saved."));
+  }
+
+  // Read Usermod Config Settings
+  bool readFromConfig(JsonObject& root)
+  {
+    // default settings values could be set here (or below using the 3-argument getJsonValue()) instead of in the class definition or constructor
+    // setting them inside readFromConfig() is slightly more robust, handling the rare but plausible use case of single value being missing after boot (e.g. if the cfg.json was manually edited and a value was removed)
+
+
+    int8_t newPin[2]; for (byte i=0; i<2; i++) newPin[i] = ioPin[i]; // prepare to note changed pins
+
+    JsonObject top = root[F("BME280/BMP280")];
+    if (top.isNull()) {
+      DEBUG_PRINT(F("BME280/BMP280"));
+      DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+      return false;
+    }
+    bool configComplete = !top.isNull();
+
+    // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
+    configComplete &= getJsonValue(top[F("TemperatureDecimals")], TemperatureDecimals, 1);
+    configComplete &= getJsonValue(top[F("HumidityDecimals")], HumidityDecimals, 0);
+    configComplete &= getJsonValue(top[F("PressureDecimals")], PressureDecimals, 0);
+    configComplete &= getJsonValue(top[F("TemperatureInterval")], TemperatureInterval, 30);
+    configComplete &= getJsonValue(top[F("PressureInterval")], PressureInterval, 30);
+    configComplete &= getJsonValue(top[F("PublishAlways")], PublishAlways, false);
+    configComplete &= getJsonValue(top[F("UseCelsius")], UseCelsius, true);
+    configComplete &= getJsonValue(top[F("HomeAssistantDiscovery")], HomeAssistantDiscovery, false);
+    for (byte i=0; i<2; i++) configComplete &= getJsonValue(top[F("pin")][i], newPin[i], ioPin[i]);
+
+    DEBUG_PRINT(FPSTR(F("BME280/BMP280")));
+    if (!initDone) {
+      // first run: reading from cfg.json
+      for (byte i=0; i<2; i++) ioPin[i] = newPin[i];
+      DEBUG_PRINTLN(F(" config loaded."));
+    } else {
+      DEBUG_PRINTLN(F(" config (re)loaded."));
+      // changing parameters from settings page
+      bool pinsChanged = false;
+      for (byte i=0; i<2; i++) if (ioPin[i] != newPin[i]) { pinsChanged = true; break; } // check if any pins changed
+      if (pinsChanged) { //if pins changed, deallocate old pins and allocate new ones
+        PinOwner po = PinOwner::UM_BME280;
+        if (ioPin[0]==HW_PIN_SCL && ioPin[1]==HW_PIN_SDA) po = PinOwner::HW_I2C;  // allow multiple allocations of HW I2C bus pins
+        pinManager.deallocateMultiplePins((const uint8_t *)ioPin, 2, po);  // deallocate pins
+        for (byte i=0; i<2; i++) ioPin[i] = newPin[i];
+        setup();
+      }
+      // use "return !top["newestParameter"].isNull();" when updating Usermod with new features
+      return !top[F("pin")].isNull();
+    }
+
+    return configComplete;
+  }
+
+  uint16_t getId() {
+    return USERMOD_ID_BME280;
   }
 };

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -128,11 +128,11 @@ private:
   // Procedure to define all MQTT discovery Topics 
   void _mqttInitialize()
   {
-    mqttTemperatureTopic = String(mqttDeviceTopic) + "/temperature";
-    mqttPressureTopic = String(mqttDeviceTopic) + "/pressure";
-    mqttHumidityTopic = String(mqttDeviceTopic) + "/humidity";
-    mqttHeatIndexTopic = String(mqttDeviceTopic) + "/heat_index";
-    mqttDewPointTopic = String(mqttDeviceTopic) + "/dew_point";
+    mqttTemperatureTopic = String(mqttDeviceTopic) + F("/temperature");
+    mqttPressureTopic = String(mqttDeviceTopic) + F("/pressure");
+    mqttHumidityTopic = String(mqttDeviceTopic) + F("/humidity");
+    mqttHeatIndexTopic = String(mqttDeviceTopic) + F("/heat_index");
+    mqttDewPointTopic = String(mqttDeviceTopic) + F("/dew_point");
 
     if (HomeAssistantDiscovery) {
       _createMqttSensor(F("Temperature"), mqttTemperatureTopic, F("temperature"), tempScale);
@@ -146,7 +146,7 @@ private:
   // Create an MQTT Sensor for Home Assistant Discovery purposes, this includes a pointer to the topic that is published to in the Loop.
   void _createMqttSensor(const String &name, const String &topic, const String &deviceClass, const String &unitOfMeasurement)
   {
-    String t = String("homeassistant/sensor/") + mqttClientID + "/" + name + "/config";
+    String t = String(F("homeassistant/sensor/")) + mqttClientID + F("/") + name + F("/config");
     
     StaticJsonDocument<600> doc;
     
@@ -168,8 +168,8 @@ private:
 
     String temp;
     serializeJson(doc, temp);
-    Serial.println(t);
-    Serial.println(temp);
+    DEBUG_PRINTLN(t);
+    DEBUG_PRINTLN(temp);
 
     mqtt->publish(t.c_str(), 0, true, temp.c_str());
   }
@@ -188,7 +188,7 @@ public:
     if (!bme.begin())
     {
       sensorType = 0;
-      Serial.println(F("Could not find BME280I2C sensor!"));
+      DEBUG_PRINTLN(F("Could not find BME280I2C sensor!"));
     }
     else
     {
@@ -196,15 +196,15 @@ public:
       {
       case BME280::ChipModel_BME280:
         sensorType = 1;
-        Serial.println(F("Found BME280 sensor! Success."));
+        DEBUG_PRINTLN(F("Found BME280 sensor! Success."));
         break;
       case BME280::ChipModel_BMP280:
         sensorType = 2;
-        Serial.println(F("Found BMP280 sensor! No Humidity available."));
+        DEBUG_PRINTLN(F("Found BMP280 sensor! No Humidity available."));
         break;
       default:
         sensorType = 0;
-        Serial.println(F("Found UNKNOWN sensor! Error!"));
+        DEBUG_PRINTLN(F("Found UNKNOWN sensor! Error!"));
       }
     }
     initDone=true;
@@ -225,7 +225,7 @@ public:
 
         UpdateBME280Data(sensorType);
 
-        float temperature = roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        float temperature = roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
         float humidity, heatIndex, dewPoint;
 
         if (WLED_MQTT_CONNECTED && !mqttInitialized)
@@ -246,25 +246,25 @@ public:
 
         if (sensorType == 1) // Only if sensor is a BME280
         {
-          humidity = roundf(sensorHumidity * pow(10, HumidityDecimals)) / pow(10, HumidityDecimals);
-          heatIndex = roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
-          dewPoint = roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+          humidity = roundf(sensorHumidity * powf(10, HumidityDecimals)) / powf(10, HumidityDecimals);
+          heatIndex = roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
+          dewPoint = roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
 
           if (humidity != lastHumidity || PublishAlways)
           {
-            String topic = String(mqttDeviceTopic) + "/humidity";
+            String topic = String(mqttDeviceTopic) + F("/humidity");
             mqtt->publish(topic.c_str(), 0, false, String(humidity, HumidityDecimals).c_str());
           }
 
           if (heatIndex != lastHeatIndex || PublishAlways)
           {
-            String topic = String(mqttDeviceTopic) + "/heat_index";
+            String topic = String(mqttDeviceTopic) + F("/heat_index");
             mqtt->publish(topic.c_str(), 0, false, String(heatIndex, TemperatureDecimals).c_str());
           }
 
           if (dewPoint != lastDewPoint || PublishAlways)
           {
-            String topic = String(mqttDeviceTopic) + "/dew_point";
+            String topic = String(mqttDeviceTopic) + F("/dew_point");
             mqtt->publish(topic.c_str(), 0, false, String(dewPoint, TemperatureDecimals).c_str());
           }
 
@@ -278,11 +278,11 @@ public:
       {
         lastPressureMeasure = timer;
 
-        float pressure = roundf(sensorPressure * pow(10, PressureDecimals)) / pow(10, PressureDecimals);
+        float pressure = roundf(sensorPressure * powf(10, PressureDecimals)) / powf(10, PressureDecimals);
 
         if (pressure != lastPressure || PublishAlways)
         {
-          String topic = String(mqttDeviceTopic) + "/pressure";
+          String topic = String(mqttDeviceTopic) + F("/pressure");
           mqttPressurePub = mqtt->publish(topic.c_str(), 0, true, String(pressure, PressureDecimals).c_str());
         }
 
@@ -296,50 +296,50 @@ public:
      */
     inline float getTemperatureC() {
       if (UseCelsius) {
-        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       } else {
-        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+        return (float)roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) * 1.8f + 32;
       }
       
     }
     inline float getTemperatureF() {
       if (UseCelsius) {
-        return ((float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+        return ((float)roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) -32) * 0.56f;
       } else {
-        return (float)roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       }
     }
     inline float getHumidity() {
-      return (float)roundf(sensorHumidity * pow(10, HumidityDecimals));
+      return (float)roundf(sensorHumidity * powf(10, HumidityDecimals));
     }
     inline float getPressure() {
-      return (float)roundf(sensorPressure * pow(10, PressureDecimals));
+      return (float)roundf(sensorPressure * powf(10, PressureDecimals));
     }
     inline float getDewPointC() {
       if (UseCelsius) {
-        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       } else {
-        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+        return (float)roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) * 1.8f + 32;
       }
     }
     inline float getDewPointF() {
       if (UseCelsius) {
-        return ((float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+        return ((float)roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) -32) * 0.56f;
       } else {
-        return (float)roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       }
     }
     inline float getHeatIndexC() {
       if (UseCelsius) {
-        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       } else {
-        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) * 1.8f + 32;
+        return (float)roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) * 1.8f + 32;
       }
     }inline float getHeatIndexF() {
       if (UseCelsius) {
-        return ((float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals) -32) * 0.56f;
+        return ((float)roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals) -32) * 0.56f;
       } else {
-        return (float)roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals);
+        return (float)roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals);
       }
     }
 
@@ -358,29 +358,29 @@ public:
     else if (sensorType==2) //BMP280
     {
       
-      JsonArray temperature_json = user.createNestedArray("Temperature");
-      JsonArray pressure_json = user.createNestedArray("Pressure");
-      temperature_json.add(roundf(sensorTemperature * pow(10, TemperatureDecimals)));
+      JsonArray temperature_json = user.createNestedArray(F("Temperature"));
+      JsonArray pressure_json = user.createNestedArray(F("Pressure"));
+      temperature_json.add(roundf(sensorTemperature * powf(10, TemperatureDecimals)));
       temperature_json.add(tempScale);
-      pressure_json.add(roundf(sensorPressure * pow(10, PressureDecimals)));
+      pressure_json.add(roundf(sensorPressure * powf(10, PressureDecimals)));
       pressure_json.add(F("hPa"));
     }
     else if (sensorType==1) //BME280
     {
-      JsonArray temperature_json = user.createNestedArray("Temperature");
-      JsonArray humidity_json = user.createNestedArray("Humidity");
-      JsonArray pressure_json = user.createNestedArray("Pressure");
-      JsonArray heatindex_json = user.createNestedArray("Heat Index");
-      JsonArray dewpoint_json = user.createNestedArray("Dew Point");
-      temperature_json.add(roundf(sensorTemperature * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      JsonArray temperature_json = user.createNestedArray(F("Temperature"));
+      JsonArray humidity_json = user.createNestedArray(F("Humidity"));
+      JsonArray pressure_json = user.createNestedArray(F("Pressure"));
+      JsonArray heatindex_json = user.createNestedArray(F("Heat Index"));
+      JsonArray dewpoint_json = user.createNestedArray(F("Dew Point"));
+      temperature_json.add(roundf(sensorTemperature * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals));
       temperature_json.add(tempScale);
-      humidity_json.add(roundf(sensorHumidity * pow(10, HumidityDecimals)));
+      humidity_json.add(roundf(sensorHumidity * powf(10, HumidityDecimals)));
       humidity_json.add(F("%"));
-      pressure_json.add(roundf(sensorPressure * pow(10, PressureDecimals)));
+      pressure_json.add(roundf(sensorPressure * powf(10, PressureDecimals)));
       pressure_json.add(F("hPa"));
-      heatindex_json.add(roundf(sensorHeatIndex * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      heatindex_json.add(roundf(sensorHeatIndex * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals));
       heatindex_json.add(tempScale);
-      dewpoint_json.add(roundf(sensorDewPoint * pow(10, TemperatureDecimals)) / pow(10, TemperatureDecimals));
+      dewpoint_json.add(roundf(sensorDewPoint * powf(10, TemperatureDecimals)) / powf(10, TemperatureDecimals));
       dewpoint_json.add(tempScale);
     }
       return;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -76,6 +76,7 @@
 #define USERMOD_ID_WORDCLOCK             27     //Usermod "usermod_v2_word_clock.h"
 #define USERMOD_ID_MY9291                28     //Usermod "usermod_MY9291.h"
 #define USERMOD_ID_SI7021_MQTT_HA        29     //Usermod "usermod_si7021_mqtt_ha.h"
+#define USERMOD_ID_BME280                30     //Usermod "usermod_bme280.h
 
 //Access point behavior
 #define AP_BEHAVIOR_BOOT_NO_CONN          0     //Open AP when no connection after boot

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -53,7 +53,8 @@ enum struct PinOwner : uint8_t {
   // #define USERMOD_ID_ELEKSTUBE_IPS                   // 0x10 // Usermod "usermod_elekstube_ips.h" -- Uses quite a few pins ... see Hardware.h and User_Setup.h
   // #define USERMOD_ID_SN_PHOTORESISTOR                // 0x11 // Usermod "usermod_sn_photoresistor.h" -- Uses hard-coded pin (PHOTORESISTOR_PIN == A0), but could be easily updated to use pinManager
   UM_RGBRotaryEncoder  = USERMOD_RGB_ROTARY_ENCODER,    // 0x16 // Usermod "rgb-rotary-encoder.h"
-  UM_QuinLEDAnPenta    = USERMOD_ID_QUINLED_AN_PENTA    // 0x17 // Usermod "quinled-an-penta.h"
+  UM_QuinLEDAnPenta    = USERMOD_ID_QUINLED_AN_PENTA,   // 0x17 // Usermod "quinled-an-penta.h"
+  UM_BME280            = USERMOD_ID_BME280              // 0x18 // Usermod "usermod_bme280.h -- Uses "standard" HW_I2C pins
 };
 static_assert(0u == static_cast<uint8_t>(PinOwner::None), "PinOwner::None must be zero, so default array initialization works as expected");
 


### PR DESCRIPTION
This is my first pull request so my apologies if I've not done anything right.  I think I did something wrong the first time I tried to submit, I think I've got it write this time.

**Changes**
I added a Usermod interface for key settings. I used a PinArray for the SDA/SCL pins, but you can't name these individually.

I have also made a display to show the temperature/humidity values in the web interface's Info screen.

I had to change the definition of those items in order to allow these new functions to work. I have not noticed any negative side effects to this change.

At the moment, I've not figured out how to make Celsius/Farenheit toggleable due to the way the #define setup works.

Finally, I have added a routine to publish MQTT Discovery Topics for Home Assistant (toggleable in the Usermod screen).

**Testing Done**
I've been testing this on two devices, one ESP32 and one ESP8266, for a few months and haven't noticed any problems.