### PR TITLE
Wled disable more

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -25,11 +25,13 @@ void shortPressAction(uint8_t b)
   }
 
   // publish MQTT message
+  #ifndef WLED_DISABLE_MQTT
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
     char subuf[64];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "short");
   }
+  #endif
 }
 
 void longPressAction(uint8_t b)
@@ -44,11 +46,13 @@ void longPressAction(uint8_t b)
   }
 
   // publish MQTT message
+  #ifndef WLED_DISABLE_MQTT
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
     char subuf[64];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "long");
   }
+  #endif
 }
 
 void doublePressAction(uint8_t b)
@@ -63,11 +67,13 @@ void doublePressAction(uint8_t b)
   }
 
   // publish MQTT message
+  #ifndef WLED_DISABLE_MQTT
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
     char subuf[64];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "double");
   }
+  #endif
 }
 
 bool isButtonPressed(uint8_t i)
@@ -120,12 +126,14 @@ void handleSwitch(uint8_t b)
     }
 
     // publish MQTT message
+    #ifndef WLED_DISABLE_MQTT
     if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
       char subuf[64];
       if (buttonType[b] == BTN_TYPE_PIR_SENSOR) sprintf_P(subuf, PSTR("%s/motion/%d"), mqttDeviceTopic, (int)b);
       else sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
       mqtt->publish(subuf, 0, false, !buttonPressedBefore[b] ? "off" : "on");
     }
+    #endif
 
     buttonLongPressed[b] = buttonPressedBefore[b]; //save the last "long term" switch state
   }

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -52,6 +52,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     CJSON(staticSubnet[i], nw_ins_0_sn[i]);
   }
 
+#ifndef WLED_DISABLE_AP
   JsonObject ap = doc["ap"];
   getStringFromJson(apSSID, ap[F("ssid")], 33);
   getStringFromJson(apPass, ap["psk"] , 65); //normally not present due to security
@@ -71,6 +72,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     apIP[i] = ap_ip;
   }
   */
+#endif
 
   noWifiSleep = doc[F("wifi")][F("sleep")] | !noWifiSleep; // inverted
   noWifiSleep = !noWifiSleep;
@@ -642,6 +644,7 @@ void serializeConfig() {
     nw_ins_0_sn.add(staticSubnet[i]);
   }
 
+#ifndef WLED_DISABLE_AP
   JsonObject ap = doc.createNestedObject("ap");
   ap[F("ssid")] = apSSID;
   ap[F("pskl")] = strlen(apPass);
@@ -653,7 +656,8 @@ void serializeConfig() {
   ap_ip.add(4);
   ap_ip.add(3);
   ap_ip.add(2);
-  ap_ip.add(1);
+  ap_ip.add(1);  
+#endif
 
   JsonObject wifi = doc.createNestedObject("wifi");
   wifi[F("sleep")] = !noWifiSleep;
@@ -1006,8 +1010,10 @@ bool deserializeConfigSec() {
   JsonObject nw_ins_0 = doc["nw"]["ins"][0];
   getStringFromJson(clientPass, nw_ins_0["psk"], 65);
 
+#ifndef WLED_DISABLE_AP
   JsonObject ap = doc["ap"];
   getStringFromJson(apPass, ap["psk"] , 65);
+#endif  
 
   JsonObject interfaces = doc["if"];
 
@@ -1052,8 +1058,10 @@ void serializeConfigSec() {
   JsonObject nw_ins_0 = nw_ins.createNestedObject();
   nw_ins_0["psk"] = clientPass;
 
+#ifndef WLED_DISABLE_AP
   JsonObject ap = doc.createNestedObject("ap");
   ap["psk"] = apPass;
+#endif
 
   JsonObject interfaces = doc.createNestedObject("if");
 #ifndef WLED_DISABLE_BLYNK

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -8,10 +8,12 @@
 #define GRADIENT_PALETTE_COUNT 58
 
 //Defaults
+#ifndef USE_MY_CONFIG
 #define DEFAULT_CLIENT_SSID "Your_Network"
 #define DEFAULT_AP_SSID     "WLED-AP"
 #define DEFAULT_AP_PASS     "wled1234"
 #define DEFAULT_OTA_PASS    "wledota"
+#endif
 
 //increase if you need more
 #ifndef WLED_MAX_USERMODS

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -8,12 +8,10 @@
 #define GRADIENT_PALETTE_COUNT 58
 
 //Defaults
-#ifndef USE_MY_CONFIG
 #define DEFAULT_CLIENT_SSID "Your_Network"
 #define DEFAULT_AP_SSID     "WLED-AP"
 #define DEFAULT_AP_PASS     "wled1234"
 #define DEFAULT_OTA_PASS    "wledota"
-#endif
 
 //increase if you need more
 #ifndef WLED_MAX_USERMODS

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -9,10 +9,12 @@
  */
 
 //alexa.cpp
+#ifndef WLED_DISABLE_ALEXA
 void onAlexaChange(EspalexaDevice* dev);
 void alexaInit();
 void handleAlexa();
 void onAlexaChange(EspalexaDevice* dev);
+#endif
 
 //blynk.cpp
 #ifndef WLED_DISABLE_BLYNK
@@ -77,8 +79,10 @@ uint8_t gamma8(uint8_t b);
 uint32_t gamma32(uint32_t);
 
 //dmx.cpp
+#ifdef WLED_ENABLE_DMX
 void initDMX();
 void handleDMX();
+#endif
 
 //e131.cpp
 void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol);
@@ -96,12 +100,14 @@ void updateFSInfo();
 void closeFile();
 
 //hue.cpp
+#ifndef WLED_DISABLE_HUESYNC
 void handleHue();
 void reconnectHue();
 void onHueError(void* arg, AsyncClient* client, int8_t error);
 void onHueConnect(void* arg, AsyncClient* client);
 void sendHuePoll();
 void onHueData(void* arg, AsyncClient* client, void *data, size_t len);
+#endif
 
 //improv.cpp
 void handleImprovPacket();
@@ -110,6 +116,7 @@ void sendImprovInfoResponse();
 void sendImprovRPCResponse(uint8_t commandId);
 
 //ir.cpp
+#ifndef WLED_DISABLE_IR
 void applyRepeatActions();
 byte relativeChange(byte property, int8_t amount, byte lowerBoundary = 0, byte higherBoundary = 0xFF);
 void decodeIR(uint32_t code);
@@ -125,6 +132,7 @@ void decodeIRJson(uint32_t code);
 
 void initIR();
 void handleIR();
+#endif
 
 //json.cpp
 #include "ESPAsyncWebServer.h"
@@ -165,8 +173,10 @@ bool parseLx(int lxValue, byte* rgbw);
 void parseLxJson(int lxValue, byte segId, bool secondary);
 
 //mqtt.cpp
+#ifndef WLED_DISABLE_MQTT
 bool initMqtt();
 void publishMqtt();
+#endif
 
 //ntp.cpp
 void handleTime();

--- a/wled00/hue.cpp
+++ b/wled00/hue.cpp
@@ -202,7 +202,4 @@ void onHueData(void* arg, AsyncClient* client, void *data, size_t len)
   }
   hueReceived = true;
 }
-#else
-void handleHue(){}
-void reconnectHue(){}
 #endif

--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -1,14 +1,11 @@
 #include "wled.h"
 
+#ifndef WLED_DISABLE_INFRARED
 #include "ir_codes.h"
 
 /*
  * Infrared sensor support for generic 24/40/44 key RGB remotes
  */
-
-#if defined(WLED_DISABLE_INFRARED)
-void handleIR(){}
-#else
 
 IRrecv* irrecv;
 //change pin in NpbWrapper.h

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -171,7 +171,9 @@ void updateInterfaces(uint8_t callMode)
   if (callMode != CALL_MODE_BLYNK && 
       callMode != CALL_MODE_NO_NOTIFY) updateBlynk();
   #endif
+  #ifndef WLED_DISABLE_MQTT
   doPublishMqtt = true;
+  #endif
   interfaceUpdateCallMode = 0; //disable
 }
 
@@ -180,7 +182,9 @@ void handleTransitions()
 {
   //handle still pending interface update
   if (interfaceUpdateCallMode && millis() - lastInterfaceUpdate > INTERFACE_UPDATE_COOLDOWN) updateInterfaces(interfaceUpdateCallMode);
+  #ifndef WLED_DISABLE_MQTT
   if (doPublishMqtt) publishMqtt();
+  #endif
   
   if (transitionActive && transitionDelayTemp > 0)
   {

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -178,7 +178,4 @@ bool initMqtt()
   return true;
 }
 
-#else
-bool initMqtt(){return false;}
-void publishMqtt(){}
 #endif

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -30,8 +30,10 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     apBehavior = request->arg(F("AB")).toInt();
     strlcpy(apSSID, request->arg(F("AS")).c_str(), 33);
     apHide = request->hasArg(F("AH"));
+#ifndef WLED_DISABLE_AP
     int passlen = request->arg(F("AP")).length();
     if (passlen == 0 || (passlen > 7 && !isAsterisksOnly(request->arg(F("AP")).c_str(), 65))) strlcpy(apPass, request->arg(F("AP")).c_str(), 65);
+#endif
     int t = request->arg(F("AC")).toInt(); if (t > 0 && t < 14) apChannel = t;
 
     noWifiSleep = request->hasArg(F("WS"));

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -666,7 +666,9 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 
   lastEditTime = millis();
   if (subPage != 2 && !doReboot) doSerializeConfig = true; //serializeConfig(); //do not save if factory reset or LED settings (which are saved after LED re-init)
+#ifndef WLED_DISABLE_ALEXA  
   if (subPage == 4) alexaInit();
+#endif  
 }
 
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -42,7 +42,9 @@ void WLED::loop()
   #endif
 
   handleTime();
+#ifndef WLED_DISABLE_IR
   handleIR();        // 2nd call to function needed for ESP32 to return valid results -- should be good for ESP8266, too
+#endif  
   handleConnection();
   handleSerial();
   handleNotifications();
@@ -64,7 +66,9 @@ void WLED::loop()
 
   yield();
   handleIO();
+  #ifndef WLED_DISABLE_IR
   handleIR();
+  #endif
   #ifndef WLED_DISABLE_ALEXA
   handleAlexa();
   #endif
@@ -135,7 +139,9 @@ void WLED::loop()
   }
   if (millis() - lastMqttReconnectAttempt > 30000 || lastMqttReconnectAttempt == 0) { // lastMqttReconnectAttempt==0 forces immediate broadcast
     lastMqttReconnectAttempt = millis();
+#ifndef WLED_DISABLE_MQTT
     initMqtt();
+#endif    
     yield();
     // refresh WLED nodes list
     refreshNodeList();
@@ -679,8 +685,10 @@ void WLED::initInterfaces()
 #endif
 
   // init Alexa hue emulation
+#ifndef WLED_DISABLE_ALEXA
   if (alexaEnabled)
     alexaInit();
+#endif    
 
 #ifndef WLED_DISABLE_OTA
   if (aOtaEnabled)
@@ -718,8 +726,12 @@ void WLED::initInterfaces()
 #endif
   e131.begin(e131Multicast, e131Port, e131Universe, E131_MAX_UNIVERSE_COUNT);
   ddp.begin(false, DDP_DEFAULT_PORT);
+#ifndef WLED_DISABLE_HUESYNC  
   reconnectHue();
+#endif
+#ifndef WLED_DISABLE_MQTT
   initMqtt();
+#endif  
   interfacesInited = true;
   wasConnected = true;
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -484,6 +484,9 @@ void WLED::beginStrip()
 
 void WLED::initAP(bool resetAP)
 {
+#ifdef WLED_DISABLE_AP
+  return;
+#else  
   if (apBehavior == AP_BEHAVIOR_BUTTON_ONLY && !resetAP)
     return;
 
@@ -516,6 +519,7 @@ void WLED::initAP(bool resetAP)
     dnsServer.start(53, "*", WiFi.softAPIP());
   }
   apActive = true;
+#endif
 }
 
 bool WLED::initEthernet()

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -403,8 +403,10 @@ void WLED::setup()
   userSetup();
   usermods.setup();
 
+#ifdef WLED_DISABLE_AP
   if (strcmp(clientSSID, DEFAULT_CLIENT_SSID) == 0)
     showWelcomePage = true;
+#endif
   WiFi.persistent(false);
   #ifdef WLED_USE_ETHERNET
   WiFi.onEvent(WiFiEvent);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -110,7 +110,9 @@
   #define NO_OTA_PORT
   #include <ArduinoOTA.h>
 #endif
+#ifdef WLED_ENABLE_FS_EDITOR
 #include <SPIFFSEditor.h>
+#endif
 #include "src/dependencies/time/TimeLib.h"
 #include "src/dependencies/timezone/Timezone.h"
 #include "src/dependencies/toki/Toki.h"
@@ -135,7 +137,9 @@
 #endif
 
 #include "src/dependencies/e131/ESPAsyncE131.h"
+#ifdef WLED_ENABLE_MQTT
 #include "src/dependencies/async-mqtt-client/AsyncMqttClient.h"
+#endif
 
 #define ARDUINOJSON_DECODE_UNICODE 0
 #include "src/dependencies/json/AsyncJson-v6.h"
@@ -641,7 +645,9 @@ WLED_GLOBAL byte optionType;
 
 WLED_GLOBAL bool doSerializeConfig _INIT(false);        // flag to initiate saving of config
 WLED_GLOBAL bool doReboot          _INIT(false);        // flag to initiate reboot from async handlers
+#ifndef WLED_DISABLE_MQTT
 WLED_GLOBAL bool doPublishMqtt     _INIT(false);
+#endif
 
 // status led
 #if defined(STATUSLED)
@@ -656,7 +662,9 @@ WLED_GLOBAL AsyncWebServer server _INIT_N(((80)));
 WLED_GLOBAL AsyncWebSocket ws _INIT_N((("/ws")));
 #endif
 WLED_GLOBAL AsyncClient* hueClient _INIT(NULL);
+#ifdef WLED_ENABLE_MQTT
 WLED_GLOBAL AsyncMqttClient* mqtt _INIT(NULL);
+#endif
 WLED_GLOBAL AsyncWebHandler *editHandler _INIT(nullptr);
 
 // udp interface objects
@@ -766,7 +774,9 @@ WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
   #define WLED_CONNECTED (WiFi.status() == WL_CONNECTED)
 #endif
 #define WLED_WIFI_CONFIGURED (strlen(clientSSID) >= 1 && strcmp(clientSSID, DEFAULT_CLIENT_SSID) != 0)
+#ifndef WLED_DISABLE_MQTT
 #define WLED_MQTT_CONNECTED (mqtt != nullptr && mqtt->connected())
+#endif
 
 #ifndef WLED_AP_SSID_UNIQUE
   #define WLED_SET_AP_SSID() do { \

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -247,7 +247,9 @@ WLED_GLOBAL char versionString[] _INIT(TOSTRING(WLED_VERSION));
 #define WLED_CODENAME "Hoshi"
 
 // AP and OTA default passwords (for maximum security change them!)
+#ifndef WLED_DISABLE_AP
 WLED_GLOBAL char apPass[65]  _INIT(WLED_AP_PASS);
+#endif
 WLED_GLOBAL char otaPass[33] _INIT(DEFAULT_OTA_PASS);
 
 // Hardware and pin config

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -1,5 +1,6 @@
 #include "wled.h"
 
+#ifdef WLED_ENABLE_ADALIGHT
 /*
  * Adalight and TPM2 handler
  */
@@ -18,6 +19,7 @@ enum class AdaState {
   TPM2_Header_CountHi,
   TPM2_Header_CountLo,
 };
+#endif
 
 uint16_t currentBaud = 1152; //default baudrate 115200 (divided by 100)
 bool continuousSendLED = false;

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -316,11 +316,13 @@ void getSettingsJS(byte subPage, char* dest)
     sappends('s',SET_F("AS"),apSSID);
     sappend('c',SET_F("AH"),apHide);
 
+#ifndef WLED_DISABLE_AP
     l = strlen(apPass);
     char fapass[l+1]; //fill password field with ***
     fapass[l] = 0;
     memset(fapass,'*',l);
     sappends('s',SET_F("AP"),fapass);
+#endif
 
     sappend('v',SET_F("AC"),apChannel);
     sappend('c',SET_F("WS"),noWifiSleep);


### PR DESCRIPTION
I shaved off another 20 KB or so by removing IR support and by adding more WLED_DISABLED wrappings around various files.
It gets kind of messy, but it removes unused structs, includes, lopping off entire blobs.

It would be nice if WLED_DISABLE was not paired with WLED_ENABLE so inconsistently, a more thorough cleanup is required.

The fcn_declare.h file was a great starting point for breaking and then fixing all related calls.
Perhaps this file could be changed into a module wrapper, which then includes the files needed for a certain functionality.

Those files could include a header per-plugin

#include "wled.h"

#ifndef WLED_DISABLE_X
// includes needed for this module
// variables
// structs 
// function & macro declarations in the order of:
// functions used from wled
// functions used within the module
// functions used by other modules
#endif

this would fascilitate a thorough cleanup of all the #ifdef / #ifndef wrappers
by replacing those with empty macros instead of empty functions

And make it a lot easier to track all the various structs / pointers / counters / variables needed for all these modules.
As those would all be moved into the module and would no longer exist in various other files.

Aside from this commit though, I currently have no time to go through the steps of this major refactoring of the code to clean up the project.