### PR TITLE
Changing voltage calculation to a weighted running average

### DIFF
--- a/usermods/Battery/battery_defaults.h
+++ b/usermods/Battery/battery_defaults.h
@@ -26,6 +26,15 @@
   #endif
 #endif
 
+//the default ratio for the voltage divider
+#ifndef USERMOD_BATTERY_VOLTAGE_MULTIPLIER
+  #ifdef ARDUINO_ARCH_ESP32
+    #define USERMOD_BATTERY_VOLTAGE_MULTIPLIER 2.0f
+  #else //ESP8266 boards
+    #define USERMOD_BATTERY_VOLTAGE_MULTIPLIER 4.2f
+  #endif
+#endif
+
 #ifndef USERMOD_BATTERY_MAX_VOLTAGE
   #define USERMOD_BATTERY_MAX_VOLTAGE 4.2f
 #endif


### PR DESCRIPTION
This helps improve precision in the readout and makes it more stable.
The calibration will now not be multiplied by 2 and therefore reflects the change in volts.
Removed check for "invalid voltages" as that just makes it hard for people to check whats going wrong in their setup when they only get "invalid voltage" in the web gui.