### PR TITLE
Save config.json with default values on initial boot

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -555,7 +555,7 @@ void deserializeConfigFromFS() {
   DEBUG_PRINTLN(F("Reading settings from /cfg.json..."));
 
   success = readObjectFromFile("/cfg.json", nullptr, &doc);
-  if (!success) { //if file does not exist, try reading from EEPROM
+  if (!success) { // if file does not exist, optionally try reading from EEPROM and then save defaults to FS
     releaseJSONBufferLock();
     #ifdef WLED_ADD_EEPROM_SUPPORT
     deEEPSettings();
@@ -566,6 +566,10 @@ void deserializeConfigFromFS() {
     JsonObject empty = JsonObject();
     usermods.readFromConfig(empty);
     serializeConfig();
+    // init Ethernet (in case default type is set at compile time)
+    #ifdef WLED_USE_ETHERNET
+    WLED::instance().initEthernet();
+    #endif
     return;
   }
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -556,10 +556,16 @@ void deserializeConfigFromFS() {
 
   success = readObjectFromFile("/cfg.json", nullptr, &doc);
   if (!success) { //if file does not exist, try reading from EEPROM
+    releaseJSONBufferLock();
     #ifdef WLED_ADD_EEPROM_SUPPORT
     deEEPSettings();
     #endif
-    releaseJSONBufferLock();
+
+    // save default values to /cfg.json
+    // call readFromConfig() with an empty object so that usermods can initialize to defaults prior to saving
+    JsonObject empty = JsonObject();
+    usermods.readFromConfig(empty);
+    serializeConfig();
     return;
   }
 
@@ -568,7 +574,7 @@ void deserializeConfigFromFS() {
   bool needsSave = deserializeConfig(doc.as<JsonObject>(), true);
   releaseJSONBufferLock();
 
-  if (needsSave) serializeConfig(); // usermods required new prameters
+  if (needsSave) serializeConfig(); // usermods required new parameters
 }
 
 void serializeConfig() {

--- a/wled00/wled_eeprom.cpp
+++ b/wled00/wled_eeprom.cpp
@@ -467,11 +467,5 @@ void deEEPSettings() {
   EEPROM.begin(EEPSIZE);
   loadSettingsFromEEPROM();
   EEPROM.end();
-
-  //call readFromConfig() with an empty object so that usermods can initialize to defaults prior to saving
-  JsonObject empty = JsonObject();
-  usermods.readFromConfig(empty);
-
-  serializeConfig();
 }
 #endif


### PR DESCRIPTION
Disabling EEPROM by default caused `cfg.json` to only be written when any settings page is first saved on fresh installs.
This doesn't cause issues in most cases, still it is better if config is always present in FS.
Also initializes Ethernet immediately if a type was set at compile time.
