### PR TITLE
Fixes DMX_MODE_PRESET preset and brightness selection via DMX controller

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -173,24 +173,30 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
       break;
 
     case DMX_MODE_PRESET:       // 2 channel: [Dimmer,Preset]
-      if (uni != e131Universe || availDMXLen < 2) return;
+      {
+        if (uni != e131Universe || availDMXLen < 2) return;
 
-      // only apply preset if value changed 
-      if (currentPreset != e131_data[dataOffset+1] && e131_data[dataOffset+1] != 0 && 
-          // only apply preset if not in playlist, or playlist changed
-          (currentPlaylist < 0 || currentPlaylist != e131_data[dataOffset+1])) { 
-        presetCycCurr = e131_data[dataOffset+1];
-        unloadPlaylist(); // applying a preset unloads the playlist
-        applyPreset(e131_data[dataOffset+1], CALL_MODE_NOTIFICATION);
+        // limit max. selectable preset to 250, even though DMX max. val is 255
+        uint8_t dmxValPreset = (e131_data[dataOffset+1] > 250 ? 250 : e131_data[dataOffset+1]);
+        
+        // only apply preset if value changed 
+        if (dmxValPreset != 0 && dmxValPreset != currentPreset &&  
+            // only apply preset if not in playlist, or playlist changed
+            (currentPlaylist < 0 || dmxValPreset != currentPlaylist)) { 
+          presetCycCurr = dmxValPreset;
+          unloadPlaylist(); // applying a preset unloads the playlist
+          applyPreset(dmxValPreset, CALL_MODE_NOTIFICATION);
+        }
+
+        // only change brightness if value changed
+        if (bri != e131_data[dataOffset]) {                                        
+          bri = e131_data[dataOffset];
+          strip.setBrightness(scaledBri(bri), false);
+          stateUpdated(CALL_MODE_WS_SEND);
+        }
+        return;
+        break;
       }
-      // only change brightness if value changed
-      if (bri != e131_data[dataOffset]) {                                        
-        bri = e131_data[dataOffset];
-        strip.setBrightness(scaledBri(bri), false);
-        stateUpdated(CALL_MODE_WS_SEND);
-      }
-      return;
-      break;
 
     case DMX_MODE_EFFECT:           // 15 channels [bri,effectCurrent,effectSpeed,effectIntensity,effectPalette,effectOption,R,G,B,R2,G2,B2,R3,G3,B3]
     case DMX_MODE_EFFECT_W:         // 18 channels, same as above but with extra +3 white channels [..,W,W2,W3]


### PR DESCRIPTION
No more overloading of the ESP when using analogue controllers sending many packets (often the same) per second to WLED. Packets selecting the _same_ preset are discarded now. 

Additional fixes:
- brightness selection slider in UI no longer flickers when preset value != dmx value
- makes playlists work together with presets as well now, allowing for a smooth selection between the two 


/ #3132 