### PR TITLE
Changes for allowing Alexa to change light color to White when auto-calculating from RGB

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -771,6 +771,7 @@ class WS2812FX {  // 96 bytes
       getActiveSegmentsNum(void),
       getFirstSelectedSegId(void),
       getLastActiveSegmentId(void),
+      getActiveSegsLightCapabilities(bool selectedOnly = false),
       setPixelSegment(uint8_t n);
 
     inline uint8_t getBrightness(void) { return _brightness; }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1330,6 +1330,14 @@ void WS2812FX::setBrightness(uint8_t b, bool direct) {
   }
 }
 
+uint8_t WS2812FX::getActiveSegsLightCapabilities(bool selectedOnly) {
+  uint8_t totalLC = 0;
+  for (segment &seg : _segments) {
+    if (seg.isActive() && (!selectedOnly || seg.isSelected())) totalLC |= seg.getLightCapabilities();
+  }
+  return totalLC;
+}
+
 uint8_t WS2812FX::getFirstSelectedSegId(void)
 {
   size_t i = 0;

--- a/wled00/alexa.cpp
+++ b/wled00/alexa.cpp
@@ -105,8 +105,15 @@ void onAlexaChange(EspalexaDevice* dev)
 			uint16_t k = 1000000 / ct; //mireds to kelvin
 			
 			if (strip.hasCCTBus()) {
+				uint8_t aWM = Bus::getGlobalAWMode();
+
 				strip.setCCT(k);
-				rgbw[0]= 0; rgbw[1]= 0; rgbw[2]= 0; rgbw[3]= 255;
+				if (aWM != RGBW_MODE_DUAL && aWM != RGBW_MODE_MANUAL_ONLY && aWM != AW_GLOBAL_DISABLED) {
+				  rgbw[0]= 255; rgbw[1]= 255; rgbw[2]= 255; rgbw[3]= 0;
+				 dev->setValue(255);
+				} else {
+				  rgbw[0]= 0; rgbw[1]= 0; rgbw[2]= 0; rgbw[3]= 255;
+				}
 			} else if (strip.hasWhiteChannel()) {
         switch (ct) { //these values empirically look good on RGBW
           case 199: rgbw[0]=255; rgbw[1]=255; rgbw[2]=255; rgbw[3]=255; break;

--- a/wled00/alexa.cpp
+++ b/wled00/alexa.cpp
@@ -101,27 +101,27 @@ void onAlexaChange(EspalexaDevice* dev)
     {
       byte rgbw[4];
       uint16_t ct = dev->getCt();
-			if (!ct) return;
-			uint16_t k = 1000000 / ct; //mireds to kelvin
-			
-			if (strip.hasCCTBus()) {
-				uint8_t aWM = Bus::getGlobalAWMode();
+      if (!ct) return;
+      uint16_t k = 1000000 / ct; //mireds to kelvin
+      
+      if (strip.hasCCTBus()) {
+        bool hasManualWhite = strip.getActiveSegsLightCapabilities(true) & SEG_CAPABILITY_W;
 
-				strip.setCCT(k);
-				if (aWM != RGBW_MODE_DUAL && aWM != RGBW_MODE_MANUAL_ONLY && aWM != AW_GLOBAL_DISABLED) {
-				  rgbw[0]= 255; rgbw[1]= 255; rgbw[2]= 255; rgbw[3]= 0;
-				  dev->setValue(255);
-				} else {
-				  rgbw[0]= 0; rgbw[1]= 0; rgbw[2]= 0; rgbw[3]= 255;
-				}
-			} else if (strip.hasWhiteChannel()) {
+        strip.setCCT(k);
+        if (hasManualWhite) {
+          rgbw[0] = 0; rgbw[1] = 0; rgbw[2] = 0; rgbw[3] = 255;
+        } else {
+          rgbw[0] = 255; rgbw[1] = 255; rgbw[2] = 255; rgbw[3] = 0;
+          dev->setValue(255);
+        }
+      } else if (strip.hasWhiteChannel()) {
         switch (ct) { //these values empirically look good on RGBW
           case 199: rgbw[0]=255; rgbw[1]=255; rgbw[2]=255; rgbw[3]=255; break;
           case 234: rgbw[0]=127; rgbw[1]=127; rgbw[2]=127; rgbw[3]=255; break;
           case 284: rgbw[0]=  0; rgbw[1]=  0; rgbw[2]=  0; rgbw[3]=255; break;
           case 350: rgbw[0]=130; rgbw[1]= 90; rgbw[2]=  0; rgbw[3]=255; break;
           case 383: rgbw[0]=255; rgbw[1]=153; rgbw[2]=  0; rgbw[3]=255; break;
-					default : colorKtoRGB(k, rgbw);
+          default : colorKtoRGB(k, rgbw);
         }
       } else {
         colorKtoRGB(k, rgbw);

--- a/wled00/alexa.cpp
+++ b/wled00/alexa.cpp
@@ -110,7 +110,7 @@ void onAlexaChange(EspalexaDevice* dev)
 				strip.setCCT(k);
 				if (aWM != RGBW_MODE_DUAL && aWM != RGBW_MODE_MANUAL_ONLY && aWM != AW_GLOBAL_DISABLED) {
 				  rgbw[0]= 255; rgbw[1]= 255; rgbw[2]= 255; rgbw[3]= 0;
-				 dev->setValue(255);
+				  dev->setValue(255);
 				} else {
 				  rgbw[0]= 0; rgbw[1]= 0; rgbw[2]= 0; rgbw[3]= 255;
 				}

--- a/wled00/alexa.cpp
+++ b/wled00/alexa.cpp
@@ -103,7 +103,7 @@ void onAlexaChange(EspalexaDevice* dev)
       uint16_t ct = dev->getCt();
       if (!ct) return;
       uint16_t k = 1000000 / ct; //mireds to kelvin
-      
+
       if (strip.hasCCTBus()) {
         bool hasManualWhite = strip.getActiveSegsLightCapabilities(true) & SEG_CAPABILITY_W;
 


### PR DESCRIPTION
Hello,

this addresses https://github.com/Aircoookie/WLED/issues/3209, I am sure this code can be improved as it only checks the "Global override for Auto-calculate white" status instead of the one from each configured LED output, on the other hand, I would not know what to do if there are differently configured LEDs.

But it works for me and is definitely an improvement, because the light doesn't simply go off when Alexa sends a CT value.

PS: The indentation is already broken in the original file, it uses mixed spaces and tabs, it probably would make sense to fix that, for the sake of clarity of this patch I didn't do it.