### PR TITLE
Fix ledmap dropdown in presets

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1821,7 +1821,7 @@ ${makePlSel(plJson[i].end?plJson[i].end:0, true)}
 </label>`;
 		if (Array.isArray(lastinfo.maps) && lastinfo.maps.length>0) {
 			content += `<div class="lbl-l">Ledmap:&nbsp;<div class="sel-p"><select class="sel-p" id="p${i}lmp"><option value="">None</option>`;
-			for (const k of (lastinfo.maps||[])) content += `<option value="${k}"${(i>0 && pJson[i].ledmap==k)?" selected":""}>${k}</option>`;
+			for (const k of (lastinfo.maps||[])) content += `<option value="${k}"${(i>0 && pJson[i].ledmap==k)?" selected":""}>ledmap${k}.json</option>`;
 			content += "</select></div></div>";
 		}
 	}

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -370,7 +370,10 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 
   usermods.readFromJsonState(root);
 
-  loadLedmap = root[F("ledmap")] | loadLedmap;
+  if (root[F("ledmap")].isNull())
+    loadLedmap = 0;
+  else
+    loadLedmap = root[F("ledmap")] | loadLedmap;
 
   byte ps = root[F("psave")];
   if (ps > 0 && ps < 251) savePreset(ps, nullptr, root);
@@ -493,6 +496,11 @@ void serializeState(JsonObject root, bool forPreset, bool includeBri, bool segme
     root["bri"] = briLast;
     root[F("transition")] = transitionDelay/100; //in 100ms
   }
+
+  if (loadLedmap>0)
+    root[F("ledmap")] = loadLedmap;
+  else
+    root.remove(F("ledmap"));
 
   if (!forPreset) {
     if (errorFlag) {root[F("error")] = errorFlag; errorFlag = ERR_NONE;} //prevent error message to persist on screen

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -13,7 +13,7 @@ static volatile byte callModeToApply = 0;
 static volatile byte presetToSave = 0;
 static char quickLoad[3];
 static char saveName[33];
-static bool includeBri = true, segBounds = true, selectedOnly = false, playlistSave = false;;
+static bool includeBri = true, segBounds = true, selectedOnly = false, playlistSave = false;
 
 static const char *getName(bool persist = true) {
   return persist ? "/presets.json" : "/tmp.json";
@@ -208,6 +208,7 @@ void savePreset(byte index, const char* pname, JsonObject sObj)
       playlistSave = true;
     }
   }
+  loadLedmap = sObj["ledmap"];
 }
 
 void deletePreset(byte index) {

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -504,7 +504,7 @@ um_data_t* simulateSound(uint8_t simulationId)
 
 
 void enumerateLedmaps() {
-  ledMaps = 1;
+  ledMaps = 0;
   for (size_t i=1; i<10; i++) {
     char fileName[16];
     sprintf_P(fileName, PSTR("/ledmap%d.json"), i);


### PR DESCRIPTION
The ledmap drop down in presets is currently not working, it should show the ledmap included in the api and if dropdown is updated, the api should also be updated. And if set to non should be removed.
Also when set to none, the customMappingTable should be cleared.

Removed also the 0 as non functional dropdown option, and shows ledmapx.json instead of only x.

Note: json files should be named ledmap1.json until ledmap9.json. Ledmap0.json will not be read but is used as "no ledmap". 

This is fixed in this pull request 