### PR TITLE
Fix Gitpod compiling

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,3 @@
 FROM gitpod/workspace-full
-                    
-USER gitpod
 
-RUN pip3 install -U platformio
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,11 @@
 tasks:
-  - command: platformio run
+  - command: pip3 install -U platformio && platformio run
 
 image:
   file: .gitpod.Dockerfile
 
 vscode:
   extensions:
-    - ms-vscode.cpptools@0.26.3:u3GsZ5PK12Ddr79vh4TWgQ==
-    - eamodio.gitlens@10.2.1:e0IYyp0efFqVsrZwsIe8CA==
-    - Atishay-Jain.All-Autocomplete@0.0.23:fbZNfSpnd8XkAHGfAPS2rA==
-    - 2gua.rainbow-brackets@0.0.6:Tbu8dTz0i+/bgcKQTQ5b8g==
+    - Atishay-Jain.All-Autocomplete
+    - esbenp.prettier-vscode
+    - shardulm94.trailing-spaces


### PR DESCRIPTION
Reason for failing is a outdated Platformio version which is placed in Gitpod image.
With this change Platformio is installed later (not in Image)