### PR TITLE
Fix for displaying 1bpp bmp files (usermod EleksTube IPS)

### DIFF
--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -141,7 +141,7 @@ private:
     h = read32(bmpFS); // height
     (void) read16(bmpFS); // color planes (must be 1)
     bitDepth = read16(bmpFS);
-    
+
     if (read32(bmpFS) != 0 || (bitDepth != 24 && bitDepth != 1 && bitDepth != 4 && bitDepth != 8)) {
       Serial.println(F("BMP format not recognized."));
       bmpFS.close();

--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -133,38 +133,34 @@ private:
       return false;
     }
 
-    read32(bmpFS); // filesize in bytes
-    read32(bmpFS); // reserved
+    (void) read32(bmpFS); // filesize in bytes
+    (void) read32(bmpFS); // reserved
     seekOffset = read32(bmpFS); // start of bitmap
     headerSize = read32(bmpFS); // header size
     w = read32(bmpFS); // width
     h = read32(bmpFS); // height
-    read16(bmpFS); // color planes (must be 1)
+    (void) read16(bmpFS); // color planes (must be 1)
     bitDepth = read16(bmpFS);
-    bool monochromatic = false;
     
     if (read32(bmpFS) != 0 || (bitDepth != 24 && bitDepth != 1 && bitDepth != 4 && bitDepth != 8)) {
       Serial.println(F("BMP format not recognized."));
       bmpFS.close();
       return false;
-    } else {
-      if (bitDepth == 1) monochromatic = true;
     }
 
     uint32_t palette[256];
-    uint32_t palette0 = 255;
     if (bitDepth <= 8) // 1,4,8 bit bitmap: read color palette
     {
-      read32(bmpFS); read32(bmpFS); read32(bmpFS); // size, w resolution, h resolution
+      (void) read32(bmpFS); (void) read32(bmpFS); (void) read32(bmpFS); // size, w resolution, h resolution
       paletteSize = read32(bmpFS);
       if (paletteSize == 0) paletteSize = bitDepth * bitDepth; //if 0, size is 2^bitDepth
       bmpFS.seek(14 + headerSize); // start of color palette
       for (uint16_t i = 0; i < paletteSize; i++) {
         palette[i] = read32(bmpFS);
       }
-      if (monochromatic) {
+      if (bitDepth == 1) { // monochromatic BMP
         palette[0] = 0;
-        palette[1] = palette0;
+        palette[1] = 255;
       }
     }
 
@@ -206,7 +202,7 @@ private:
           }
           b = c; g = c >> 8; r = c >> 16;
         }
-        if (dimming != 255) { // only dimm when needed
+        if (dimming != 255) { // only dim when needed
           r *= dimming; g *= dimming; b *= dimming;
           r  = r  >> 8; g  = g  >> 8; b  = b  >> 8;
         }

--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -141,14 +141,18 @@ private:
     h = read32(bmpFS); // height
     read16(bmpFS); // color planes (must be 1)
     bitDepth = read16(bmpFS);
-
+    bool monochromatic = false;
+    
     if (read32(bmpFS) != 0 || (bitDepth != 24 && bitDepth != 1 && bitDepth != 4 && bitDepth != 8)) {
       Serial.println(F("BMP format not recognized."));
       bmpFS.close();
       return false;
+    } else {
+      if (bitDepth == 1) monochromatic = true;
     }
 
     uint32_t palette[256];
+    uint32_t palette0 = 255;
     if (bitDepth <= 8) // 1,4,8 bit bitmap: read color palette
     {
       read32(bmpFS); read32(bmpFS); read32(bmpFS); // size, w resolution, h resolution
@@ -157,6 +161,10 @@ private:
       bmpFS.seek(14 + headerSize); // start of color palette
       for (uint16_t i = 0; i < paletteSize; i++) {
         palette[i] = read32(bmpFS);
+      }
+      if (monochromatic) {
+        palette[0] = 0;
+        palette[1] = palette0;
       }
     }
 

--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -153,14 +153,10 @@ private:
     {
       (void) read32(bmpFS); (void) read32(bmpFS); (void) read32(bmpFS); // size, w resolution, h resolution
       paletteSize = read32(bmpFS);
-      if (paletteSize == 0) paletteSize = bitDepth * bitDepth; //if 0, size is 2^bitDepth
+      if (paletteSize == 0) paletteSize = 1 << bitDepth; //if 0, size is 2^bitDepth
       bmpFS.seek(14 + headerSize); // start of color palette
       for (uint16_t i = 0; i < paletteSize; i++) {
         palette[i] = read32(bmpFS);
-      }
-      if (bitDepth == 1) { // monochromatic BMP
-        palette[0] = 0;
-        palette[1] = 255;
       }
     }
 


### PR DESCRIPTION
When working with a 1 bit per pixel bmp file, this forces the color palette to zero and something other than zero (tried 255 and it worked for me). Before this fix, the monochrome bmp would display fine in the file manager but would display all black on the ips screen.