### PR TITLE
support the ESP32-C3-12F module from AI-Thinker and associated boards

### DIFF
--- a/boards/esp32-c3-12f.json
+++ b/boards/esp32-c3-12f.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "esp32c3_out.ld"
+    },
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "extra_flags": [
+      "-DARDUINO_USB_MODE=1"
+    ],
+    "mcu": "esp32c3",
+    "variant": "esp32c3"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Ai-Thinker ESP32-C3-12F",
+  "upload": {
+    "flash_size": "2MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 2097152,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.electrodragon.com/product/esp-led-strip-board/",
+  "vendor": "Ai-Thinker"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -195,7 +195,7 @@ build_flags =
 ; restrict to minimal mime-types
   -DMIMETYPE_MINIMAL
 
-lib_deps = 
+lib_deps =
   ${env.lib_deps}
   #https://github.com/lorol/LITTLEFS.git
   ESPAsyncTCP @ 1.2.2
@@ -398,7 +398,7 @@ platform = espressif32@5.1.1
 platform_packages =
 upload_speed = 921600 ; or  460800
 build_unflags = ${common.build_unflags}
-build_flags =  ${common.build_flags} ${esp32s3.build_flags} 
+build_flags =  ${common.build_flags} ${esp32s3.build_flags}
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_CDC_ON_BOOT=0 -D ARDUINO_USB_MSC_ON_BOOT=0 -D ARDUINO_DFU_ON_BOOT=0 -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   ;-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MSC_ON_BOOT=0 -D ARDUINO_DFU_ON_BOOT=0 ; -D ARDUINO_USB_MODE=0 ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -416,10 +416,10 @@ monitor_filters = esp32_exception_decoder
 ;board = esp32s3box   ; -> error: 'esp32_adc2gpio' was not declared in this scope
 board = esp32-s3-devkitc-1 ; -> compiles, but does not support PSRAM
 platform = espressif32 @ ~5.2.0
-platform_packages = 
+platform_packages =
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags =  ${common.build_flags} ${esp32s3.build_flags} 
+build_flags =  ${common.build_flags} ${esp32s3.build_flags}
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_MODE=1 -D ARDUINO_USB_MSC_ON_BOOT=0 ; -D ARDUINO_USB_CDC_ON_BOOT=0
   ; -D WLED_RELEASE_NAME=ESP32-S3_PSRAM
@@ -641,3 +641,9 @@ lib_deps =
   ${esp32.lib_deps}
   TFT_eSPI @ ^2.3.70
 board_build.partitions = ${esp32.default_partitions}
+
+[env:esp32-c3-12f]
+extends = env:esp32c3
+board = esp32-c3-12f
+platform = espressif32@5.2.0
+board_build.partitions = tools/WLED_ESP32_2MB_C3.csv

--- a/tools/WLED_ESP32_2MB_C3.csv
+++ b/tools/WLED_ESP32_2MB_C3.csv
@@ -1,0 +1,5 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,    20K,
+otadata,  data, ota,     0xe000,    8K,
+app0,     app,  ota_0,   0x10000,   1536K,
+spiffs,   data, spiffs,  0x190000,  384K,


### PR DESCRIPTION
An addition to support the Ai-Thinker ESP32-C3-12F module which has 2MB flash and needs a special board and partition layout. Board is not officially supported upstream yet (https://github.com/platformio/platform-espressif32/issues/806) so a custom board was added.

In Discord it sounded like we didn't want this to be a primary supported board, yet. But opening this PR early so others can see it if they want to pull it in to compile.