### PR TITLE
init DS1307RTC only if needed

### DIFF
--- a/wled00/src/dependencies/time/DS1307RTC.cpp
+++ b/wled00/src/dependencies/time/DS1307RTC.cpp
@@ -213,6 +213,6 @@ uint8_t DS1307RTC::bcd2dec(uint8_t num)
 }
 
 bool DS1307RTC::exists = false;
-
-DS1307RTC RTC = DS1307RTC(); // create an instance for the user
-
+#if defined(USERMOD_RTC) || defined(USERMOD_ELEKSTUBE_IPS)
+  DS1307RTC RTC = DS1307RTC(); // create an instance for the user
+#endif


### PR DESCRIPTION
DS1307RTC is only required by USERMOD_RTC and USERMOD_ELEKSTUBE_IPS.
If we don't use it, we do not want to execute `Wire.begin();` which configure gpio port 21 et 22 as I2C ports. This created a regression as it was possible to use gpio 21 and 22 for relays.