### PR TITLE
Fix  build errors when mpu6050_imu usermod is installed

### DIFF
--- a/usermods/mpu6050_imu/usermod_mpu6050_imu.h
+++ b/usermods/mpu6050_imu/usermod_mpu6050_imu.h
@@ -209,7 +209,7 @@ class MPU6050Driver : public Usermod {
       JsonObject user = root["u"];
       if (user.isNull()) user = root.createNestedObject("u");
 
-      JsonArray imu_meas = user.createNestedObject("IMU");
+      JsonObject imu_meas = user.createNestedObject("IMU");
       JsonArray quat_json = imu_meas.createNestedArray("Quat");
       quat_json.add(qat.w);
       quat_json.add(qat.x);


### PR DESCRIPTION
Change type from JsonArray to JsonObject, and am now able to successfully get data from MPU6050 using he API0 as advertised.