### PR TITLE
Use constant for mDNS name to allow overriding from my_config.h

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -12,6 +12,7 @@
 #define DEFAULT_AP_SSID     "WLED-AP"
 #define DEFAULT_AP_PASS     "wled1234"
 #define DEFAULT_OTA_PASS    "wledota"
+#define DEFAULT_MDNS_NAME   "x"
 
 //increase if you need more
 #ifndef WLED_MAX_USERMODS

--- a/wled00/my_config_sample.h
+++ b/wled00/my_config_sample.h
@@ -22,4 +22,5 @@
 #define CLIENT_PASS "Your_Password"
 */
 
-//#define MAX_LEDS 1500       //Maximum total LEDs. More than 1500 might create a low memory situation on ESP8266.
+//#define MAX_LEDS 1500       // Maximum total LEDs. More than 1500 might create a low memory situation on ESP8266.
+//#define MDNS_NAME "wled"    // mDNS hostname, ie: *.local

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -175,6 +175,10 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
   #define CLIENT_PASS ""
 #endif
 
+#ifndef MDNS_NAME
+  #define MDNS_NAME DEFAULT_MDNS_NAME
+#endif
+
 #if defined(WLED_AP_PASS) && !defined(WLED_AP_SSID)
   #error WLED_AP_PASS is defined but WLED_AP_SSID is still the default. \
          Please change WLED_AP_SSID to something unique.
@@ -285,7 +289,7 @@ WLED_GLOBAL char ntpServerName[33] _INIT("0.wled.pool.ntp.org");   // NTP server
 // WiFi CONFIG (all these can be changed via web UI, no need to set them here)
 WLED_GLOBAL char clientSSID[33] _INIT(CLIENT_SSID);
 WLED_GLOBAL char clientPass[65] _INIT(CLIENT_PASS);
-WLED_GLOBAL char cmDNS[33] _INIT("x");                             // mDNS address (placeholder, is replaced by wledXXXXXX.local)
+WLED_GLOBAL char cmDNS[33] _INIT(MDNS_NAME);                       // mDNS address (*.local, replaced by wledXXXXXX if default is used)
 WLED_GLOBAL char apSSID[33] _INIT("");                             // AP off by default (unless setup)
 WLED_GLOBAL byte apChannel _INIT(1);                               // 2.4GHz WiFi AP channel (1-13)
 WLED_GLOBAL byte apHide    _INIT(0);                               // hidden AP SSID


### PR DESCRIPTION
I've found this useful when deploying test builds to various ESP modules to make it easier to find/load the ui on my network, so I figured others might as well.