### PR TITLE
Add Freqpalette effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7110,6 +7110,42 @@ uint16_t mode_waterfall(void) {                   // Waterfall. By: Andrew Tulin
 static const char _data_FX_MODE_WATERFALL[] PROGMEM = "Waterfall@!,Adjust color,Select bin,Volume (min);!,!;!;1f;c2=0,m12=2,si=0"; // Circles, Beatsin
 
 
+/*
+ * Uses the average value from user-selected FFT buckets to select a single
+ * color from a palette.
+ */
+uint16_t mode_freqpalette() {
+  um_data_t *um_data;
+  if (!usermods.getUMData(&um_data, USERMOD_ID_AUDIOREACTIVE)) {
+    // add support for no audio
+    um_data = simulateSound(SEGMENT.soundSim);
+  }
+
+  // Get minimum and maximum FFT bands to consider
+  uint8_t minBand = constrain(SEGMENT.custom1 / 16, 0, 15);
+  uint8_t maxBand = constrain(SEGMENT.custom2 / 16, 0, 15);
+  if (maxBand < minBand) {
+    uint8_t temp = minBand;
+    minBand = maxBand;
+    maxBand = temp;
+  }
+
+  // Average the bands' values, scaled by user-specified sensitivity
+  uint32_t value = 0;
+  uint8_t *fftResult = (uint8_t*)um_data->u_data[2];
+  for (uint8_t band = minBand; band <= maxBand; ++band) {
+    value += fftResult[band] * SEGMENT.intensity;
+  }
+  value /= (maxBand - minBand + 1) * (256 / 8);
+  value = constrain(value, 0, 255);
+
+  SEGMENT.fill(SEGMENT.color_from_palette(value, false, false, 0));
+
+  return FRAMETIME;
+}
+static const char _data_FX_MODE_FREQPALETTE[] PROGMEM = "Freqpalette@,Sensitivity,First FFT Band,Last FFT Band;;!;1f;ix=128,c1=0,c2=255,m12=0,si=0,pal=4";
+
+
 #ifndef WLED_DISABLE_2D
 /////////////////////////
 //     ** 2D GEQ       //
@@ -7550,6 +7586,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_NOISEMETER, &mode_noisemeter, _data_FX_MODE_NOISEMETER);
   addEffect(FX_MODE_FREQWAVE, &mode_freqwave, _data_FX_MODE_FREQWAVE);
   addEffect(FX_MODE_FREQMATRIX, &mode_freqmatrix, _data_FX_MODE_FREQMATRIX);
+  addEffect(FX_MODE_FREQPALETTE, &mode_freqpalette, _data_FX_MODE_FREQPALETTE);
 
   addEffect(FX_MODE_WATERFALL, &mode_waterfall, _data_FX_MODE_WATERFALL);
   addEffect(FX_MODE_FREQPIXELS, &mode_freqpixels, _data_FX_MODE_FREQPIXELS);

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -316,8 +316,9 @@
 #define FX_MODE_WAVESINS               184
 #define FX_MODE_ROCKTAVES              185
 #define FX_MODE_2DAKEMI                186
+#define FX_MODE_FREQPALETTE            187
 
-#define MODE_COUNT                     187
+#define MODE_COUNT                     188
 
 typedef enum mapping1D2D {
   M12_Pixels = 0,


### PR DESCRIPTION
This sound-reactive effect uses the average value from user-selected FFT buckets to select a single color from a palette.

I couldn't find any existing SR effect that could do this - the volume-reactive ones only consider the entire signal and not a specific frequency range.

I use this on a set of shelves, where each shelf has a different FFT range that it lights up in response to. This creates a cool effect where each responds to different parts of incoming audio i.e., kick, snares, synths etc.

Bad video demo: (warning, flashing lights)

https://user-images.githubusercontent.com/15011974/229482894-710e4f1e-8718-42ce-b299-66e6bfdeef38.mp4

