### PR TITLE
Restore Github actions CI build

### DIFF
--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -8,21 +8,23 @@ jobs:
     name: Gather Environments
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
     - name: Install PlatformIO
       run: pip install -r requirements.txt
     - name: Get default environments
       id: envs
       run: |
-        echo "::set-output name=environments::$(pio project config --json-output | jq -cr '.[0][1][0][1]')"
+        echo "environments=$(pio project config --json-output | jq -cr '.[0][1][0][1]')" >> $GITHUB_OUTPUT
     outputs:
       environments: ${{ steps.envs.outputs.environments }}
 
@@ -35,21 +37,23 @@ jobs:
       matrix:
         environment: ${{ fromJSON(needs.get_default_envs.outputs.environments) }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache PlatformIO
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.platformio
         key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+      with:
+          python-version: '3.9'
     - name: Install PlatformIO
       run: pip install -r requirements.txt
     - name: Build firmware

--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: get_default_envs
     strategy:
+      fail-fast: false
       matrix:
         environment: ${{ fromJSON(needs.get_default_envs.outputs.environments) }}
     steps:

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,8 +9,11 @@
 # (use `platformio_override.ini` when building for your own board; see `platformio_override.ini.sample` for an example)
 # ------------------------------------------------------------------------------
 
-# Release / CI binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32s2_saola, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
+# CI binaries
+ci_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
+
+# Release binaries
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
 
 # Build everything
 ; default_envs = esp32dev, esp8285_4CH_MagicHome, codm-controller-0.6-rev2, codm-controller-0.6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,63 +4,59 @@
 #
 #    pip-compile
 #
-aiofiles==0.8.0
+aiofiles==22.1.0
     # via platformio
 ajsonrpc==1.2.0
     # via platformio
-anyio==3.6.1
+anyio==3.6.2
     # via starlette
-async-timeout==4.0.2
-    # via zeroconf
-bottle==0.12.23
+bottle==0.12.25
     # via platformio
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
     #   platformio
     #   uvicorn
-colorama==0.4.5
-    # via platformio
-h11==0.13.0
+colorama==0.4.6
+    # via
+    #   click
+    #   platformio
+h11==0.14.0
     # via
     #   uvicorn
     #   wsproto
-idna==3.3
+idna==3.4
     # via
     #   anyio
     #   requests
-ifaddr==0.2.0
-    # via zeroconf
-marshmallow==3.17.0
+marshmallow==3.19.0
     # via platformio
-packaging==21.3
+packaging==23.1
     # via marshmallow
-platformio==6.1.4
+platformio==6.1.6
     # via -r requirements.in
 pyelftools==0.29
     # via platformio
-pyparsing==3.0.9
-    # via packaging
 pyserial==3.5
     # via platformio
-requests==2.28.1
+requests==2.28.2
     # via platformio
 semantic-version==2.10.0
     # via platformio
-sniffio==1.2.0
+sniffio==1.3.0
     # via anyio
-starlette==0.20.4
+starlette==0.23.1
     # via platformio
-tabulate==0.8.10
+tabulate==0.9.0
     # via platformio
-urllib3==1.26.11
+typing-extensions==4.5.0
+    # via starlette
+urllib3==1.26.15
     # via requests
-uvicorn==0.18.2
+uvicorn==0.20.0
     # via platformio
-wsproto==1.1.0
-    # via platformio
-zeroconf==0.39.0
+wsproto==1.2.0
     # via platformio


### PR DESCRIPTION
- Introduces a separate `ci_envs` variable to specify environments to be used by GH actions.
- Updates various Python dependencies.
- Temporarily disables CI builds for S2/S3/C3 as the toolchain version `espressif/toolchain-riscv32-esp @ 8.4.0+2021r2-patch3` is (no longer?) available on the `linux_x86_64` system.

TODO experimenting with espressif32 6.x cores or manually specifying a working toolchain version, but merging open PRs has priority.

