### PR TITLE
Brightness limiter utilizing global LED buffer and improved color restauration

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -289,7 +289,6 @@ uint16_t mode_dynamic(void) {
   if (!SEGENV.allocateData(SEGLEN)) return mode_static(); //allocation failed
 
   if(SEGENV.call == 0) {
-    //SEGMENT.setUpLeds();  //lossless getPixelColor()
     //SEGMENT.fill(BLACK);
     for (int i = 0; i < SEGLEN; i++) SEGENV.data[i] = random8();
   }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -677,6 +677,7 @@ class WS2812FX {  // 96 bytes
       // true private variables
       _length(DEFAULT_LED_COUNT),
       _brightness(DEFAULT_BRIGHTNESS),
+      _renderBrightness(0),
       _transitionDur(750),
       _targetFps(WLED_FPS),
       _frametime(FRAMETIME_FIXED),
@@ -875,7 +876,7 @@ class WS2812FX {  // 96 bytes
 
   private:
     uint16_t _length;
-    uint8_t  _brightness;
+    uint8_t  _brightness, _renderBrightness;
     uint16_t _transitionDur;
 
     uint8_t  _targetFps;
@@ -906,7 +907,7 @@ class WS2812FX {  // 96 bytes
 
     static uint32_t *_globalLedBuffer; // global leds[] array
 
-    void
+    uint8_t
       estimateCurrentAndLimitBri(void);
 };
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1263,7 +1263,8 @@ void WS2812FX::show(void) {
   uint8_t busBrightness = estimateCurrentAndLimitBri();
 
   if (_globalLedBuffer) { // copy data from buffer to bus
-    for (uint16_t i = 0; i < _length; i++) busses.setPixelColor(i, _globalLedBuffer[i]);
+    //for (uint16_t i = 0; i < _length; i++) busses.setPixelColor(i, _globalLedBuffer[i]);
+    busses.setColorsFromBuffer(_globalLedBuffer);
   } else {
     // if brightness changed since last show, must set everything again to update to new luminance
     if (_renderBrightness != busBrightness) {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -563,3 +563,4 @@ uint16_t BusManager::getTotalLength() {
 int16_t Bus::_cct = -1;
 uint8_t Bus::_cctBlend = 0;
 uint8_t Bus::_gAWM = 255;
+uint8_t Bus::_restaurationBri = 255;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -172,7 +172,7 @@ uint32_t BusDigital::getPixelColor(uint16_t pix) {
   if (_type == TYPE_WS2812_1CH_X3) { // map to correct IC, each controls 3 LEDs
     uint16_t pOld = pix;
     pix = IC_INDEX_WS2812_1CH_3X(pix);
-    uint32_t c = PolyBus::getPixelColor(_busPtr, _iType, pix, co);
+    uint32_t c = restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, pix, co));
     switch (pOld % 3) { // get only the single channel
       case 0: c = RGBW32(G(c), G(c), G(c), G(c)); break;
       case 1: c = RGBW32(R(c), R(c), R(c), R(c)); break;
@@ -180,7 +180,7 @@ uint32_t BusDigital::getPixelColor(uint16_t pix) {
     }
     return c;
   }
-  return PolyBus::getPixelColor(_busPtr, _iType, pix, co);
+  return restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, pix, co));
 }
 
 uint8_t BusDigital::getPins(uint8_t* pinArray) {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -506,12 +506,21 @@ void BusManager::setStatusPixel(uint32_t c) {
   }
 }
 
-void IRAM_ATTR BusManager::setPixelColor(uint16_t pix, uint32_t c, int16_t cct) {
+void IRAM_ATTR BusManager::setPixelColor(uint16_t pix, uint32_t c) {
   for (uint8_t i = 0; i < numBusses; i++) {
     Bus* b = busses[i];
     uint16_t bstart = b->getStart();
     if (pix < bstart || pix >= bstart + b->getLength()) continue;
     busses[i]->setPixelColor(pix - bstart, c);
+  }
+}
+
+void BusManager::setColorsFromBuffer(uint32_t* buf) {
+  for (uint8_t i = 0; i < numBusses; i++) {
+    Bus* b = busses[i];
+    uint16_t bstart = b->getStart();
+    for (uint16_t pix = 0; pix < b->getLength(); pix++)
+      busses[i]->setPixelColor(pix, buf[bstart + pix]);
   }
 }
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -357,7 +357,9 @@ class BusManager {
 
     void setStatusPixel(uint32_t c);
 
-    void setPixelColor(uint16_t pix, uint32_t c, int16_t cct=-1);
+    void setPixelColor(uint16_t pix, uint32_t c);
+
+    void setColorsFromBuffer(uint32_t* buf);
 
     void setBrightness(uint8_t b);
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -154,6 +154,7 @@ class Bus {
     inline        uint8_t getAutoWhiteMode()          { return _autoWhiteMode; }
     inline static void    setGlobalAWMode(uint8_t m)  { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
     inline static uint8_t getGlobalAWMode()           { return _gAWM; }
+    inline static void    setRestoreBri(uint8_t b)    { _restaurationBri = b; }
 
     bool reversed = false;
 
@@ -168,6 +169,7 @@ class Bus {
     static uint8_t _gAWM;
     static int16_t _cct;
     static uint8_t _cctBlend;
+    static uint8_t _restaurationBri; // previous brightness used as setPixelColor was called. Used for lossy restoration
 
     uint32_t autoWhiteCalc(uint32_t c);
 };
@@ -231,7 +233,7 @@ class BusDigital : public Bus {
       for (uint8_t i=0; i<4; i++)
       {
         uint16_t val = chan[i];
-        chan[i] = (val << 8) / (_bri + 1);
+        chan[i] = ((val << 8) + _restaurationBri) / (_restaurationBri + 1); //adding _bri slighly improves recovery / stops degradation on re-scale
       }
       return c;
     }

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -223,6 +223,18 @@ class BusDigital : public Bus {
     uint16_t _frequencykHz = 0U;
     void * _busPtr = nullptr;
     const ColorOrderMap &_colorOrderMap;
+
+    inline uint32_t restoreColorLossy(uint32_t c) {
+      if (_bri == 255) return c;
+      uint8_t* chan = (uint8_t*) &c;
+
+      for (uint8_t i=0; i<4; i++)
+      {
+        uint16_t val = chan[i];
+        chan[i] = (val << 8) / (_bri + 1);
+      }
+      return c;
+    }
 };
 
 

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -810,97 +810,97 @@ class PolyBus {
     switch (busType) {
       case I_NONE: break;
     #ifdef ESP8266
-      case I_8266_U0_NEO_3: (static_cast<B_8266_U0_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_NEO_3: (static_cast<B_8266_U1_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_NEO_3: (static_cast<B_8266_DM_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_NEO_3: (static_cast<B_8266_BB_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_NEO_4: (static_cast<B_8266_U0_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_NEO_4: (static_cast<B_8266_U1_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_NEO_4: (static_cast<B_8266_DM_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_NEO_4: (static_cast<B_8266_BB_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_400_3: (static_cast<B_8266_U0_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_400_3: (static_cast<B_8266_U1_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_400_3: (static_cast<B_8266_DM_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_400_3: (static_cast<B_8266_BB_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_TM1_4: (static_cast<B_8266_U0_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_TM2_3: (static_cast<B_8266_U0_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_TM2_3: (static_cast<B_8266_U1_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_TM2_3: (static_cast<B_8266_DM_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_TM2_3: (static_cast<B_8266_BB_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_UCS_3: (static_cast<B_8266_U0_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_UCS_3: (static_cast<B_8266_U1_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_UCS_3: (static_cast<B_8266_DM_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_UCS_3: (static_cast<B_8266_BB_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_UCS_4: (static_cast<B_8266_U0_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_UCS_4: (static_cast<B_8266_U1_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_UCS_4: (static_cast<B_8266_DM_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_UCS_4: (static_cast<B_8266_BB_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_NEO_3: (static_cast<B_8266_U0_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_NEO_3: (static_cast<B_8266_U1_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_NEO_3: (static_cast<B_8266_DM_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_NEO_3: (static_cast<B_8266_BB_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_NEO_4: (static_cast<B_8266_U0_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_NEO_4: (static_cast<B_8266_U1_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_NEO_4: (static_cast<B_8266_DM_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_NEO_4: (static_cast<B_8266_BB_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_400_3: (static_cast<B_8266_U0_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_400_3: (static_cast<B_8266_U1_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_400_3: (static_cast<B_8266_DM_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_400_3: (static_cast<B_8266_BB_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_TM1_4: (static_cast<B_8266_U0_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_TM2_3: (static_cast<B_8266_U0_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_TM2_3: (static_cast<B_8266_U1_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_TM2_3: (static_cast<B_8266_DM_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_TM2_3: (static_cast<B_8266_BB_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_UCS_3: (static_cast<B_8266_U0_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_UCS_3: (static_cast<B_8266_U1_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_UCS_3: (static_cast<B_8266_DM_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_UCS_3: (static_cast<B_8266_BB_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_UCS_4: (static_cast<B_8266_U0_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_UCS_4: (static_cast<B_8266_U1_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_UCS_4: (static_cast<B_8266_DM_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_UCS_4: (static_cast<B_8266_BB_UCS_4*>(busPtr))->SetLuminance(b); break;
     #endif
     #ifdef ARDUINO_ARCH_ESP32
-      case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_NEO_3: (static_cast<B_32_BB_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_NEO_3: (static_cast<B_32_BB_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_NEO_4: (static_cast<B_32_BB_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_NEO_4: (static_cast<B_32_BB_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_400_3: (static_cast<B_32_BB_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_TM2_3: (static_cast<B_32_RN_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_400_3: (static_cast<B_32_BB_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_TM2_3: (static_cast<B_32_RN_TM2_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_I0_TM2_3: (static_cast<B_32_I0_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_I0_TM2_3: (static_cast<B_32_I0_TM2_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_I1_TM2_3: (static_cast<B_32_I1_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_I1_TM2_3: (static_cast<B_32_I1_TM2_3*>(busPtr))->SetLuminance(b); break;
       #endif
-      case I_32_RN_UCS_3: (static_cast<B_32_RN_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_UCS_3: (static_cast<B_32_RN_UCS_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_UCS_3: (static_cast<B_32_I0_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_UCS_3: (static_cast<B_32_I0_UCS_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_UCS_3: (static_cast<B_32_I1_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_UCS_3: (static_cast<B_32_I1_UCS_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_UCS_3: (static_cast<B_32_BB_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_UCS_4: (static_cast<B_32_RN_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_UCS_3: (static_cast<B_32_BB_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_UCS_4: (static_cast<B_32_RN_UCS_4*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_UCS_4: (static_cast<B_32_I0_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_UCS_4: (static_cast<B_32_I0_UCS_4*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_UCS_4: (static_cast<B_32_I1_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_UCS_4: (static_cast<B_32_I1_UCS_4*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_UCS_4: (static_cast<B_32_BB_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_UCS_4: (static_cast<B_32_BB_UCS_4*>(busPtr))->SetLuminance(b); break;
     #endif
-      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_LPO_3: (static_cast<B_HS_LPO_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_LPO_3: (static_cast<B_SS_LPO_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_LPO_3: (static_cast<B_HS_LPO_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_LPO_3: (static_cast<B_SS_LPO_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetLuminance(b); break;
     }
   };
   static uint32_t getPixelColor(void* busPtr, uint8_t busType, uint16_t pix, uint8_t co) {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -90,7 +90,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(strip.cctBlending, hw_led[F("cb")]);
   Bus::setCCTBlend(strip.cctBlending);
   strip.setTargetFps(hw_led["fps"]); //NOP if 0, default 42 FPS
-  CJSON(strip.useLedsArray, hw_led[F("ld")]);
+  CJSON(strip.useGlobalLedBuffer, hw_led[F("ld")]);
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings
@@ -706,7 +706,7 @@ void serializeConfig() {
   hw_led[F("cb")] = strip.cctBlending;
   hw_led["fps"] = strip.getTargetFps();
   hw_led[F("rgbwm")] = Bus::getGlobalAWMode(); // global auto white mode override
-  hw_led[F("ld")] = strip.useLedsArray;
+  hw_led[F("ld")] = strip.useGlobalLedBuffer;
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -141,7 +141,7 @@
 			let len = parseInt(d.getElementsByName("LC"+n)[0].value);
 			len += parseInt(d.getElementsByName("SL"+n)[0].value); // skipped LEDs are allocated too
 			let dbl = 0;
-			if (d.Sf.LD.checked) dbl = len * 3;	// double buffering
+			if (d.Sf.LD.checked) dbl = len * 4;	// double buffering
 			if (t < 32) {
 				if (t==26 || t==29) len *= 2; // 16 bit LEDs
 				if (maxM < 10000 && d.getElementsByName("L0"+n)[0].value == 3) { //8266 DMA uses 5x the mem

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -91,7 +91,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     Bus::setCCTBlend(strip.cctBlending);
     Bus::setGlobalAWMode(request->arg(F("AW")).toInt());
     strip.setTargetFps(request->arg(F("FR")).toInt());
-    strip.useLedsArray = request->hasArg(F("LD"));
+    strip.useGlobalLedBuffer = request->hasArg(F("LD"));
 
     bool busesChanged = false;
     for (uint8_t s = 0; s < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; s++) {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -151,11 +151,16 @@ void WLED::loop()
     DEBUG_PRINTLN(F("Re-init busses."));
     bool aligned = strip.checkSegmentAlignment(); //see if old segments match old bus(ses)
     busses.removeAll();
-    uint32_t mem = 0;
+    uint32_t mem = 0, globalBufMem = 0;
+    uint16_t maxlen = 0;
     for (uint8_t i = 0; i < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; i++) {
       if (busConfigs[i] == nullptr) break;
       mem += BusManager::memUsage(*busConfigs[i]);
-      if (mem <= MAX_LED_MEMORY) {
+      if (strip.useGlobalLedBuffer && busConfigs[i]->start + busConfigs[i]->count > maxlen) {
+          maxlen = busConfigs[i]->start + busConfigs[i]->count;
+          globalBufMem = maxlen * 4;
+      }
+      if (mem + globalBufMem <= MAX_LED_MEMORY) {
         busses.add(*busConfigs[i]);
       }
       delete busConfigs[i]; busConfigs[i] = nullptr;

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -404,7 +404,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("CB"),strip.cctBlending);
     sappend('v',SET_F("FR"),strip.getTargetFps());
     sappend('v',SET_F("AW"),Bus::getGlobalAWMode());
-    sappend('c',SET_F("LD"),strip.useLedsArray);
+    sappend('c',SET_F("LD"),strip.useGlobalLedBuffer);
 
     for (uint8_t s=0; s < busses.getNumBusses(); s++) {
       Bus* bus = busses.getBus(s);


### PR DESCRIPTION
Fixes #3264 

- Decoupled global buffer from optional segment `leds` buffer, per-segment buffers are only allocated if the global buffer is disabled (per-segment buffer could still be useful with global buffer enabled in some cases as it is lossless even if less than maximum segment opacity is set, so we may consider changing the buffer option to a dropdown with "Global", "None", "Per-segment", "Global + per-segment")
- Added improved lossy color restauration to `BusDigital::getPixelColor()`. Such functionality was part of NeoPixelBrightnessBus, but not NeoPixelBusLg, still it is absolutely essential if no double buffer is used. The restauration equation is improved to be lossless when setting repeatedly, e.g. calling `setPixelColor(i, getPixelColor(i))` will not gradually degrade the color to black.
- ABL `makePostAdjustments()` hotfix replaced by reading global buffer if enabled, else using restored colors from bus (lower performance) 
- Global buffer is now of type `uint32_t` for ease of implementation, using RgbColor or CRGB types would also work and is up for consideration so that enabling global buffer would use 1 byte less per LED (perhaps at least if the setup contains no white channel LEDs at all?). Would cause headaches with how to get the white channel for ABL though and might impact performance slightly by having to convert from/to uint32_t.

@Makuna if you are interested in testing the improved lossy restauration even though NPBrightnessBus is already deprecated, just replacing `*ptr++ = (value << 8) / scale;` ([L78](https://github.com/Makuna/NeoPixelBus/blob/1cf6b3187b1a78c532f79c952e4d89f199c194c4/src/NeoPixelBrightnessBus.h#L7)) with `*ptr++ = ((value << 8) + _brightness) / scale;` should do the trick. While there is still significant loss, the recovered color is frequently one value closer to the one originally set, but most importantly repeatedly getting and setting again should no longer degrade the color any further.