### PR TITLE
Fix errors in DDP implementation

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -25,7 +25,7 @@ void handleDDPPacket(e131_packet_t* p) {
     }
   }
 
-  uint8_t ddpChannelsPerLed = (p->dataType == DDP_TYPE_RGBW32) ? 4 : 3; // data type 0x1A is RGBW (type 3, 8 bit/channel)
+  uint8_t ddpChannelsPerLed = (p->dataType & 0b00111000 == 0b011) ? 4 : 3; // data type 0x1B (formerly 0x1A) is RGBW (type 3, 8 bit/channel)
 
   uint32_t start =  htonl(p->channelOffset) / ddpChannelsPerLed;
   start += DMXAddress / ddpChannelsPerLed;

--- a/wled00/src/dependencies/e131/ESPAsyncE131.h
+++ b/wled00/src/dependencies/e131/ESPAsyncE131.h
@@ -53,8 +53,8 @@ typedef struct ip_addr ip4_addr_t;
 #define DDP_PUSH_FLAG 0x01
 #define DDP_TIMECODE_FLAG 0x10
 
-#define DDP_TYPE_RGB24  0x0D
-#define DDP_TYPE_RGBW32 0x1E
+#define DDP_TYPE_RGB24  0x0B // 00 001 011 (RGB , 8 bits per channel, 3 channels)
+#define DDP_TYPE_RGBW32 0x1B // 00 011 011 (RGBW, 8 bits per channel, 4 channels)
 
 #define ARTNET_OPCODE_OPDMX 0x5000
 #define ARTNET_OPCODE_OPPOLL 0x2000

--- a/wled00/src/dependencies/e131/ESPAsyncE131.h
+++ b/wled00/src/dependencies/e131/ESPAsyncE131.h
@@ -53,8 +53,8 @@ typedef struct ip_addr ip4_addr_t;
 #define DDP_PUSH_FLAG 0x01
 #define DDP_TIMECODE_FLAG 0x10
 
-#define DDP_TYPE_RGB24  0x0A
-#define DDP_TYPE_RGBW32 0x1A
+#define DDP_TYPE_RGB24  0x0D
+#define DDP_TYPE_RGBW32 0x1E
 
 #define ARTNET_OPCODE_OPDMX 0x5000
 #define ARTNET_OPCODE_OPPOLL 0x2000


### PR DESCRIPTION
I think these values are wrong given the spec.

`0x0A` in binary is 0b00001010

**Spec is:**
> Bits: C R TTT SSS
> C is 0 for standard types or 1 for Customer defined
> R is reserved and should be 0.
> TTT is data type 
> 	000 = undefined
> 	001 = RGB
> 	010 = HSL
> 	011 = RGBW
> 	100 = grayscale
> SSS is size in bits per pixel element (like just R or G or B data)
> 	0=undefined, 1=1, 2=4, 3=8, 4=16, 5=24, 6=32

So in this case, `0x0A` maps to 010 which means 2, 4 bits per pixel
but really what the constant wants to represent is 24 bits, which should be 110 so `0x0D` and 32 bits should be `0x1E`