### PR TITLE
Buttons: Trigger on button press (instead of release) if all configured presets are the same

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -257,6 +257,14 @@ void handleButton()
     //momentary button logic
     if (isButtonPressed(b)) { //pressed
 
+      // no need to wait for release or another press
+      if(macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
+        if(!buttonPressedBefore[b])
+          shortPressAction(b);
+        buttonPressedBefore[b] = true;
+        return;
+      }
+
       if (!buttonPressedBefore[b]) buttonPressedTime[b] = now;
       buttonPressedBefore[b] = true;
 
@@ -270,6 +278,11 @@ void handleButton()
       }
 
     } else if (!isButtonPressed(b) && buttonPressedBefore[b]) { //released
+
+      if(macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
+        buttonPressedBefore[b] = false;
+        return;
+      }
 
       long dur = now - buttonPressedTime[b];
       if (dur < WLED_DEBOUNCE_THRESHOLD) {buttonPressedBefore[b] = false; continue;} //too short "press", debounce

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -227,9 +227,8 @@ void handleButton()
   static unsigned long lastRun = 0UL;
   unsigned long now = millis();
 
-  //if (strip.isUpdating()) return; // don't interfere with strip updates. Our button will still be there in 1ms (next cycle)
-  if (strip.isUpdating() && (millis() - lastRun < 400)) return;   // be niced, but avoid button starvation
-  lastRun = millis();
+  if (strip.isUpdating() && (now - lastRun < 400)) return; // don't interfere with strip update (unless strip is updating continuously, e.g. very long strips)
+  lastRun = now;
 
   for (uint8_t b=0; b<WLED_MAX_BUTTONS; b++) {
     #ifdef ESP8266
@@ -240,7 +239,7 @@ void handleButton()
 
     if (usermods.handleButton(b)) continue; // did usermod handle buttons
 
-    if (buttonType[b] == BTN_TYPE_ANALOG || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {   // button is not a button but a potentiometer
+    if (buttonType[b] == BTN_TYPE_ANALOG || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) { // button is not a button but a potentiometer
       if (now - lastRead > ANALOG_BTN_READ_CYCLE) {
         handleAnalog(b);
         lastRead = now;
@@ -248,20 +247,21 @@ void handleButton()
       continue;
     }
 
-    //button is not momentary, but switch. This is only suitable on pins whose on-boot state does not matter (NOT gpio0)
+    // button is not momentary, but switch. This is only suitable on pins whose on-boot state does not matter (NOT gpio0)
     if (buttonType[b] == BTN_TYPE_SWITCH || buttonType[b] == BTN_TYPE_PIR_SENSOR) {
       handleSwitch(b);
       continue;
     }
 
-    //momentary button logic
-    if (isButtonPressed(b)) { //pressed
+    // momentary button logic
+    if (isButtonPressed(b)) { // pressed
 
-      // no need to wait for release or another press
-      if(macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
-        if(!buttonPressedBefore[b])
+      // if all macros are the same, fire action immediately on rising edge
+      if (macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
+        if (!buttonPressedBefore[b])
           shortPressAction(b);
         buttonPressedBefore[b] = true;
+        buttonPressedTime[b] = now; // continually update (for debouncing to work in release handler)
         return;
       }
 
@@ -278,14 +278,15 @@ void handleButton()
       }
 
     } else if (!isButtonPressed(b) && buttonPressedBefore[b]) { //released
+      long dur = now - buttonPressedTime[b];
 
-      if(macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
-        buttonPressedBefore[b] = false;
+      // released after rising-edge short press action
+      if (macroButton[b] && macroButton[b] == macroLongPress[b] && macroButton[b] == macroDoublePress[b]) {
+        if (dur > WLED_DEBOUNCE_THRESHOLD) buttonPressedBefore[b] = false; // debounce, blocks button for 50 ms once it has been released
         return;
       }
 
-      long dur = now - buttonPressedTime[b];
-      if (dur < WLED_DEBOUNCE_THRESHOLD) {buttonPressedBefore[b] = false; continue;} //too short "press", debounce
+      if (dur < WLED_DEBOUNCE_THRESHOLD) {buttonPressedBefore[b] = false; continue;} // too short "press", debounce
       bool doublePress = buttonWaitTime[b]; //did we have a short press before?
       buttonWaitTime[b] = 0;
 


### PR DESCRIPTION
Hello,

this addresses #3189. It works well for me, but I'm not sure if it doesn't maybe need additional debouncing code with some switches.

