### PR TITLE
Add build flags for global i2c & SPI pins

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -392,12 +392,22 @@
 
 #define INTERFACE_UPDATE_COOLDOWN 2000 //time in ms to wait between websockets, alexa, and MQTT updates
 
+// HW_PIN_SCL & HW_PIN_SDA are used for information in usermods settings page and usermods themselves
+// which GPIO pins are actually used in a hardwarea layout (controller board)
+#if defined(I2CSCLPIN) && !defined(HW_PIN_SCL)
+  #define HW_PIN_SCL I2CSCLPIN
+#endif
+#if defined(I2CSDAPIN) && !defined(HW_PIN_SDA)
+  #define HW_PIN_SDA I2CSDAPIN
+#endif
+// you cannot change HW I2C pins on 8266
 #if defined(ESP8266) && defined(HW_PIN_SCL)
   #undef HW_PIN_SCL
 #endif
 #if defined(ESP8266) && defined(HW_PIN_SDA)
   #undef HW_PIN_SDA
 #endif
+// defaults for 1st I2C on ESP32 (Wire global)
 #ifndef HW_PIN_SCL
   #define HW_PIN_SCL SCL
 #endif
@@ -405,6 +415,18 @@
   #define HW_PIN_SDA SDA
 #endif
 
+// HW_PIN_SCLKSPI & HW_PIN_MOSISPI & HW_PIN_MISOSPI are used for information in usermods settings page and usermods themselves
+// which GPIO pins are actually used in a hardwarea layout (controller board)
+#if defined(SPISCLKPIN) && !defined(HW_PIN_CLOCKSPI)
+  #define HW_PIN_CLOCKSPI SPISCLKPIN
+#endif
+#if defined(SPIMOSIPIN) && !defined(HW_PIN_MOSISPI)
+  #define HW_PIN_MOSISPI SPIMOSIPIN
+#endif
+#if defined(SPIMISOPIN) && !defined(HW_PIN_MISOSPI)
+  #define HW_PIN_MISOSPI SPIMISOPIN
+#endif
+// you cannot change HW SPI pins on 8266
 #if defined(ESP8266) && defined(HW_PIN_CLOCKSPI)
   #undef HW_PIN_CLOCKSPI
 #endif
@@ -414,10 +436,7 @@
 #if defined(ESP8266) && defined(HW_PIN_MISOSPI)
   #undef HW_PIN_MISOSPI
 #endif
-#if defined(ESP8266) && defined(HW_PIN_CSSPI)
-  #undef HW_PIN_CSSPI
-#endif
-// defaults for VSPI
+// defaults for VSPI on ESP32 (SPI global, SPI.cpp) as HSPI is used by WLED (bus_wrapper.h)
 #ifndef HW_PIN_CLOCKSPI
   #define HW_PIN_CLOCKSPI SCK
 #endif
@@ -426,9 +445,6 @@
 #endif
 #ifndef HW_PIN_MISOSPI
   #define HW_PIN_MISOSPI MISO
-#endif
-#ifndef HW_PIN_CSSPI
-  #define HW_PIN_CSSPI SS
 #endif
 
 #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -676,32 +676,32 @@ WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available l
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 
-// global I2C SDA pin [HW_PIN_SDA] (used for usermods)
+// global I2C SDA pin (used for usermods)
 #ifndef I2CSDAPIN
 WLED_GLOBAL int8_t i2c_sda  _INIT(-1);
 #else
 WLED_GLOBAL int8_t i2c_sda  _INIT(I2CSDAPIN);
 #endif
-// global I2C SCL pin [HW_PIN_SCL] (used for usermods)
+// global I2C SCL pin (used for usermods)
 #ifndef I2CSCLPIN
 WLED_GLOBAL int8_t i2c_scl  _INIT(-1);
 #else
 WLED_GLOBAL int8_t i2c_scl  _INIT(I2CSCLPIN);
 #endif
 
-// global SPI DATA/MOSI pin [HW_PIN_DATASPI] (used for usermods)
+// global SPI DATA/MOSI pin (used for usermods)
 #ifndef SPIMOSIPIN
 WLED_GLOBAL int8_t spi_mosi  _INIT(-1);
 #else
 WLED_GLOBAL int8_t spi_mosi  _INIT(SPIMOSIPIN);
 #endif
-// global SPI DATA/MISO pin [HW_PIN_MISOSPI] (used for usermods)
+// global SPI DATA/MISO pin (used for usermods)
 #ifndef SPIMISOPIN
 WLED_GLOBAL int8_t spi_miso  _INIT(-1);
 #else
 WLED_GLOBAL int8_t spi_miso  _INIT(SPIMISOPIN);
 #endif
-// global SPI CLOCK/SCLK pin [HW_PIN_CLOCKSPI] (used for usermods)
+// global SPI CLOCK/SCLK pin (used for usermods)
 #ifndef SPISCLKPIN
 WLED_GLOBAL int8_t spi_sclk  _INIT(-1);
 #else

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -130,7 +130,7 @@
   #include "src/dependencies/dmx/ESPDMX.h"
  #else //ESP32
   #include "src/dependencies/dmx/SparkFunDMX.h"
- #endif  
+ #endif
 #endif
 
 #include "src/dependencies/e131/ESPAsyncE131.h"
@@ -393,8 +393,8 @@ WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to f
  #ifdef ESP8266
   WLED_GLOBAL DMXESPSerial dmx;
  #else //ESP32
-  WLED_GLOBAL SparkFunDMX dmx; 
- #endif 
+  WLED_GLOBAL SparkFunDMX dmx;
+ #endif
 WLED_GLOBAL uint16_t e131ProxyUniverse _INIT(0);                  // output this E1.31 (sACN) / ArtNet universe via MAX485 (0 = disabled)
 #endif
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
@@ -578,7 +578,7 @@ WLED_GLOBAL int16_t currentPlaylist _INIT(-1);
 //still used for "PL=~" HTTP API command
 WLED_GLOBAL byte presetCycCurr _INIT(0);
 WLED_GLOBAL byte presetCycMin _INIT(1);
-WLED_GLOBAL byte presetCycMax _INIT(5); 
+WLED_GLOBAL byte presetCycMax _INIT(5);
 
 // realtime
 WLED_GLOBAL byte realtimeMode _INIT(REALTIME_MODE_INACTIVE);
@@ -676,11 +676,37 @@ WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available l
 // Usermod manager
 WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
 
-WLED_GLOBAL int8_t i2c_sda  _INIT(-1);      // global I2C SDA pin [HW_PIN_SDA] (used for usermods)
-WLED_GLOBAL int8_t i2c_scl  _INIT(-1);      // global I2C SCL pin [HW_PIN_SCL] (used for usermods)
-WLED_GLOBAL int8_t spi_mosi _INIT(-1);      // global SPI DATA/MOSI pin [HW_PIN_DATASPI] (used for usermods)
-WLED_GLOBAL int8_t spi_miso _INIT(-1);      // global SPI DATA/MISO pin [HW_PIN_MISOSPI] (used for usermods)
-WLED_GLOBAL int8_t spi_sclk _INIT(-1);      // global SPI CLOCK/SCLK pin [HW_PIN_CLOCKSPI] (used for usermods)
+// global I2C SDA pin [HW_PIN_SDA] (used for usermods)
+#ifndef I2CSDAPIN
+WLED_GLOBAL int8_t i2c_sda  _INIT(-1);
+#else
+WLED_GLOBAL int8_t i2c_sda  _INIT(I2CSDAPIN);
+#endif
+// global I2C SCL pin [HW_PIN_SCL] (used for usermods)
+#ifndef I2CSCLPIN
+WLED_GLOBAL int8_t i2c_scl  _INIT(-1);
+#else
+WLED_GLOBAL int8_t i2c_scl  _INIT(I2CSCLPIN);
+#endif
+
+// global SPI DATA/MOSI pin [HW_PIN_DATASPI] (used for usermods)
+#ifndef SPIMOSIPIN
+WLED_GLOBAL int8_t spi_mosi  _INIT(-1);
+#else
+WLED_GLOBAL int8_t spi_mosi  _INIT(SPIMOSIPIN);
+#endif
+// global SPI DATA/MISO pin [HW_PIN_MISOSPI] (used for usermods)
+#ifndef SPIMISOPIN
+WLED_GLOBAL int8_t spi_miso  _INIT(-1);
+#else
+WLED_GLOBAL int8_t spi_miso  _INIT(SPIMISOPIN);
+#endif
+// global SPI CLOCK/SCLK pin [HW_PIN_CLOCKSPI] (used for usermods)
+#ifndef SPISCLKPIN
+WLED_GLOBAL int8_t spi_sclk  _INIT(-1);
+#else
+WLED_GLOBAL int8_t spi_sclk  _INIT(SPISCLKPIN);
+#endif
 
 // global ArduinoJson buffer
 WLED_GLOBAL StaticJsonDocument<JSON_BUFFER_SIZE> doc;


### PR DESCRIPTION
Hey there,

it's me again! We also don't have enough build flags, do we? :) So please let me add some more!

This PR is to make the new global i2c and SPI pins configurable via build flags. Why would I want that? Because for the QuinLED boards, we compile a build that already has everything set (like LED outputs, relay pin, IR pin, etc.) using build flags. And now in combination with my new SHT usermod (https://github.com/Aircoookie/WLED/pull/2942), we can also provide a build with that mod included, but we currently can't set the i2c pins; users would need to do that themselves still.

With this PR, we could pre-configure everything on the boards so boards are even more Plug-n-Play:
```
[env:custom_i2c_pin_test]
board = esp32dev
platform = ${esp32.platform}
platform_packages = ${esp32.platform_packages}
build_unflags = ${common.build_unflags}
build_flags = ${common.build_flags_esp32}
  -D I2CSDAPIN=32
  -D I2CSCLPIN=13
  -D SPIMOSIPIN=0
  -D SPIMISOPIN=1
  -D SPISCLKPIN=2
board_build.partitions = ${esp32.default_partitions}
```

We only need the i2c pins, but I thought it would be stupid to not do the same for the SPI pins :)

Thanks for considering this PR and greetings,

Andy!