### PR TITLE
Fix WS2801 output on boards with ethrnet 

### DIFF
--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -247,7 +247,11 @@
 #define B_SS_LPO_3 NeoPixelBusLg<Lpd6803GrbFeature, Lpd6803Method, NeoGammaNullMethod>
 
 //WS2801
+#ifdef WLED_USE_ETHERNET
+#define B_HS_WS1_3 NeoPixelBusLg<NeoRbgFeature, Ws2801MethodBase<TwoWireHspiImple<SpiSpeedHz>>, NeoGammaNullMethod>
+#else
 #define B_HS_WS1_3 NeoPixelBusLg<NeoRbgFeature, Ws2801SpiHzMethod, NeoGammaNullMethod>
+#endif
 #define B_SS_WS1_3 NeoPixelBusLg<NeoRbgFeature, Ws2801Method, NeoGammaNullMethod>
 
 //P9813


### PR DESCRIPTION
Similar to #2542 and the corresponding fix https://github.com/Aircoookie/WLED/commit/d1fed11d0d0e93b727d8156e9523f3d1a47ce05f.

Previously the ethernet connection would stop working, now it doesn't. Since a define for Hspi like for the APA102 doesn't exist for the WS2801 in the NeoPixelBus Library, I just do without.