### PR TITLE
added some useful default settings #define

### DIFF
--- a/usermods/usermod_v2_auto_save/readme.md
+++ b/usermods/usermod_v2_auto_save/readme.md
@@ -1,20 +1,17 @@
 # Auto Save
 
-v2 Usermod to automatically save settings 
-to preset number AUTOSAVE_PRESET_NUM after a change to any of
-
+v2 Usermod to automatically save settings
+to preset number AUTOSAVE_PRESET_NUM after a change to any of:
 * brightness
 * effect speed
 * effect intensity
 * mode (effect)
 * palette
 
-but it will wait for AUTOSAVE_SETTLE_MS milliseconds, a "settle" 
-period in case there are other changes (any change will 
-extend the "settle" window).
+but it will wait for AUTOSAVE_AFTER_SEC seconds,
+a "settle" period in case there are other changes (any change will extend the "settle" window).
 
-It will additionally load preset AUTOSAVE_PRESET_NUM at startup.
-during the first `loop()`.  Reasoning below.
+It will additionally load preset AUTOSAVE_PRESET_NUM at startup during the first `loop()`.
 
 AutoSaveUsermod is standalone, but if FourLineDisplayUsermod is installed, it will notify the user of the saved changes.
 
@@ -28,10 +25,21 @@ This file should be placed in the same directory as `platformio.ini`.
 
 ### Define Your Options
 
-* `USERMOD_AUTO_SAVE`   - define this to have this the Auto Save usermod included wled00\usermods_list.cpp
-* `USERMOD_FOUR_LINE_DISPLAY`  - define this to have this the Four Line Display mod included wled00\usermods_list.cpp - also tells this usermod that the display is available (see the Four Line Display usermod `readme.md` for more details)
+* `USERMOD_AUTO_SAVE`           - define this to have this the Auto Save usermod included wled00\usermods_list.cpp
+* `AUTOSAVE_AFTER_SEC`          - define the delay time after the settings auto-saving routine should be executed
+* `AUTOSAVE_PRESET_NUM`         - define the preset number used by autosave usermod
+* `USERMOD_AUTO_SAVE_ON_BOOT`   - define if autosave should be enabled on boot
+* `USERMOD_FOUR_LINE_DISPLAY`   - define this to have this the Four Line Display mod included wled00\usermods_list.cpp
+                                    also tells this usermod that the display is available
+                                    (see the Four Line Display usermod `readme.md` for more details)
 
-You can configure auto-save parameters using Usermods settings page.
+Example to add in platformio_override:
+  -D USERMOD_AUTO_SAVE
+  -D AUTOSAVE_AFTER_SEC=10
+  -D AUTOSAVE_PRESET_NUM=100
+  -D USERMOD_AUTO_SAVE_ON_BOOT=true
+
+You can also configure auto-save parameters using Usermods settings page.
 
 ### PlatformIO requirements
 

--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
@@ -33,9 +33,23 @@ class AutoSaveUsermod : public Usermod {
     bool enabled = true;
 
     // configurable parameters
+    #ifdef AUTOSAVE_AFTER_SEC
+    uint16_t autoSaveAfterSec = AUTOSAVE_AFTER_SEC;
+    #else
     uint16_t autoSaveAfterSec = 15;       // 15s by default
+    #endif
+
+    #ifdef AUTOSAVE_PRESET_NUM
+    uint8_t autoSavePreset = AUTOSAVE_PRESET_NUM;
+    #else
     uint8_t autoSavePreset = 250;         // last possible preset
+    #endif
+
+    #ifdef USERMOD_AUTO_SAVE_ON_BOOT
+    bool applyAutoSaveOnBoot = USERMOD_AUTO_SAVE_ON_BOOT; 
+    #else
     bool applyAutoSaveOnBoot = false;     // do we load auto-saved preset on boot?
+    #endif
 
     // If we've detected the need to auto save, this will be non zero.
     unsigned long autoSaveAfter = 0;

--- a/usermods/usermod_v2_rotary_encoder_ui/readme.md
+++ b/usermods/usermod_v2_rotary_encoder_ui/readme.md
@@ -15,11 +15,14 @@ This file should be placed in the same directory as `platformio.ini`.
 
 ### Define Your Options
 
-* `USERMOD_ROTARY_ENCODER_UI`  - define this to have this user mod included wled00\usermods_list.cpp
-* `USERMOD_FOUR_LINE_DISPLAY`  - define this to have this the Four Line Display mod included wled00\usermods_list.cpp - also tells this usermod that the display is available (see the Four Line Display usermod `readme.md` for more details)
-* `ENCODER_DT_PIN`             - The encoders DT pin, defaults to 12
-* `ENCODER_CLK_PIN`            - The encoders CLK pin, defaults to 14
-* `ENCODER_SW_PIN`             - The encoders SW pin, defaults to 13
+* `USERMOD_ROTARY_ENCODER_UI`   - define this to have this user mod included wled00\usermods_list.cpp
+* `USERMOD_ROTARY_ENCODER_GPIO` - define the GPIO function (INPUT, INPUT_PULLUP, etc...)
+* `USERMOD_FOUR_LINE_DISPLAY`   - define this to have this the Four Line Display mod included wled00\usermods_list.cpp
+                                    also tells this usermod that the display is available
+                                    (see the Four Line Display usermod `readme.md` for more details)
+* `ENCODER_DT_PIN`              - The encoders DT pin, defaults to 12
+* `ENCODER_CLK_PIN`             - The encoders CLK pin, defaults to 14
+* `ENCODER_SW_PIN`              - The encoders SW pin, defaults to 13
 
 ### PlatformIO requirements
 

--- a/usermods/usermod_v2_rotary_encoder_ui/usermod_v2_rotary_encoder_ui.h
+++ b/usermods/usermod_v2_rotary_encoder_ui/usermod_v2_rotary_encoder_ui.h
@@ -109,9 +109,13 @@ public:
       return;
     }
 
-    pinMode(pinA, INPUT_PULLUP);
-    pinMode(pinB, INPUT_PULLUP);
-    pinMode(pinC, INPUT_PULLUP);
+    #ifndef USERMOD_ROTARY_ENCODER_GPIO
+      #define USERMOD_ROTARY_ENCODER_GPIO INPUT_PULLUP
+    #endif
+    pinMode(pinA, USERMOD_ROTARY_ENCODER_GPIO);
+    pinMode(pinB, USERMOD_ROTARY_ENCODER_GPIO);
+    pinMode(pinC, USERMOD_ROTARY_ENCODER_GPIO);
+
     currentTime = millis();
     loopTime = currentTime;
 

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
@@ -277,9 +277,13 @@ public:
       return;
     }
 
-    pinMode(pinA, INPUT_PULLUP);
-    pinMode(pinB, INPUT_PULLUP);
-    pinMode(pinC, INPUT_PULLUP);
+    #ifndef USERMOD_ROTARY_ENCODER_GPIO
+      #define USERMOD_ROTARY_ENCODER_GPIO INPUT_PULLUP
+    #endif
+    pinMode(pinA, USERMOD_ROTARY_ENCODER_GPIO);
+    pinMode(pinB, USERMOD_ROTARY_ENCODER_GPIO);
+    pinMode(pinC, USERMOD_ROTARY_ENCODER_GPIO);
+
     loopTime = millis();
 
     for (uint8_t s = 0; s < busses.getNumBusses(); s++) {

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -302,6 +302,7 @@
   #define ABL_MILLIAMPS_DEFAULT 850  // auto lower brightness to stay close to milliampere limit
 #else
   #if ABL_MILLIAMPS_DEFAULT < 250  // make sure value is at least 250
+   #warning "make sure value is at least 250"
    #define ABL_MILLIAMPS_DEFAULT 250
   #endif
 #endif


### PR DESCRIPTION
added the possibility to customize some defaults using #define in platformio_override.ini:
- GPIO function for rotary encoder (needed on my custom PCB).
- change the defaults settings for auto-save usermod.

added a warning for ABL_MILLIAMPS_DEFAULT defined as less than 250 mA (this should help users that build WLED using this setting).