### PR TITLE
feat(wifi): add compile time configurtation

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -9,6 +9,7 @@
 
 //Defaults
 #define DEFAULT_CLIENT_SSID "Your_Network"
+#define DEFAULT_AP_SSID     "WLED-AP"
 #define DEFAULT_AP_PASS     "wled1234"
 #define DEFAULT_OTA_PASS    "wledota"
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -364,7 +364,13 @@ void WLED::setup()
 #endif
   updateFSInfo();
 
-  strcpy_P(apSSID, PSTR("WLED-AP"));  // otherwise it is empty on first boot until config is saved
+  // generate module IDs must be done before AP setup
+  escapedMac = WiFi.macAddress();
+  escapedMac.replace(":", "");
+  escapedMac.toLowerCase();
+
+  WLED_SET_AP_SSID(); // otherwise it is empty on first boot until config is saved
+
   DEBUG_PRINTLN(F("Reading config"));
   deserializeConfigFromFS();
 
@@ -398,10 +404,6 @@ void WLED::setup()
   }
   #endif
 
-  // generate module IDs
-  escapedMac = WiFi.macAddress();
-  escapedMac.replace(":", "");
-  escapedMac.toLowerCase();
   // fill in unique mdns default
   if (strcmp(cmDNS, "x") == 0) sprintf_P(cmDNS, PSTR("wled-%*s"), 6, escapedMac.c_str() + 6);
   if (mqttDeviceTopic[0] == 0) sprintf_P(mqttDeviceTopic, PSTR("wled/%*s"), 6, escapedMac.c_str() + 6);
@@ -480,8 +482,8 @@ void WLED::initAP(bool resetAP)
     return;
 
   if (resetAP) {
-    strcpy_P(apSSID, PSTR("WLED-AP"));
-    strcpy_P(apPass, PSTR(DEFAULT_AP_PASS));
+    WLED_SET_AP_SSID();
+    strcpy_P(apPass, PSTR(WLED_AP_PASS));
   }
   DEBUG_PRINT(F("Opening access point "));
   DEBUG_PRINTLN(apSSID);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -171,6 +171,29 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
   #define CLIENT_PASS ""
 #endif
 
+#if defined(WLED_AP_PASS) && !defined(WLED_AP_SSID)
+  #error WLED_AP_PASS is defined but WLED_AP_SSID is still the default. \
+         Please change WLED_AP_SSID to something unique.
+#endif
+
+#if defined(WLED_AP_SSID_UNIQUE) && !defined(WLED_AP_SSID)
+  #error WLED_AP_SSID_UNIQUE is defined but WLED_AP_SSID is still the \
+         default. Please change WLED_AP_SSID to something unique.
+#endif
+
+#if defined(WLED_AP_SSID_UNIQUE) && !defined(WLED_AP_PASS)
+  #error WLED_AP_SSID_UNIQUE is defined but WLED_AP_PASS is still the \
+         default. Please change WLED_AP_PASS to something unique.
+#endif
+
+#ifndef WLED_AP_SSID
+  #define WLED_AP_SSID DEFAULT_AP_SSID
+#endif
+
+#ifndef WLED_AP_PASS
+  #define WLED_AP_PASS DEFAULT_AP_PASS
+#endif
+
 #ifndef SPIFFS_EDITOR_AIRCOOOKIE
   #error You are not using the Aircoookie fork of the ESPAsyncWebserver library.\
   Using upstream puts your WiFi password at risk of being served by the filesystem.\
@@ -225,7 +248,7 @@ WLED_GLOBAL char versionString[] _INIT(TOSTRING(WLED_VERSION));
 #define WLED_CODENAME "Hoshi"
 
 // AP and OTA default passwords (for maximum security change them!)
-WLED_GLOBAL char apPass[65]  _INIT(DEFAULT_AP_PASS);
+WLED_GLOBAL char apPass[65]  _INIT(WLED_AP_PASS);
 WLED_GLOBAL char otaPass[33] _INIT(DEFAULT_OTA_PASS);
 
 // Hardware and pin config
@@ -707,6 +730,23 @@ WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
 #endif
 #define WLED_WIFI_CONFIGURED (strlen(clientSSID) >= 1 && strcmp(clientSSID, DEFAULT_CLIENT_SSID) != 0)
 #define WLED_MQTT_CONNECTED (mqtt != nullptr && mqtt->connected())
+
+#ifndef WLED_AP_SSID_UNIQUE
+  #define WLED_SET_AP_SSID() do { \
+    strcpy_P(apSSID, PSTR(WLED_AP_SSID)); \
+  } while(0)
+#else
+  #define WLED_SET_AP_SSID() do { \
+    strcpy_P(apSSID, PSTR(WLED_AP_SSID)); \
+    snprintf_P(\
+      apSSID+strlen(WLED_AP_SSID), \
+      sizeof(apSSID)-strlen(WLED_AP_SSID), \
+      PSTR("-%*s"), \
+      6, \
+      escapedMac.c_str() + 6\
+    ); \
+  } while(0)
+#endif
 
 //macro to convert F to const
 #define SET_F(x)  (const char*)F(x)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -176,16 +176,6 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
          Please change WLED_AP_SSID to something unique.
 #endif
 
-#if defined(WLED_AP_SSID_UNIQUE) && !defined(WLED_AP_SSID)
-  #error WLED_AP_SSID_UNIQUE is defined but WLED_AP_SSID is still the \
-         default. Please change WLED_AP_SSID to something unique.
-#endif
-
-#if defined(WLED_AP_SSID_UNIQUE) && !defined(WLED_AP_PASS)
-  #error WLED_AP_SSID_UNIQUE is defined but WLED_AP_PASS is still the \
-         default. Please change WLED_AP_PASS to something unique.
-#endif
-
 #ifndef WLED_AP_SSID
   #define WLED_AP_SSID DEFAULT_AP_SSID
 #endif


### PR DESCRIPTION
Add `WLED_AP_SSID` and `WLED_AP_PASS` defines to allow configuring the SoftAP SSID and Password at compile time. Default to existing values.

Add `WLED_AP_SSID`_UNIQUE flag to append the device portion of the mac address to `WLED_AP_SSID`.

Example use of all flags (note the quoting to preserve "stringification"):

```
build_flags =
    -D WLED_AP_SSID='"MyAP"'
    -D WLED_AP_PASS='"MyPassword"'
    -D WLED_AP_SSID_UNIQUE
```