### PR TITLE
Bluetooth Serial JSON Control and WiFi Deferment

### DIFF
--- a/tools/WLED_ESP32_NO_OTA.csv
+++ b/tools/WLED_ESP32_NO_OTA.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x200000,
+spiffs,   data, spiffs,  0x210000,0x1F0000,

--- a/usermods/bluetooth_serial/bluetooth_serial.h
+++ b/usermods/bluetooth_serial/bluetooth_serial.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "wled.h"
 #include "BluetoothSerial.h"
+#include "esp_bt_device.h"
 
 BluetoothSerial SerialBT;
 
@@ -17,10 +18,21 @@ class BluetoothSerialUsermod : public Usermod {
       SerialBT.begin(serverDescription);
 
       Serial.println("Bluetooth Serial Usermod setup complete");
+
+      // The name the bluetooth device will appear as, same as set in server description
       Serial.print("Bluetooth Name: ");
       Serial.println(serverDescription);
+
+      // The local bluetooth device address
       Serial.print("Bluetooth Address: ");
-      Serial.println("todo");
+      const uint8_t* point = esp_bt_dev_get_address();
+      for (int i = 0; i < 6; i++) {
+        char str[3];
+        sprintf(str, "%02X", (int)point[i]);
+        Serial.print(str);
+        if (i < 5) Serial.print(":");
+      }
+      Serial.println();
     }
 
 

--- a/usermods/bluetooth_serial/bluetooth_serial.h
+++ b/usermods/bluetooth_serial/bluetooth_serial.h
@@ -9,6 +9,7 @@ class BluetoothSerialUsermod : public Usermod {
  
   public:
 
+
     void setup() {
 
       // Tell WLED to defer all WiFi Connectivity

--- a/usermods/bluetooth_serial/bluetooth_serial.h
+++ b/usermods/bluetooth_serial/bluetooth_serial.h
@@ -17,6 +17,10 @@ class BluetoothSerialUsermod : public Usermod {
       SerialBT.begin(serverDescription);
 
       Serial.println("Bluetooth Serial Usermod setup complete");
+      Serial.print("Bluetooth Name: ");
+      Serial.println(serverDescription);
+      Serial.print("Bluetooth Address: ");
+      Serial.println("todo");
     }
 
 

--- a/usermods/bluetooth_serial/bluetooth_serial.h
+++ b/usermods/bluetooth_serial/bluetooth_serial.h
@@ -1,0 +1,73 @@
+#pragma once
+#include "wled.h"
+#include "BluetoothSerial.h"
+
+BluetoothSerial SerialBT;
+
+class BluetoothSerialUsermod : public Usermod {
+ 
+  public:
+
+    void setup() {
+
+      // Tell WLED to defer all WiFi Connectivity
+      deferConnections = true;
+      
+      // Begin Bluetooth device with same name as server description
+      SerialBT.begin(serverDescription);
+
+      Serial.println("Bluetooth Serial Usermod setup complete");
+    }
+
+
+    // Cleans up and lets WLED run WiFi normally.
+    // Once called, this usermod is disabled until next boot
+    void stop(){
+      SerialBT.flush();
+      SerialBT.end();
+      deferConnections=false;
+      Serial.println("Stop Bluetooth Serial and use WLED normally");
+    }
+
+
+    void loop() {
+
+      // If Wifi Deferment has ended, do nothing
+      if(!deferConnections){
+        return;
+      }
+
+      // If not set up or if preset changes in first 5* seconds of boot, disable Bluetooth and end WiFi deferment
+      unsigned long now = millis();
+      if(now > 1000 && now < 6000 && (currentPreset != bootPreset || currentPreset == 0 && bootPreset == 0)){
+        stop();
+      }
+
+      while (SerialBT.available() > 0)
+      {
+        yield();
+        byte next = SerialBT.peek();
+
+        // If 'e' is received, stop bluetooth and end WiFi deferment so WLED WiFi can start
+        if (next == 'e'){
+          stop();
+          break;
+        }
+
+        else if (next == '{') { // JSON API
+          bool verboseResponse = false;
+          if (!requestJSONBufferLock(16)) return;
+          DeserializationError error = deserializeJson(doc, SerialBT);
+          if (error) {
+            releaseJSONBufferLock();
+            return;
+          }
+          verboseResponse = deserializeState(doc.as<JsonObject>());
+          releaseJSONBufferLock();
+        }
+        SerialBT.read(); // Discard the byte
+      }
+    }
+
+    uint16_t getId(){return USERMOD_ID_EXAMPLE;}
+};

--- a/usermods/bluetooth_serial/bluetooth_serial.h
+++ b/usermods/bluetooth_serial/bluetooth_serial.h
@@ -9,16 +9,19 @@ class BluetoothSerialUsermod : public Usermod {
  
   public:
 
+    //const char *pin = "987654";
 
     void setup() {
 
       // Tell WLED to defer all WiFi Connectivity
       deferConnections = true;
-      
+
+      //SerialBT.setPin(pin); // Deeper issues are here, does not work as is
+
       // Begin Bluetooth device with same name as server description
       SerialBT.begin(serverDescription);
-
-      Serial.println("Bluetooth Serial Usermod setup complete");
+      
+      DEBUG_PRINTLN(F("Bluetooth Serial Usermod setup complete"));
 
       // The name the bluetooth device will appear as, same as set in server description
       Serial.print("Bluetooth Name: ");
@@ -43,7 +46,8 @@ class BluetoothSerialUsermod : public Usermod {
       SerialBT.flush();
       SerialBT.end();
       deferConnections=false;
-      Serial.println("Stop Bluetooth Serial and use WLED normally");
+      forceReconnect=true; // May not be needed
+      DEBUG_PRINTLN(F("Stop Bluetooth Serial and use WLED normally"));
     }
 
 
@@ -56,7 +60,7 @@ class BluetoothSerialUsermod : public Usermod {
 
       // If not set up or if preset changes in first 5* seconds of boot, disable Bluetooth and end WiFi deferment
       unsigned long now = millis();
-      if(now > 1000 && now < 6000 && (currentPreset != bootPreset || currentPreset == 0 && bootPreset == 0)){
+      if((now > 1000 && now < 6000) && ((currentPreset != bootPreset) || (currentPreset == 0 && bootPreset == 0))){
         stop();
       }
 

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -7,16 +7,10 @@
   * Normal WiFi functionality until "Apply preset at boot" is set.
   * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume. (simple button press would suffice)
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
-* __Only tested on D1 Mini ESP32 with the following PlatformIO example__
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing
 * [Reference: Python to ESP32 bluetooth serial](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
 * [Example Python Script](https://gist.github.com/ChuckMash/7752b77ea1bf204a7e8f0acac6e27641) for WLED control over Bluetooth Serial
-
-
-
-
-
-
+* __Only tested on D1 Mini ESP32 with the following PlatformIO example__
 
 ```
 [platformio]

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -5,7 +5,7 @@ Experimental Bluetooth Control for WLED.
 * Bluetooth device shows up as whatever is set in "Server description", "WLED" by default.
 * Normal WiFi functionality can be accessed for general WLED setup under the following conditions
   * Normal WiFi functionality until "Apply preset at boot" is set.
-  * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume.
+  * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume. (simple button press would suffice)
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
 * Only tested on D1 Mini ESP32 with the following PlatformIO example
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -4,7 +4,7 @@
 * __Normal WiFi functionality is disabled while Bluetooth is in use. OTA disabled due to size constraints__
 * Bluetooth device shows up as whatever is set in "Server description", "WLED" by default.
 * Normal WiFi functionality can be accessed for general WLED setup under the following conditions
-  * Normal WiFi functionality until "Apply preset at boot" is set.
+  * Normal WiFi functionality until "Apply preset at boot" is set (other than 0).
   * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume. (simple button press would suffice)
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -9,7 +9,7 @@ Experimental Bluetooth Control for WLED.
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
 * Only tested on D1 Mini ESP32 with the following PlatformIO example
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing
-
+* [Python to WLED bluetooth serial reference](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
 
 
 

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -1,7 +1,7 @@
-Experimental Bluetooth Control for WLED.
+# Experimental Bluetooth Control for WLED.
 
 * Allows access to JSON API over Bluetooth Serial Connection.
-* Normal WiFi functionality is disabled while Bluetooth is in use
+* __Normal WiFi functionality is disabled while Bluetooth is in use__
 * Bluetooth device shows up as whatever is set in "Server description", "WLED" by default.
 * Normal WiFi functionality can be accessed for general WLED setup under the following conditions
   * Normal WiFi functionality until "Apply preset at boot" is set.
@@ -9,8 +9,8 @@ Experimental Bluetooth Control for WLED.
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
 * Only tested on D1 Mini ESP32 with the following PlatformIO example
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing
-* [Python to WLED bluetooth serial reference](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
-
+* [Reference: Python to ESP32 bluetooth serial](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
+* [Example Python Script](https://gist.github.com/ChuckMash/7752b77ea1bf204a7e8f0acac6e27641) for WLED control over Bluetooth Serial
 
 
 

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -1,7 +1,7 @@
 # Experimental Bluetooth Control for WLED.
 
 * Allows access to JSON API over Bluetooth Serial Connection.
-* __Normal WiFi functionality is disabled while Bluetooth is in use__
+* __Normal WiFi functionality is disabled while Bluetooth is in use. OTA disabled due to size constraints__
 * Bluetooth device shows up as whatever is set in "Server description", "WLED" by default.
 * Normal WiFi functionality can be accessed for general WLED setup under the following conditions
   * Normal WiFi functionality until "Apply preset at boot" is set.

--- a/usermods/bluetooth_serial/readme.md
+++ b/usermods/bluetooth_serial/readme.md
@@ -7,7 +7,7 @@
   * Normal WiFi functionality until "Apply preset at boot" is set.
   * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume. (simple button press would suffice)
   * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
-* Only tested on D1 Mini ESP32 with the following PlatformIO example
+* __Only tested on D1 Mini ESP32 with the following PlatformIO example__
 * [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing
 * [Reference: Python to ESP32 bluetooth serial](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
 * [Example Python Script](https://gist.github.com/ChuckMash/7752b77ea1bf204a7e8f0acac6e27641) for WLED control over Bluetooth Serial

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -99,6 +99,7 @@
 #define USERMOD_ID_ADS1115               35     //Usermod "usermod_ads1115.h"
 #define USERMOD_ID_SD_CARD               37     //Usermod "usermod_sd_card.h"
 #define USERMOD_ID_PWM_OUTPUTS           38     //Usermod "usermod_pwm_outputs.h
+#define USERMOD_ID_BLUETOOTH_SERIAL      39     //Usermod "bluetooth_serial.h"
 
 //Access point behavior
 #define AP_BEHAVIOR_BOOT_NO_CONN          0     //Open AP when no connection after boot

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -69,9 +69,9 @@ class PinManagerClass {
   uint8_t pinAlloc[3] = {0x00, 0x00, 0x00}; //24bit, 1 bit per pin, we use first 17bits
   PinOwner ownerTag[17] = { PinOwner::None };
   #else
-  uint8_t pinAlloc[5] = {0x00, 0x00, 0x00, 0x00, 0x00}; //40bit, 1 bit per pin, we use all bits
+  uint8_t pinAlloc[7] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}; // 56bit, 1 bit per pin, we use 50 bits on ESP32-S3
   uint8_t ledcAlloc[2] = {0x00, 0x00}; //16 LEDC channels
-  PinOwner ownerTag[40] = { PinOwner::None };
+  PinOwner ownerTag[50] = { PinOwner::None }; // new MCU's have up to 50 GPIO
   #endif
   struct {
     uint8_t i2cAllocCount : 4; // allow multiple allocation of I2C bus pins but keep track of allocations

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -176,6 +176,9 @@
 #include "../usermods/pwm_outputs/usermod_pwm_outputs.h"
 #endif
 
+#ifdef USERMOD_BLUETOOTH_SERIAL
+  #include "../usermods/bluetooth_serial/bluetooth_serial.h"
+#endif
 
 void registerUsermods()
 {
@@ -331,5 +334,9 @@ void registerUsermods()
   
   #ifdef USERMOD_PWM_OUTPUTS
   usermods.add(new PwmOutputsUsermod());
+  #endif
+
+  #ifdef USERMOD_BLUETOOTH_SERIAL
+  usermods.add(new BluetoothSerialUsermod());
   #endif
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -716,6 +716,10 @@ void WLED::initInterfaces()
 
 void WLED::handleConnection()
 {
+  // If deferConnections is set, do nothing until unset
+  if (deferConnections)
+    return;
+
   static byte stacO = 0;
   static uint32_t lastHeap = UINT32_MAX;
   static unsigned long heapTime = 0;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -481,6 +481,12 @@ WLED_GLOBAL uint32_t lastReconnectAttempt _INIT(0);
 WLED_GLOBAL bool interfacesInited _INIT(false);
 WLED_GLOBAL bool wasConnected _INIT(false);
 
+#ifdef WLED_DEFER_CONNECTIONS
+WLED_GLOBAL bool deferConnections _INIT(true);
+#else
+WLED_GLOBAL bool deferConnections _INIT(false);
+#endif
+
 // color
 WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
 

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -110,6 +110,10 @@ void handleSerial()
         } else if (next == 'o') {continuousSendLED = false; // Disable Continuous Serial Streaming  
         } else if (next == 'O') {continuousSendLED = true; // Enable Continuous Serial Streaming
 
+        #ifdef WLED_DEFER_CONNECTIONS
+        } else if (next == 'e') {if(deferConnections) deferConnections = false;
+        #endif
+
         } else if (next == '{') { //JSON API
           bool verboseResponse = false;
           if (!requestJSONBufferLock(16)) return;

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -110,6 +110,7 @@ void handleSerial()
         } else if (next == 'o') {continuousSendLED = false; // Disable Continuous Serial Streaming  
         } else if (next == 'O') {continuousSendLED = true; // Enable Continuous Serial Streaming
 
+        // If compiled with defered connection option, add serial command to end deferment
         #ifdef WLED_DEFER_CONNECTIONS
         } else if (next == 'e') {if(deferConnections) deferConnections = false;
         #endif


### PR DESCRIPTION
Due to a very similar PR (#2925) also today, I will open this a draft to encourage discussion between the 2 similar implementations.


* Allows access to JSON API over Bluetooth Serial Connection.
* __Normal WiFi functionality is disabled while Bluetooth is in use. OTA disabled due to size constraints__
* Bluetooth device shows up as whatever is set in "Server description", "WLED" by default.
* Normal WiFi functionality can be accessed for general WLED setup under the following conditions
  * Normal WiFi functionality until "Apply preset at boot" is set.
  * If active preset changes by any means during first 5 seconds, normal WiFi functionality will resume. (simple button press would suffice)
  * If 'e' is sent over the bluetooth serial connection, normal WiFi functionality will resume.
* [Serial Bluetooth Terminal](https://play.google.com/store/apps/details?id=de.kai_morich.serial_bluetooth_terminal) Android app for testing
* [Reference: Python to ESP32 bluetooth serial](https://medium.com/@18218004/devlog-6-bluetooth-and-esp32-ba076a8e207d)
* [Example Python Script](https://gist.github.com/ChuckMash/7752b77ea1bf204a7e8f0acac6e27641) for WLED control over Bluetooth Serial