### PR TITLE
Upgrade DHT usermod

### DIFF
--- a/usermods/DHT/platformio_override.ini
+++ b/usermods/DHT/platformio_override.ini
@@ -6,7 +6,7 @@
 ; USERMOD_DHT_CELSIUS              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
 ; USERMOD_DHT_MEASUREMENT_INTERVAL - the number of milliseconds between measurements, defaults to 60 seconds
 ; USERMOD_DHT_FIRST_MEASUREMENT_AT - the number of milliseconds after boot to take first measurement, defaults to 90 seconds
-; USERMOD_DTH_MQTT                 - publish measurements to the MQTT broker
+; USERMOD_DHT_MQTT                 - publish measurements to the MQTT broker
 ; USERMOD_DHT_STATS                - For debug, report delay stats
 
 [env:d1_mini_usermod_dht_C]

--- a/usermods/DHT/platformio_override.ini
+++ b/usermods/DHT/platformio_override.ini
@@ -6,12 +6,13 @@
 ; USERMOD_DHT_CELSIUS              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
 ; USERMOD_DHT_MEASUREMENT_INTERVAL - the number of milliseconds between measurements, defaults to 60 seconds
 ; USERMOD_DHT_FIRST_MEASUREMENT_AT - the number of milliseconds after boot to take first measurement, defaults to 90 seconds
+; USERMOD_DTH_MQTT                 - publish measurements to the MQTT broker
 ; USERMOD_DHT_STATS                - For debug, report delay stats
 
 [env:d1_mini_usermod_dht_C]
 extends = env:d1_mini
 build_flags = ${env:d1_mini.build_flags} -D USERMOD_DHT -D USERMOD_DHT_CELSIUS
-lib_deps = ${env.lib_deps}
+lib_deps = ${env:d1_mini.lib_deps}
     https://github.com/alwynallan/DHT_nonblocking
 
 [env:custom32_LEDPIN_16_usermod_dht_C]

--- a/usermods/DHT/readme.md
+++ b/usermods/DHT/readme.md
@@ -1,7 +1,7 @@
 # DHT Temperature/Humidity sensor usermod
 
 This usermod will read from an attached DHT22 or DHT11 humidity and temperature sensor.
-The sensor readings are displayed in the Info section of the web UI.
+The sensor readings are displayed in the Info section of the web UI (and optionally send to a MQTT broker).
 
 If sensor is not detected after a while (10 update intervals), this usermod will be disabled.
 
@@ -17,6 +17,7 @@ Copy the example `platformio_override.ini` to the root directory.  This file sho
 * `USERMOD_DHT_CELSIUS`              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
 * `USERMOD_DHT_MEASUREMENT_INTERVAL` - the number of milliseconds between measurements, defaults to 60 seconds
 * `USERMOD_DHT_FIRST_MEASUREMENT_AT` - the number of milliseconds after boot to take first measurement, defaults to 90 seconds
+* `USERMOD_DTH_MQTT`                 - publish measurements to the MQTT broker
 * `USERMOD_DHT_STATS`                - For debug, report delay stats
 
 ## Project link
@@ -29,13 +30,15 @@ If you are using `platformio_override.ini`, you should be able to refresh the ta
 
 
 ## Change Log
-
+2022-10-15
+* Add possibility to publish sensor readings to an MQTT broker
+* fix compilation error for sample [env:d1_mini_usermod_dht_C] task
 2020-02-04
 * Change default QuinLed pin to Q2
 * Instead of trying to keep updates at constant cadence, space readings out by measurement interval; hope this helps to avoid occasional bursts of readings with errors
 * Add some more (optional) stats
 2020-02-03
 * Due to poor readouts on ESP32 with previous DHT library, rewrote to use https://github.com/alwynallan/DHT_nonblocking
-* The new library serializes/delays up to 5ms for the sensor readout  
-2020-02-02 
+* The new library serializes/delays up to 5ms for the sensor readout
+2020-02-02
 * Created

--- a/usermods/DHT/readme.md
+++ b/usermods/DHT/readme.md
@@ -5,6 +5,10 @@ The sensor readings are displayed in the Info section of the web UI (and optiona
 
 If sensor is not detected after a while (10 update intervals), this usermod will be disabled.
 
+If enabled measured temperature and humidity will be published to the following MQTT topics
+* `{devceTopic}/dht/temperature`
+* `{devceTopic}/dht/humidity`
+
 ## Installation
 
 Copy the example `platformio_override.ini` to the root directory.  This file should be placed in the same directory as `platformio.ini`.
@@ -17,7 +21,7 @@ Copy the example `platformio_override.ini` to the root directory.  This file sho
 * `USERMOD_DHT_CELSIUS`              - define this to report temperatures in degrees celsious, otherwise fahrenheit will be reported
 * `USERMOD_DHT_MEASUREMENT_INTERVAL` - the number of milliseconds between measurements, defaults to 60 seconds
 * `USERMOD_DHT_FIRST_MEASUREMENT_AT` - the number of milliseconds after boot to take first measurement, defaults to 90 seconds
-* `USERMOD_DTH_MQTT`                 - publish measurements to the MQTT broker
+* `USERMOD_DHT_MQTT`                 - publish measurements to the MQTT broker
 * `USERMOD_DHT_STATS`                - For debug, report delay stats
 
 ## Project link

--- a/usermods/DHT/usermod_dht.h
+++ b/usermods/DHT/usermod_dht.h
@@ -62,7 +62,7 @@ class UsermodDHT : public Usermod {
     float humidity, temperature = 0;
     bool initializing = true;
     bool disabled = false;
-    #ifdef USERMOD_DTH_MQTT
+    #ifdef USERMOD_DHT_MQTT
     char dhtMqttTopic[64];
     size_t dhtMqttTopicLen;
     #endif
@@ -80,8 +80,8 @@ class UsermodDHT : public Usermod {
     void setup() {
       nextReadTime = millis() + USERMOD_DHT_FIRST_MEASUREMENT_AT;
       lastReadTime = millis();
-      #ifdef USERMOD_DTH_MQTT
-      sprintf(dhtMqttTopic, "%s/dth", mqttDeviceTopic);
+      #ifdef USERMOD_DHT_MQTT
+      sprintf(dhtMqttTopic, "%s/dht", mqttDeviceTopic);
       dhtMqttTopicLen = strlen(dhtMqttTopic);
       #endif
       #ifdef USERMOD_DHT_STATS
@@ -118,7 +118,7 @@ class UsermodDHT : public Usermod {
         temperature = tempC * 9 / 5 + 32;
         #endif
 
-        #ifdef USERMOD_DTH_MQTT
+        #ifdef USERMOD_DHT_MQTT
         // 10^n where n is number of decimal places to display in mqtt message. Please adjust buff size together with this constant
         #define FLOAT_PREC 100
         if (WLED_MQTT_CONNECTED) {

--- a/usermods/DHT/usermod_dht.h
+++ b/usermods/DHT/usermod_dht.h
@@ -62,6 +62,10 @@ class UsermodDHT : public Usermod {
     float humidity, temperature = 0;
     bool initializing = true;
     bool disabled = false;
+    #ifdef USERMOD_DTH_MQTT
+    char dhtMqttTopic[64];
+    size_t dhtMqttTopicLen;
+    #endif
     #ifdef USERMOD_DHT_STATS
     unsigned long nextResetStatsTime = 0;
     uint16_t updates = 0;
@@ -76,6 +80,10 @@ class UsermodDHT : public Usermod {
     void setup() {
       nextReadTime = millis() + USERMOD_DHT_FIRST_MEASUREMENT_AT;
       lastReadTime = millis();
+      #ifdef USERMOD_DTH_MQTT
+      sprintf(dhtMqttTopic, "%s/dth", mqttDeviceTopic);
+      dhtMqttTopicLen = strlen(dhtMqttTopic);
+      #endif
       #ifdef USERMOD_DHT_STATS
       nextResetStatsTime = millis() + 60*60*1000;
       #endif
@@ -110,10 +118,29 @@ class UsermodDHT : public Usermod {
         temperature = tempC * 9 / 5 + 32;
         #endif
 
+        #ifdef USERMOD_DTH_MQTT
+        // 10^n where n is number of decimal places to display in mqtt message. Please adjust buff size together with this constant
+        #define FLOAT_PREC 100
+        if (WLED_MQTT_CONNECTED) {
+          char buff[10];
+
+          strcpy(dhtMqttTopic + dhtMqttTopicLen, "/temperature");
+          sprintf(buff, "%d.%d", (int)temperature, ((int)(temperature * FLOAT_PREC)) % FLOAT_PREC);
+          mqtt->publish(dhtMqttTopic, 0, false, buff);
+
+          sprintf(buff, "%d.%d", (int)humidity, ((int)(humidity * FLOAT_PREC)) % FLOAT_PREC);
+          strcpy(dhtMqttTopic + dhtMqttTopicLen, "/humidity");
+          mqtt->publish(dhtMqttTopic, 0, false, buff);
+
+          dhtMqttTopic[dhtMqttTopicLen] = '\0';
+        }
+        #undef FLOAT_PREC
+        #endif
+
         nextReadTime = millis() + USERMOD_DHT_MEASUREMENT_INTERVAL;
         lastReadTime = millis();
         initializing = false;
-        
+
         #ifdef USERMOD_DHT_STATS
         unsigned long icalc = millis() - currentIteration;
         if (icalc > maxIteration) {
@@ -134,7 +161,7 @@ class UsermodDHT : public Usermod {
       dcalc = millis() - dcalc;
       if (dcalc > maxDelay) {
         maxDelay = dcalc;
-      } 
+      }
       #endif
 
       if (((millis() - lastReadTime) > 10*USERMOD_DHT_MEASUREMENT_INTERVAL)) {
@@ -207,7 +234,7 @@ class UsermodDHT : public Usermod {
       temp.add("°F");
       #endif
     }
-   
+
     uint16_t getId()
     {
       return USERMOD_ID_DHT;


### PR DESCRIPTION
I am not the original author of this mod but I wanted to use such functionality and I think it may be useful for others.
Now it is possible to enable publishing DHT data to the configured MQTT broker. You can do that with compile flag `USERMOD_DHT_MQTT`. Also the sample build configuration was not working for me so I fixed it.

All the original functionalities are intact and this one is disabled by default.