### PR TITLE
Automatically set PC Mode if unset

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -262,8 +262,7 @@ function onLoad()
 	d.addEventListener("visibilitychange", handleVisibilityChange, false);
 	size();
 	gId("cv").style.opacity=0;
-	if (localStorage.getItem('pcm') == "true") togglePcMode(true);
-	if (!/Mobi/.test(navigator.userAgent) && localStorage.getItem('pcm') == null) togglePcMode(true);
+	if (localStorage.getItem('pcm') == "true" || (!/Mobi/.test(navigator.userAgent) && localStorage.getItem('pcm') == null)) togglePcMode(true);
 	var sls = d.querySelectorAll('input[type="range"]');
 	for (var sl of sls) {
 		sl.addEventListener('touchstart', toggleBubble);

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -263,6 +263,7 @@ function onLoad()
 	size();
 	gId("cv").style.opacity=0;
 	if (localStorage.getItem('pcm') == "true") togglePcMode(true);
+	if (!/Mobi/.test(navigator.userAgent) && localStorage.getItem('pcm') == null) togglePcMode(true);
 	var sls = d.querySelectorAll('input[type="range"]');
 	for (var sl of sls) {
 		sl.addEventListener('touchstart', toggleBubble);


### PR DESCRIPTION
I added a short JavaScript snippet that enables PC mode when the browser's User Agent isn't mobile and PC mode is unset. So you can override it and it will respect that.

[Mozilla says](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#mobile_tablet_or_desktop), "we recommend looking for the string Mobi anywhere in the User Agent to detect a mobile device." So that's what I did.