### PR TITLE
Don't use internal pulldown on button inputs

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -200,11 +200,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       int8_t pin = btn["pin"][0] | -1;
       if (pin > -1 && pinManager.allocatePin(pin, false, PinOwner::Button)) {
         btnPin[s] = pin;
-        #ifdef ESP32
-        pinMode(btnPin[s], buttonType[s]==BTN_TYPE_PUSH_ACT_HIGH ? INPUT_PULLDOWN : INPUT_PULLUP);
-        #else
         pinMode(btnPin[s], INPUT_PULLUP);
-        #endif
       } else {
         btnPin[s] = -1;
       }


### PR DESCRIPTION
After stumbling upon issues with a PCB design, I found out that the issue was caused by the use of internal pulllup resistors on the input pins that is not mentioned in the documentation. Another suggestion for my fix for the documentation was to mention that on ESP32 (but not ESP8266), an internal pulldown (instead of pullup) is used when the input type is set to "inverted button".

This behaviour is confusing because of several reasons:

1.  It is different between ESP32 and ESP8266, and many boards can be used with both MCUs on pin compatible modules (Wemos D1 etc.).
2. Normally, a button is connected between signal and ground for several reasons: It is easier to route the PCB as a GND layer should be all over the board, whereas the power trace must be routed to the button if it is connected between VDD and signal. GND is usually less noisy than VDD. Debouncing capacitor should be connected between signal and GND. Less EMI as the return path for the signal is GND instead of VDD.
3. As most buttons are connected between signal and GND, with a pullup to VDD on most boards, setting an internal pullldown resistor might cause additional issues, as then the external pullup and the internal pulldown act as a voltage divider, which can then cause the signal to be under the threshold voltage for high level. As the internal pull resistor value is not very precise ("between 10k and 100k", https://esp32.com/viewtopic.php?t=5111), this adds another layer of confusing randomness to the problem, as even though the button might work on a certain pin on a certain board, it might not work on a different pin or a different board.

The "inverted button" has a different use case: wiring is the same as with a normal button (pullup to VDD, switch and debounce capacitor connected to GND), but a normal switch is normally open and a inverted switch is normally closed.
On a normally open switch, the signal is usually pulled high, but is connected to GND when the switch is activated.
On a normally closed switch, the signal is usually connected to GND, but is pulled high when the switch is activated.

I also checked https://kno.wled.ge/basics/compatible-hardware/ and none of the boards in the list uses buttons that are connected between signal and VDD. So changing the behaviour as suggested should not cause any issues with existing designs.

Here's the link to the PR for the fix and additional information in the documentation:https://github.com/Aircoookie/WLED-Docs/pull/93

Best solution would be to allow the user to set the input type (pullup, pulldown, none), but this is beyond my coding capabilities. I'm am hardware guy.