### PR TITLE
Fix SSDR usermod compilation

### DIFF
--- a/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
+++ b/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
@@ -384,7 +384,7 @@ public:
     if (!umSSDRDisplayTime || strip.isUpdating()) {
       return;
     }
-    #ifdef USERMOD_ID_SN_PHOTORESISTOR
+    #ifdef USERMOD_SN_PHOTORESISTOR
       if(bri != 0 && umSSDREnableLDR && (millis() - umSSDRLastRefresh > umSSDRResfreshTime)) {
         if (ptr != nullptr) {
           uint16_t lux = ptr->getLastLDRValue();


### PR DESCRIPTION
Hello,

This PR fixes a compilation error when compiling WLED with the SSDR usermod enabled.

Another commit (b211d8b085475247cc99379260aa67839b0e368d) already addressed this issue but one of the `#ifndef USERMOD_ID_SN_PHOTORESISTOR` was left unchanged.

Thanks