### PR TITLE
added new compile #defines

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -285,7 +285,7 @@
 #ifdef ESP8266
 #define SETTINGS_STACK_BUF_SIZE 2048
 #else
-#define SETTINGS_STACK_BUF_SIZE 3096 
+#define SETTINGS_STACK_BUF_SIZE 3096
 #endif
 
 #ifdef WLED_USE_ETHERNET
@@ -302,6 +302,7 @@
   #define ABL_MILLIAMPS_DEFAULT 850  // auto lower brightness to stay close to milliampere limit
 #else
   #if ABL_MILLIAMPS_DEFAULT < 250  // make sure value is at least 250
+   #warning "make sure value is at least 250"
    #define ABL_MILLIAMPS_DEFAULT 250
   #endif
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -24,10 +24,18 @@
 //#define WLED_DISABLE_OTA         // saves 14kb
 
 // You can choose some of these features to disable:
-//#define WLED_DISABLE_ALEXA       // saves 11kb
-//#define WLED_DISABLE_BLYNK       // saves 6kb
-//#define WLED_DISABLE_HUESYNC     // saves 4kb
-//#define WLED_DISABLE_INFRARED    // there is no pin left for this on ESP8266-01, saves 12kb
+#ifndef WLED_ENABLE_ALEXA
+  #define WLED_DISABLE_ALEXA       // saves 11kb
+#endif
+#ifndef WLED_ENABLE_BLYNK
+#define WLED_DISABLE_BLYNK         // saves 6kb
+#endif
+#ifndef WLED_ENABLE_HUESYNC
+#define WLED_DISABLE_HUESYNC       // saves 4kb
+#endif
+#ifndef WLED_ENABLE_INFRARED
+  #define WLED_DISABLE_INFRARED    // there is no pin left for this on ESP8266-01, saves 12kb
+#endif
 #ifndef WLED_DISABLE_MQTT
   #define WLED_ENABLE_MQTT         // saves 12kb
 #endif


### PR DESCRIPTION
added #define to easily enable/disable Alexa, Blynk, HueSync, IR into platformio_override.ini using these:
-D WLED_ENABLE_ALEXA
-D WLED_ENABLE_BLYNK
-D WLED_ENABLE_HUESYNC
-D WLED_ENABLE_INFRARED

added warning to inform that the DEFAULT value should not be lower than 250 mA