### PR TITLE
Apply correct iOS scroll to all tabcontent

### DIFF
--- a/wled00/data/index.css
+++ b/wled00/data/index.css
@@ -318,9 +318,6 @@ button {
 	height: 100%;
 	overscroll-behavior: none;
 	padding: 0 4px;
-}
-
-#Effects {
 	-webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
Right now the touch scroll is only applying to `#Effects`. with this change all scrolls works properly, video of the current state:

https://user-images.githubusercontent.com/7963804/233815400-c85a0863-c901-4fa9-97c1-06fefce45466.mp4

