### PR TITLE
E1.31: Ignore non-zero start code and preview data

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -70,8 +70,14 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
     seq = p->art_sequence_number;
     mde = REALTIME_MODE_ARTNET;
   } else if (protocol == P_E131) {
-    uni = htons(p->universe);
+    // Ignore PREVIEW data (E1.31: 6.2.6)
+    if ((p->options & 0x80) != 0)
+      return;
     dmxChannels = htons(p->property_value_count) -1;
+    // DMX level data is zero start code. Ignore everything else. (E1.11: 8.5)
+    if (dmxChannels == 0 || p->property_values[0] != 0)
+      return;
+    uni = htons(p->universe);
     e131_data = p->property_values;
     seq = p->sequence_number;
   } else { //DDP


### PR DESCRIPTION
Only the zero start code is level data.

Data tagged as "Preview" is intended for visualisation software, eg to preview edits to a future cue, and should be ignored by real luminaires.

Part of issue #3067