### PR TITLE
Bus-level global buffering

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -289,7 +289,6 @@ uint16_t mode_dynamic(void) {
   if (!SEGENV.allocateData(SEGLEN)) return mode_static(); //allocation failed
 
   if(SEGENV.call == 0) {
-    //SEGMENT.setUpLeds();  //lossless getPixelColor()
     //SEGMENT.fill(BLACK);
     for (int i = 0; i < SEGLEN; i++) SEGENV.data[i] = random8();
   }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -677,6 +677,7 @@ class WS2812FX {  // 96 bytes
       // true private variables
       _length(DEFAULT_LED_COUNT),
       _brightness(DEFAULT_BRIGHTNESS),
+      _renderBrightness(0),
       _transitionDur(750),
       _targetFps(WLED_FPS),
       _frametime(FRAMETIME_FIXED),
@@ -875,7 +876,7 @@ class WS2812FX {  // 96 bytes
 
   private:
     uint16_t _length;
-    uint8_t  _brightness;
+    uint8_t  _brightness, _renderBrightness;
     uint16_t _transitionDur;
 
     uint8_t  _targetFps;
@@ -906,7 +907,7 @@ class WS2812FX {  // 96 bytes
 
     static uint32_t *_globalLedBuffer; // global leds[] array
 
-    void
+    uint8_t
       estimateCurrentAndLimitBri(void);
 };
 

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -199,8 +199,6 @@ void /*IRAM_ATTR*/ Segment::setPixelColorXY(int x, int y, uint32_t col)
   if (Segment::maxHeight==1) return; // not a matrix set-up
   if (x >= virtualWidth() || y >= virtualHeight() || x<0 || y<0) return;  // if pixel would fall out of virtual segment just exit
 
-  if (leds) leds[XY(x,y)] = col;
-
   uint8_t _bri_t = currentBri(on ? opacity : 0);
   if (_bri_t < 255) {
     byte r = scale8(R(col), _bri_t);
@@ -286,8 +284,6 @@ void Segment::setPixelColorXY(float x, float y, uint32_t col, bool aa)
 
 // returns RGBW values of pixel
 uint32_t Segment::getPixelColorXY(uint16_t x, uint16_t y) {
-  int i = XY(x,y);
-  if (leds) return RGBW32(leds[i].r, leds[i].g, leds[i].b, 0);
   if (reverse  ) x = virtualWidth()  - x - 1;
   if (reverse_y) y = virtualHeight() - y - 1;
   if (transpose) { uint16_t t = x; x = y; y = t; } // swap X & Y if segment transposed

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -199,6 +199,8 @@ void /*IRAM_ATTR*/ Segment::setPixelColorXY(int x, int y, uint32_t col)
   if (Segment::maxHeight==1) return; // not a matrix set-up
   if (x >= virtualWidth() || y >= virtualHeight() || x<0 || y<0) return;  // if pixel would fall out of virtual segment just exit
 
+  if (leds) leds[XY(x,y)] = col;
+
   uint8_t _bri_t = currentBri(on ? opacity : 0);
   if (_bri_t < 255) {
     byte r = scale8(R(col), _bri_t);
@@ -284,6 +286,7 @@ void Segment::setPixelColorXY(float x, float y, uint32_t col, bool aa)
 
 // returns RGBW values of pixel
 uint32_t Segment::getPixelColorXY(uint16_t x, uint16_t y) {
+  if (leds) return leds[XY(x,y)];
   if (reverse  ) x = virtualWidth()  - x - 1;
   if (reverse_y) y = virtualHeight() - y - 1;
   if (transpose) { uint16_t t = x; x = y; y = t; } // swap X & Y if segment transposed

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1263,7 +1263,8 @@ void WS2812FX::show(void) {
   uint8_t busBrightness = estimateCurrentAndLimitBri();
 
   if (_globalLedBuffer) { // copy data from buffer to bus
-    for (uint16_t i = 0; i < _length; i++) busses.setPixelColor(i, _globalLedBuffer[i]);
+    //for (uint16_t i = 0; i < _length; i++) busses.setPixelColor(i, _globalLedBuffer[i]);
+    busses.setColorsFromBuffer(_globalLedBuffer);
   } else {
     // if brightness changed since last show, must set everything again to update to new luminance
     if (_renderBrightness != busBrightness) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1219,9 +1219,11 @@ uint8_t WS2812FX::estimateCurrentAndLimitBri() {
 }
 
 void WS2812FX::show(void) {
+  #ifdef WLED_DEBUG
   static unsigned long sumMicros = 0, sumCurrent = 0;
   static size_t calls = 0;
   unsigned long microsStart = micros();
+  #endif
 
   // avoid race condition, caputre _callback value
   show_callback callback = _callback;
@@ -1229,7 +1231,9 @@ void WS2812FX::show(void) {
 
   uint8_t busBrightness = estimateCurrentAndLimitBri();
   busses.setBrightness(busBrightness);
+  #ifdef WLED_DEBUG
   sumCurrent += micros() - microsStart;
+  #endif
 
   // some buses send asynchronously and this method will return before
   // all of the data has been sent.
@@ -1242,12 +1246,14 @@ void WS2812FX::show(void) {
   _cumulativeFps = (3 * _cumulativeFps + fpsCurr) >> 2;
   _lastShow = now;
 
+  #ifdef WLED_DEBUG
   sumMicros += micros() - microsStart;
   if (++calls == 100) {
     DEBUG_PRINTF("show calls: %d micros: %lu avg: %lu (current: %lu avg: %lu)\n", calls, sumMicros, sumMicros/calls, sumCurrent, sumCurrent/calls);
     sumMicros = sumCurrent = 0;
     calls = 0;
   }
+  #endif
 }
 
 /**

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1084,10 +1084,7 @@ void WS2812FX::service() {
     if(nowUp > seg.next_time || _triggered || (doShow && seg.mode == FX_MODE_STATIC))
     {
       if (seg.grouping == 0) seg.grouping = 1; // sanity check
-//      if (!doShow) {
-//        busses.setBrightness(_brightness); // bus luminance must be set before FX using setPixelColor()
-        doShow = true;
-//      }
+      doShow = true;
       uint16_t delay = FRAMETIME;
 
       if (!seg.freeze) { //only run effect function if not frozen

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -147,18 +147,11 @@ void BusDigital::show() {
       else pix += _skip;
       PolyBus::setPixelColor(_busPtr, _iType, pix, c, co);
     }
-    PolyBus::show(_busPtr, _iType);
   } else {
     PolyBus::applyPostAdjustments(_busPtr, _iType);
-    PolyBus::show(_busPtr, _iType);
-    // now restore (as close as possible) previous colors
-    // warning: this may not be the best idea as the buffer may still be in use
-    for (size_t i=0; i<_len; i++) {
-      uint8_t co = _colorOrderMap.getPixelColorOrder(i+_start, _colorOrder);
-      setPixelColor(i, restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, i, co), _bri));
-    }
   }
-  PolyBus::setBrightness(_busPtr, _iType, 255); // restore full brightness
+  PolyBus::show(_busPtr, _iType);
+  PolyBus::setBrightness(_busPtr, _iType, 255); // restore full brightness at bus level (setting unscaled pixel color)
 }
 
 bool BusDigital::canShow() {
@@ -243,7 +236,7 @@ uint32_t BusDigital::getPixelColor(uint16_t pix) {
       }
       return c;
     }
-    return PolyBus::getPixelColor(_busPtr, _iType, pix, co);
+    return restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, pix, co), _bri);
   }
 }
 

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -563,3 +563,4 @@ uint16_t BusManager::getTotalLength() {
 int16_t Bus::_cct = -1;
 uint8_t Bus::_cctBlend = 0;
 uint8_t Bus::_gAWM = 255;
+uint8_t Bus::_restaurationBri = 255;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -172,7 +172,7 @@ uint32_t BusDigital::getPixelColor(uint16_t pix) {
   if (_type == TYPE_WS2812_1CH_X3) { // map to correct IC, each controls 3 LEDs
     uint16_t pOld = pix;
     pix = IC_INDEX_WS2812_1CH_3X(pix);
-    uint32_t c = PolyBus::getPixelColor(_busPtr, _iType, pix, co);
+    uint32_t c = restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, pix, co));
     switch (pOld % 3) { // get only the single channel
       case 0: c = RGBW32(G(c), G(c), G(c), G(c)); break;
       case 1: c = RGBW32(R(c), R(c), R(c), R(c)); break;
@@ -180,7 +180,7 @@ uint32_t BusDigital::getPixelColor(uint16_t pix) {
     }
     return c;
   }
-  return PolyBus::getPixelColor(_busPtr, _iType, pix, co);
+  return restoreColorLossy(PolyBus::getPixelColor(_busPtr, _iType, pix, co));
 }
 
 uint8_t BusDigital::getPins(uint8_t* pinArray) {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -506,12 +506,21 @@ void BusManager::setStatusPixel(uint32_t c) {
   }
 }
 
-void IRAM_ATTR BusManager::setPixelColor(uint16_t pix, uint32_t c, int16_t cct) {
+void IRAM_ATTR BusManager::setPixelColor(uint16_t pix, uint32_t c) {
   for (uint8_t i = 0; i < numBusses; i++) {
     Bus* b = busses[i];
     uint16_t bstart = b->getStart();
     if (pix < bstart || pix >= bstart + b->getLength()) continue;
     busses[i]->setPixelColor(pix - bstart, c);
+  }
+}
+
+void BusManager::setColorsFromBuffer(uint32_t* buf) {
+  for (uint8_t i = 0; i < numBusses; i++) {
+    Bus* b = busses[i];
+    uint16_t bstart = b->getStart();
+    for (uint16_t pix = 0; pix < b->getLength(); pix++)
+      busses[i]->setPixelColor(pix, buf[bstart + pix]);
   }
 }
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -236,13 +236,13 @@ class BusDigital : public Bus {
     void * _busPtr = nullptr;
     const ColorOrderMap &_colorOrderMap;
 
-    inline uint32_t restoreColorLossy(uint32_t c, uint8_t _restaurationBri) {
-      if (_bri == 255) return c;
+    inline uint32_t restoreColorLossy(uint32_t c, uint_fast8_t _restaurationBri) {
+      if (_restaurationBri == 255) return c;
       uint8_t* chan = (uint8_t*) &c;
 
-      for (uint8_t i=0; i<4; i++)
+      for (uint_fast8_t i=0; i<4; i++)
       {
-        uint16_t val = chan[i];
+        uint_fast16_t val = chan[i];
         chan[i] = ((val << 8) + _restaurationBri) / (_restaurationBri + 1); //adding _bri slighly improves recovery / stops degradation on re-scale
       }
       return c;

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -357,7 +357,9 @@ class BusManager {
 
     void setStatusPixel(uint32_t c);
 
-    void setPixelColor(uint16_t pix, uint32_t c, int16_t cct=-1);
+    void setPixelColor(uint16_t pix, uint32_t c);
+
+    void setColorsFromBuffer(uint32_t* buf);
 
     void setBrightness(uint8_t b);
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -154,6 +154,7 @@ class Bus {
     inline        uint8_t getAutoWhiteMode()          { return _autoWhiteMode; }
     inline static void    setGlobalAWMode(uint8_t m)  { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
     inline static uint8_t getGlobalAWMode()           { return _gAWM; }
+    inline static void    setRestoreBri(uint8_t b)    { _restaurationBri = b; }
 
     bool reversed = false;
 
@@ -168,6 +169,7 @@ class Bus {
     static uint8_t _gAWM;
     static int16_t _cct;
     static uint8_t _cctBlend;
+    static uint8_t _restaurationBri; // previous brightness used as setPixelColor was called. Used for lossy restoration
 
     uint32_t autoWhiteCalc(uint32_t c);
 };
@@ -231,7 +233,7 @@ class BusDigital : public Bus {
       for (uint8_t i=0; i<4; i++)
       {
         uint16_t val = chan[i];
-        chan[i] = (val << 8) / (_bri + 1);
+        chan[i] = ((val << 8) + _restaurationBri) / (_restaurationBri + 1); //adding _bri slighly improves recovery / stops degradation on re-scale
       }
       return c;
     }

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -35,15 +35,24 @@ struct BusConfig {
   uint8_t pins[5] = {LEDPIN, 255, 255, 255, 255};
   uint16_t frequency;
   bool doubleBuffer;
-  BusConfig(uint8_t busType, uint8_t* ppins, uint16_t pstart, uint16_t len = 1, uint8_t pcolorOrder = COL_ORDER_GRB, bool rev = false, uint8_t skip = 0, byte aw=RGBW_MODE_MANUAL_ONLY, uint16_t clock_kHz=0U, bool dblBfr=false) {
+
+  BusConfig(uint8_t busType, uint8_t* ppins, uint16_t pstart, uint16_t len = 1, uint8_t pcolorOrder = COL_ORDER_GRB, bool rev = false, uint8_t skip = 0, byte aw=RGBW_MODE_MANUAL_ONLY, uint16_t clock_kHz=0U, bool dblBfr=false)
+  : count(len)
+  , start(pstart)
+  , colorOrder(pcolorOrder)
+  , reversed(rev)
+  , skipAmount(skip)
+  , autoWhite(aw)
+  , frequency(clock_kHz)
+  , doubleBuffer(dblBfr)
+  {
     refreshReq = (bool) GET_BIT(busType,7);
     type = busType & 0x7F;  // bit 7 may be/is hacked to include refresh info (1=refresh in off state, 0=no refresh)
-    count = len; start = pstart; colorOrder = pcolorOrder; reversed = rev; skipAmount = skip; autoWhite = aw; frequency = clock_kHz; doubleBuffer = dblBfr;
-    uint8_t nPins = 1;
+    size_t nPins = 1;
     if (type >= TYPE_NET_DDP_RGB && type < 96) nPins = 4; //virtual network bus. 4 "pins" store IP address
     else if (type > 47) nPins = 2;
     else if (type > 40 && type < 46) nPins = NUM_PWM_PINS(type);
-    for (uint8_t i = 0; i < nPins; i++) pins[i] = ppins[i];
+    for (size_t i = 0; i < nPins; i++) pins[i] = ppins[i];
   }
 
   //validates start and length and extends total if needed
@@ -70,9 +79,7 @@ struct ColorOrderMapEntry {
 struct ColorOrderMap {
     void add(uint16_t start, uint16_t len, uint8_t colorOrder);
 
-    uint8_t count() const {
-      return _count;
-    }
+    uint8_t count() const { return _count; }
 
     void reset() {
       _count = 0;
@@ -97,38 +104,41 @@ struct ColorOrderMap {
 //parent class of BusDigital, BusPwm, and BusNetwork
 class Bus {
   public:
-    Bus(uint8_t type, uint16_t start, uint8_t aw)
-    : _bri(255)
-    , _len(1)
-    , _data(nullptr) // keep data access consistent across all types of buses
+    Bus(uint8_t type, uint16_t start, uint8_t aw, uint16_t len = 1, bool reversed = false, bool refresh = false)
+    : _type(type)
+    , _bri(255)
+    , _start(start)
+    , _len(len)
+    , _reversed(reversed)
     , _valid(false)
-    , _needsRefresh(false)
+    , _needsRefresh(refresh)
+    , _data(nullptr) // keep data access consistent across all types of buses
     {
-      _type = type;
-      _start = start;
       _autoWhiteMode = Bus::hasWhite(_type) ? aw : RGBW_MODE_MANUAL_ONLY;
     };
 
     virtual ~Bus() {} //throw the bus under the bus
 
     virtual void     show() = 0;
-    virtual bool     canShow() { return true; }
-    virtual void     setStatusPixel(uint32_t c) {}
+    virtual bool     canShow()                   { return true; }
+    virtual void     setStatusPixel(uint32_t c)  {}
     virtual void     setPixelColor(uint16_t pix, uint32_t c) = 0;
     virtual uint32_t getPixelColor(uint16_t pix) { return 0; }
-    virtual void     setBrightness(uint8_t b) { _bri = b; };
+    virtual void     setBrightness(uint8_t b)    { _bri = b; };
     virtual void     cleanup() = 0;
-    virtual uint8_t  getPins(uint8_t* pinArray) { return 0; }
-    virtual uint16_t getLength() { return _len; }
-    virtual void     setColorOrder() {}
-    virtual uint8_t  getColorOrder() { return COL_ORDER_RGB; }
-    virtual uint8_t  skippedLeds() { return 0; }
-    virtual uint16_t getFrequency() { return 0U; }
-    inline  uint16_t getStart() { return _start; }
-    inline  void     setStart(uint16_t start) { _start = start; }
-    inline  uint8_t  getType() { return _type; }
-    inline  bool     isOk() { return _valid; }
-    inline  bool     isOffRefreshRequired() { return _needsRefresh; }
+    virtual uint8_t  getPins(uint8_t* pinArray)  { return 0; }
+    virtual uint16_t getLength()                 { return _len; }
+    virtual void     setColorOrder()             {}
+    virtual uint8_t  getColorOrder()             { return COL_ORDER_RGB; }
+    virtual uint8_t  skippedLeds()               { return 0; }
+    virtual uint16_t getFrequency()              { return 0U; }
+    inline  void     setReversed(bool reversed)  { _reversed = reversed; }
+    inline  uint16_t getStart()                  { return _start; }
+    inline  void     setStart(uint16_t start)    { _start = start; }
+    inline  uint8_t  getType()                   { return _type; }
+    inline  bool     isOk()                      { return _valid; }
+    inline  bool     isReversed()                { return _reversed; }
+    inline  bool     isOffRefreshRequired()      { return _needsRefresh; }
             bool     containsPixel(uint16_t pix) { return pix >= _start && pix < _start+_len; }
 
     virtual bool hasRGB(void) { return Bus::hasRGB(_type); }
@@ -165,17 +175,16 @@ class Bus {
     inline static void    setGlobalAWMode(uint8_t m)  { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
     inline static uint8_t getGlobalAWMode()           { return _gAWM; }
 
-    bool reversed = false;
-
   protected:
     uint8_t  _type;
     uint8_t  _bri;
     uint16_t _start;
     uint16_t _len;
-    uint8_t  *_data;
+    bool     _reversed;
     bool     _valid;
     bool     _needsRefresh;
     uint8_t  _autoWhiteMode;
+    uint8_t  *_data;
     static uint8_t _gAWM;
     static int16_t _cct;
     static uint8_t _cctBlend;
@@ -189,54 +198,31 @@ class Bus {
 class BusDigital : public Bus {
   public:
     BusDigital(BusConfig &bc, uint8_t nr, const ColorOrderMap &com);
+    ~BusDigital() { cleanup(); }
 
-    inline void show();
-
+    void show();
     bool canShow();
-
     void setBrightness(uint8_t b);
-
     void setStatusPixel(uint32_t c);
-
     void setPixelColor(uint16_t pix, uint32_t c);
-
-    uint32_t getPixelColor(uint16_t pix);
-
-    uint8_t getColorOrder() {
-      return _colorOrder;
-    }
-
-    uint16_t getLength() {
-      return _len - _skip;
-    }
-
-    uint8_t getPins(uint8_t* pinArray);
-
     void setColorOrder(uint8_t colorOrder);
-
-    uint8_t skippedLeds() {
-      return _skip;
-    }
-
-    uint16_t getFrequency() { return _frequencykHz; }
-
+    uint32_t getPixelColor(uint16_t pix);
+    uint8_t  getColorOrder() { return _colorOrder; }
+    uint8_t  getPins(uint8_t* pinArray);
+    uint8_t  skippedLeds()   { return _skip; }
+    uint16_t getFrequency()  { return _frequencykHz; }
     void reinit();
-
     void cleanup();
 
-    ~BusDigital() {
-      cleanup();
-    }
-
   private:
-    uint8_t _colorOrder = COL_ORDER_GRB;
-    uint8_t _pins[2] = {255, 255};
-    uint8_t _iType = 0; //I_NONE;
-    uint8_t _skip = 0;
-    uint16_t _frequencykHz = 0U;
-    void * _busPtr = nullptr;
+    uint8_t _skip;
+    uint8_t _colorOrder;
+    uint8_t _pins[2];
+    uint8_t _iType;
+    uint16_t _frequencykHz;
+    void * _busPtr;
     const ColorOrderMap &_colorOrderMap;
-    bool buffering = false; // temporary until we figure out why comparison "_data != nullptr" causes severe FPS drop
+    bool buffering; // temporary until we figure out why comparison "_data != nullptr" causes severe FPS drop
 
     inline uint32_t restoreColorLossy(uint32_t c, uint_fast8_t _restaurationBri) {
       if (_bri == 255) return c;
@@ -255,33 +241,22 @@ class BusDigital : public Bus {
 class BusPwm : public Bus {
   public:
     BusPwm(BusConfig &bc);
+    ~BusPwm() { cleanup(); }
 
     void setPixelColor(uint16_t pix, uint32_t c);
-
-    //does no index check
-    uint32_t getPixelColor(uint16_t pix);
-
-    void show();
-
-    uint8_t getPins(uint8_t* pinArray);
-
+    uint32_t getPixelColor(uint16_t pix); //does no index check
+    uint8_t  getPins(uint8_t* pinArray);
     uint16_t getFrequency() { return _frequency; }
-
-    void cleanup() {
-      deallocatePins();
-    }
-
-    ~BusPwm() {
-      cleanup();
-    }
+    void show();
+    void cleanup() { deallocatePins(); }
 
   private:
-    uint8_t _pins[5] = {255, 255, 255, 255, 255};
-    uint8_t _pwmdata[5] = {0};
+    uint8_t _pins[5];
+    uint8_t _pwmdata[5];
     #ifdef ARDUINO_ARCH_ESP32
-    uint8_t _ledcStart = 255;
+    uint8_t _ledcStart;
     #endif
-    uint16_t _frequency = 0U;
+    uint16_t _frequency;
 
     void deallocatePins();
 };
@@ -290,58 +265,33 @@ class BusPwm : public Bus {
 class BusOnOff : public Bus {
   public:
     BusOnOff(BusConfig &bc);
+    ~BusOnOff() { cleanup(); }
 
     void setPixelColor(uint16_t pix, uint32_t c);
-
     uint32_t getPixelColor(uint16_t pix);
-
+    uint8_t  getPins(uint8_t* pinArray);
     void show();
-
-    uint8_t getPins(uint8_t* pinArray);
-
-    void cleanup() {
-      pinManager.deallocatePin(_pin, PinOwner::BusOnOff);
-    }
-
-    ~BusOnOff() {
-      cleanup();
-    }
+    void cleanup() { pinManager.deallocatePin(_pin, PinOwner::BusOnOff); }
 
   private:
-    uint8_t _pin = 255;
-    uint8_t _onoffdata = 0;
+    uint8_t _pin;
+    uint8_t _onoffdata;
 };
 
 
 class BusNetwork : public Bus {
   public:
     BusNetwork(BusConfig &bc);
+    ~BusNetwork() { cleanup(); }
 
-    bool hasRGB() { return true; }
+    bool hasRGB()   { return true; }
     bool hasWhite() { return _rgbw; }
-
+    bool canShow()  { return !_broadcastLock; } // this should be a return value from UDP routine if it is still sending data out
     void setPixelColor(uint16_t pix, uint32_t c);
-
     uint32_t getPixelColor(uint16_t pix);
-
+    uint8_t  getPins(uint8_t* pinArray);
     void show();
-
-    bool canShow() {
-      // this should be a return value from UDP routine if it is still sending data out
-      return !_broadcastLock;
-    }
-
-    uint8_t getPins(uint8_t* pinArray);
-
-    uint16_t getLength() {
-      return _len;
-    }
-
     void cleanup();
-
-    ~BusNetwork() {
-      cleanup();
-    }
 
   private:
     IPAddress _client;
@@ -354,7 +304,7 @@ class BusNetwork : public Bus {
 
 class BusManager {
   public:
-    BusManager() {};
+    BusManager() : numBusses(0) {};
 
     //utility to get the approx. memory usage of a given BusConfig
     static uint32_t memUsage(BusConfig &bc);
@@ -365,38 +315,24 @@ class BusManager {
     void removeAll();
 
     void show();
-
-    void setStatusPixel(uint32_t c);
-
-    void setPixelColor(uint16_t pix, uint32_t c);
-
-    void setBrightness(uint8_t b);
-
-    void setSegmentCCT(int16_t cct, bool allowWBCorrection = false);
-
-    uint32_t getPixelColor(uint16_t pix);
-
     bool canAllShow();
+    void setStatusPixel(uint32_t c);
+    void setPixelColor(uint16_t pix, uint32_t c);
+    void setBrightness(uint8_t b);
+    void setSegmentCCT(int16_t cct, bool allowWBCorrection = false);
+    uint32_t getPixelColor(uint16_t pix);
 
     Bus* getBus(uint8_t busNr);
 
     //semi-duplicate of strip.getLengthTotal() (though that just returns strip._length, calculated in finalizeInit())
     uint16_t getTotalLength();
+    inline uint8_t getNumBusses() const { return numBusses; }
 
-    inline void updateColorOrderMap(const ColorOrderMap &com) {
-      memcpy(&colorOrderMap, &com, sizeof(ColorOrderMap));
-    }
-
-    inline const ColorOrderMap& getColorOrderMap() const {
-      return colorOrderMap;
-    }
-
-    inline uint8_t getNumBusses() {
-      return numBusses;
-    }
+    inline void                 updateColorOrderMap(const ColorOrderMap &com) { memcpy(&colorOrderMap, &com, sizeof(ColorOrderMap)); }
+    inline const ColorOrderMap& getColorOrderMap() const { return colorOrderMap; }
 
   private:
-    uint8_t numBusses = 0;
+    uint8_t numBusses;
     Bus* busses[WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES];
     ColorOrderMap colorOrderMap;
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -130,20 +130,22 @@ class Bus {
     inline  bool     isOffRefreshRequired() { return _needsRefresh; }
             bool     containsPixel(uint16_t pix) { return pix >= _start && pix < _start+_len; }
 
-    virtual bool hasRGB() {
-      if ((_type >= TYPE_WS2812_1CH && _type <= TYPE_WS2812_WWA) || _type == TYPE_ANALOG_1CH || _type == TYPE_ANALOG_2CH || _type == TYPE_ONOFF) return false;
+    virtual bool hasRGB(void) { return Bus::hasRGB(_type); }
+    static  bool hasRGB(uint8_t type) {
+      if ((type >= TYPE_WS2812_1CH && type <= TYPE_WS2812_WWA) || type == TYPE_ANALOG_1CH || type == TYPE_ANALOG_2CH || type == TYPE_ONOFF) return false;
       return true;
     }
-    virtual bool hasWhite() { return Bus::hasWhite(_type); }
+    virtual bool hasWhite(void) { return Bus::hasWhite(_type); }
     static  bool hasWhite(uint8_t type) {
       if ((type >= TYPE_WS2812_1CH && type <= TYPE_WS2812_WWA) || type == TYPE_SK6812_RGBW || type == TYPE_TM1814) return true; // digital types with white channel
       if (type > TYPE_ONOFF && type <= TYPE_ANALOG_5CH && type != TYPE_ANALOG_3CH) return true; // analog types with white channel
       if (type == TYPE_NET_DDP_RGBW) return true; // network types with white channel
       return false;
     }
-    virtual bool hasCCT() {
-      if (_type == TYPE_WS2812_2CH_X3 || _type == TYPE_WS2812_WWA ||
-          _type == TYPE_ANALOG_2CH    || _type == TYPE_ANALOG_5CH) return true;
+    virtual bool hasCCT(void) { return Bus::hasCCT(_type); }
+    static  bool hasCCT(uint8_t type) {
+      if (type == TYPE_WS2812_2CH_X3 || type == TYPE_WS2812_WWA ||
+          type == TYPE_ANALOG_2CH    || type == TYPE_ANALOG_5CH) return true;
       return false;
     }
     static void setCCT(uint16_t cct) {

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -223,6 +223,18 @@ class BusDigital : public Bus {
     uint16_t _frequencykHz = 0U;
     void * _busPtr = nullptr;
     const ColorOrderMap &_colorOrderMap;
+
+    inline uint32_t restoreColorLossy(uint32_t c) {
+      if (_bri == 255) return c;
+      uint8_t* chan = (uint8_t*) &c;
+
+      for (uint8_t i=0; i<4; i++)
+      {
+        uint16_t val = chan[i];
+        chan[i] = (val << 8) / (_bri + 1);
+      }
+      return c;
+    }
 };
 
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -237,7 +237,7 @@ class BusDigital : public Bus {
     const ColorOrderMap &_colorOrderMap;
 
     inline uint32_t restoreColorLossy(uint32_t c, uint_fast8_t _restaurationBri) {
-      if (_restaurationBri == 255) return c;
+      if (_bri == 255) return c;
       uint8_t* chan = (uint8_t*) &c;
 
       for (uint_fast8_t i=0; i<4; i++)

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -280,6 +280,7 @@ class PolyBus {
     #endif
     if (clock_kHz) dotStar_strip->SetMethodSettings(NeoSpiSettings((uint32_t)clock_kHz*1000));
   }
+
   // Begin & initialize the PixelSettings for TM1814 strips.
   template <class T>
   static void beginTM1814(void* busPtr) {
@@ -288,6 +289,7 @@ class PolyBus {
     // Max current for each LED (22.5 mA).
     tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/225, /*G*/225, /*B*/225, /*W*/225));
   }
+
   static void begin(void* busPtr, uint8_t busType, uint8_t* pins, uint16_t clock_kHz = 0U) {
     switch (busType) {
       case I_NONE: break;
@@ -390,7 +392,8 @@ class PolyBus {
       case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->Begin(); break;
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->Begin(); break;
     }
-  };
+  }
+
   static void* create(uint8_t busType, uint8_t* pins, uint16_t len, uint8_t channel, uint16_t clock_kHz = 0U) {
     void* busPtr = nullptr;
     switch (busType) {
@@ -491,7 +494,8 @@ class PolyBus {
     }
     begin(busPtr, busType, pins, clock_kHz);
     return busPtr;
-  };
+  }
+
   static void show(void* busPtr, uint8_t busType) {
     switch (busType) {
       case I_NONE: break;
@@ -588,7 +592,8 @@ class PolyBus {
       case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->Show(); break;
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->Show(); break;
     }
-  };
+  }
+
   static bool canShow(void* busPtr, uint8_t busType) {
     switch (busType) {
       case I_NONE: return true;
@@ -685,7 +690,8 @@ class PolyBus {
       case I_SS_P98_3: return (static_cast<B_SS_P98_3*>(busPtr))->CanShow(); break;
     }
     return true;
-  };
+  }
+
   static void setPixelColor(void* busPtr, uint8_t busType, uint16_t pix, uint32_t c, uint8_t co) {
     uint8_t r = c >> 16;
     uint8_t g = c >> 8;
@@ -805,7 +811,8 @@ class PolyBus {
       case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetPixelColor(pix, RgbColor(col)); break;
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetPixelColor(pix, RgbColor(col)); break;
     }
-  };
+  }
+
   static void setBrightness(void* busPtr, uint8_t busType, uint8_t b) {
     switch (busType) {
       case I_NONE: break;
@@ -902,7 +909,106 @@ class PolyBus {
       case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetLuminance(b); break;
       case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetLuminance(b); break;
     }
-  };
+  }
+
+  static void applyPostAdjustments(void* busPtr, uint8_t busType) {
+    switch (busType) {
+      case I_NONE: break;
+    #ifdef ESP8266
+      case I_8266_U0_NEO_3: (static_cast<B_8266_U0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_NEO_3: (static_cast<B_8266_U1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_NEO_3: (static_cast<B_8266_DM_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_NEO_3: (static_cast<B_8266_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_NEO_4: (static_cast<B_8266_U0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_NEO_4: (static_cast<B_8266_U1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_NEO_4: (static_cast<B_8266_DM_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_NEO_4: (static_cast<B_8266_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_400_3: (static_cast<B_8266_U0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_400_3: (static_cast<B_8266_U1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_400_3: (static_cast<B_8266_DM_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_400_3: (static_cast<B_8266_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_TM1_4: (static_cast<B_8266_U0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_TM2_3: (static_cast<B_8266_U0_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_TM2_3: (static_cast<B_8266_U1_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_TM2_3: (static_cast<B_8266_DM_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_TM2_3: (static_cast<B_8266_BB_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_UCS_3: (static_cast<B_8266_U0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_UCS_3: (static_cast<B_8266_U1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_UCS_3: (static_cast<B_8266_DM_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_UCS_3: (static_cast<B_8266_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_UCS_4: (static_cast<B_8266_U0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U1_UCS_4: (static_cast<B_8266_U1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_DM_UCS_4: (static_cast<B_8266_DM_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_BB_UCS_4: (static_cast<B_8266_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+    #endif
+    #ifdef ARDUINO_ARCH_ESP32
+      case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+//      case I_32_BB_NEO_3: (static_cast<B_32_BB_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+//      case I_32_BB_NEO_4: (static_cast<B_32_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+//      case I_32_BB_400_3: (static_cast<B_32_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_TM2_3: (static_cast<B_32_RN_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_TM2_3: (static_cast<B_32_I0_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_TM2_3: (static_cast<B_32_I1_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      case I_32_RN_UCS_3: (static_cast<B_32_RN_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_UCS_3: (static_cast<B_32_I0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_UCS_3: (static_cast<B_32_I1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+//      case I_32_BB_UCS_3: (static_cast<B_32_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_UCS_4: (static_cast<B_32_RN_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #ifndef WLED_NO_I2S0_PIXELBUS
+      case I_32_I0_UCS_4: (static_cast<B_32_I0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+      #ifndef WLED_NO_I2S1_PIXELBUS
+      case I_32_I1_UCS_4: (static_cast<B_32_I1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      #endif
+//      case I_32_BB_UCS_4: (static_cast<B_32_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+    #endif
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_LPO_3: (static_cast<B_HS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_SS_LPO_3: (static_cast<B_SS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
+    }
+  }
+
   static uint32_t getPixelColor(void* busPtr, uint8_t busType, uint16_t pix, uint8_t co) {
     RgbwColor col(0,0,0,0);
     switch (busType) {

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -810,97 +810,97 @@ class PolyBus {
     switch (busType) {
       case I_NONE: break;
     #ifdef ESP8266
-      case I_8266_U0_NEO_3: (static_cast<B_8266_U0_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_NEO_3: (static_cast<B_8266_U1_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_NEO_3: (static_cast<B_8266_DM_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_NEO_3: (static_cast<B_8266_BB_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_NEO_4: (static_cast<B_8266_U0_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_NEO_4: (static_cast<B_8266_U1_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_NEO_4: (static_cast<B_8266_DM_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_NEO_4: (static_cast<B_8266_BB_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_400_3: (static_cast<B_8266_U0_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_400_3: (static_cast<B_8266_U1_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_400_3: (static_cast<B_8266_DM_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_400_3: (static_cast<B_8266_BB_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_TM1_4: (static_cast<B_8266_U0_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_TM2_3: (static_cast<B_8266_U0_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_TM2_3: (static_cast<B_8266_U1_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_TM2_3: (static_cast<B_8266_DM_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_TM2_3: (static_cast<B_8266_BB_TM2_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_TM2_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_UCS_3: (static_cast<B_8266_U0_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_UCS_3: (static_cast<B_8266_U1_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_UCS_3: (static_cast<B_8266_DM_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_UCS_3: (static_cast<B_8266_BB_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U0_UCS_4: (static_cast<B_8266_U0_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_U1_UCS_4: (static_cast<B_8266_U1_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_U1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_DM_UCS_4: (static_cast<B_8266_DM_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_DM_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_8266_BB_UCS_4: (static_cast<B_8266_BB_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_8266_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_8266_U0_NEO_3: (static_cast<B_8266_U0_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_NEO_3: (static_cast<B_8266_U1_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_NEO_3: (static_cast<B_8266_DM_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_NEO_3: (static_cast<B_8266_BB_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_NEO_4: (static_cast<B_8266_U0_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_NEO_4: (static_cast<B_8266_U1_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_NEO_4: (static_cast<B_8266_DM_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_NEO_4: (static_cast<B_8266_BB_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_400_3: (static_cast<B_8266_U0_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_400_3: (static_cast<B_8266_U1_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_400_3: (static_cast<B_8266_DM_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_400_3: (static_cast<B_8266_BB_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_TM1_4: (static_cast<B_8266_U0_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_TM1_4: (static_cast<B_8266_U1_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_TM1_4: (static_cast<B_8266_DM_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_TM1_4: (static_cast<B_8266_BB_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_TM2_3: (static_cast<B_8266_U0_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_TM2_3: (static_cast<B_8266_U1_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_TM2_3: (static_cast<B_8266_DM_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_TM2_3: (static_cast<B_8266_BB_TM2_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_UCS_3: (static_cast<B_8266_U0_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_UCS_3: (static_cast<B_8266_U1_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_UCS_3: (static_cast<B_8266_DM_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_UCS_3: (static_cast<B_8266_BB_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U0_UCS_4: (static_cast<B_8266_U0_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_U1_UCS_4: (static_cast<B_8266_U1_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_DM_UCS_4: (static_cast<B_8266_DM_UCS_4*>(busPtr))->SetLuminance(b); break;
+      case I_8266_BB_UCS_4: (static_cast<B_8266_BB_UCS_4*>(busPtr))->SetLuminance(b); break;
     #endif
     #ifdef ARDUINO_ARCH_ESP32
-      case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_NEO_3: (static_cast<B_32_RN_NEO_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_NEO_3: (static_cast<B_32_I0_NEO_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_NEO_3: (static_cast<B_32_I1_NEO_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_NEO_3: (static_cast<B_32_BB_NEO_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_NEO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_NEO_3: (static_cast<B_32_BB_NEO_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_NEO_4: (static_cast<B_32_RN_NEO_4*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_NEO_4: (static_cast<B_32_I0_NEO_4*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_NEO_4: (static_cast<B_32_I1_NEO_4*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_NEO_4: (static_cast<B_32_BB_NEO_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_NEO_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_NEO_4: (static_cast<B_32_BB_NEO_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_400_3: (static_cast<B_32_RN_400_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_400_3: (static_cast<B_32_I0_400_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_400_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_400_3: (static_cast<B_32_I1_400_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_400_3: (static_cast<B_32_BB_400_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_400_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_TM2_3: (static_cast<B_32_RN_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_400_3: (static_cast<B_32_BB_400_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_TM1_4: (static_cast<B_32_RN_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_TM2_3: (static_cast<B_32_RN_TM2_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_I0_TM2_3: (static_cast<B_32_I0_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_TM1_4: (static_cast<B_32_I0_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_I0_TM2_3: (static_cast<B_32_I0_TM2_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_TM1_4*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_I1_TM2_3: (static_cast<B_32_I1_TM2_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_TM2_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_TM1_4: (static_cast<B_32_I1_TM1_4*>(busPtr))->SetLuminance(b); break;
+      case I_32_I1_TM2_3: (static_cast<B_32_I1_TM2_3*>(busPtr))->SetLuminance(b); break;
       #endif
-      case I_32_RN_UCS_3: (static_cast<B_32_RN_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_RN_UCS_3: (static_cast<B_32_RN_UCS_3*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_UCS_3: (static_cast<B_32_I0_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_UCS_3: (static_cast<B_32_I0_UCS_3*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_UCS_3: (static_cast<B_32_I1_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_UCS_3: (static_cast<B_32_I1_UCS_3*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_UCS_3: (static_cast<B_32_BB_UCS_3*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_UCS_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_32_RN_UCS_4: (static_cast<B_32_RN_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_RN_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_UCS_3: (static_cast<B_32_BB_UCS_3*>(busPtr))->SetLuminance(b); break;
+      case I_32_RN_UCS_4: (static_cast<B_32_RN_UCS_4*>(busPtr))->SetLuminance(b); break;
       #ifndef WLED_NO_I2S0_PIXELBUS
-      case I_32_I0_UCS_4: (static_cast<B_32_I0_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I0_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I0_UCS_4: (static_cast<B_32_I0_UCS_4*>(busPtr))->SetLuminance(b); break;
       #endif
       #ifndef WLED_NO_I2S1_PIXELBUS
-      case I_32_I1_UCS_4: (static_cast<B_32_I1_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_I1_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_32_I1_UCS_4: (static_cast<B_32_I1_UCS_4*>(busPtr))->SetLuminance(b); break;
       #endif
-//      case I_32_BB_UCS_4: (static_cast<B_32_BB_UCS_4*>(busPtr))->SetLuminance(b); (static_cast<B_32_BB_UCS_4*>(busPtr))->ApplyPostAdjustments(); break;
+//      case I_32_BB_UCS_4: (static_cast<B_32_BB_UCS_4*>(busPtr))->SetLuminance(b); break;
     #endif
-      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_DOT_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_LPD_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_LPO_3: (static_cast<B_HS_LPO_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_LPO_3: (static_cast<B_SS_LPO_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_LPO_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_WS1_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetLuminance(b); (static_cast<B_HS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
-      case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetLuminance(b); (static_cast<B_SS_P98_3*>(busPtr))->ApplyPostAdjustments(); break;
+      case I_HS_DOT_3: (static_cast<B_HS_DOT_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_DOT_3: (static_cast<B_SS_DOT_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_LPD_3: (static_cast<B_HS_LPD_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_LPD_3: (static_cast<B_SS_LPD_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_LPO_3: (static_cast<B_HS_LPO_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_LPO_3: (static_cast<B_SS_LPO_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_WS1_3: (static_cast<B_HS_WS1_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_WS1_3: (static_cast<B_SS_WS1_3*>(busPtr))->SetLuminance(b); break;
+      case I_HS_P98_3: (static_cast<B_HS_P98_3*>(busPtr))->SetLuminance(b); break;
+      case I_SS_P98_3: (static_cast<B_SS_P98_3*>(busPtr))->SetLuminance(b); break;
     }
   };
   static uint32_t getPixelColor(void* busPtr, uint8_t busType, uint16_t pix, uint8_t co) {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -90,7 +90,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(strip.cctBlending, hw_led[F("cb")]);
   Bus::setCCTBlend(strip.cctBlending);
   strip.setTargetFps(hw_led["fps"]); //NOP if 0, default 42 FPS
-  CJSON(strip.useGlobalLedBuffer, hw_led[F("ld")]);
+  CJSON(useGlobalLedBuffer, hw_led[F("ld")]);
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings
@@ -163,7 +163,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       if (fromFS) {
         BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz);
         mem += BusManager::memUsage(bc);
-        if (strip.useGlobalLedBuffer && start + length > maxlen) {
+        if (useGlobalLedBuffer && start + length > maxlen) {
           maxlen = start + length;
           globalBufMem = maxlen * 4;
         }
@@ -711,7 +711,7 @@ void serializeConfig() {
   hw_led[F("cb")] = strip.cctBlending;
   hw_led["fps"] = strip.getTargetFps();
   hw_led[F("rgbwm")] = Bus::getGlobalAWMode(); // global auto white mode override
-  hw_led[F("ld")] = strip.useGlobalLedBuffer;
+  hw_led[F("ld")] = useGlobalLedBuffer;
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -90,7 +90,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(strip.cctBlending, hw_led[F("cb")]);
   Bus::setCCTBlend(strip.cctBlending);
   strip.setTargetFps(hw_led["fps"]); //NOP if 0, default 42 FPS
-  CJSON(strip.useLedsArray, hw_led[F("ld")]);
+  CJSON(strip.useGlobalLedBuffer, hw_led[F("ld")]);
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings
@@ -706,7 +706,7 @@ void serializeConfig() {
   hw_led[F("cb")] = strip.cctBlending;
   hw_led["fps"] = strip.getTargetFps();
   hw_led[F("rgbwm")] = Bus::getGlobalAWMode(); // global auto white mode override
-  hw_led[F("ld")] = strip.useLedsArray;
+  hw_led[F("ld")] = strip.useGlobalLedBuffer;
 
   #ifndef WLED_DISABLE_2D
   // 2D Matrix Settings

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -178,7 +178,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     doInitBusses = busesChanged;
     // finalization done in beginStrip()
   }
-  if (hw_led["rev"]) busses.getBus(0)->reversed = true; //set 0.11 global reversed setting for first bus
+  if (hw_led["rev"]) busses.getBus(0)->setReversed(true); //set 0.11 global reversed setting for first bus
 
   // read color order map configuration
   JsonArray hw_com = hw[F("com")];
@@ -746,7 +746,7 @@ void serializeConfig() {
     uint8_t nPins = bus->getPins(pins);
     for (uint8_t i = 0; i < nPins; i++) ins_pin.add(pins[i]);
     ins[F("order")] = bus->getColorOrder();
-    ins["rev"] = bus->reversed;
+    ins["rev"] = bus->isReversed();
     ins[F("skip")] = bus->skippedLeds();
     ins["type"] = bus->getType() & 0x7F;
     ins["ref"] = bus->isOffRefreshRequired();

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -161,7 +161,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       ledType |= refresh << 7; // hack bit 7 to indicate strip requires off refresh
       uint8_t AWmode = elm[F("rgbwm")] | autoWhiteMode;
       if (fromFS) {
-        BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz);
+        BusConfig bc = BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer);
         mem += BusManager::memUsage(bc);
         if (useGlobalLedBuffer && start + length > maxlen) {
           maxlen = start + length;
@@ -170,7 +170,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
         if (mem + globalBufMem <= MAX_LED_MEMORY) if (busses.add(bc) == -1) break;  // finalization will be done in WLED::beginStrip()
       } else {
         if (busConfigs[s] != nullptr) delete busConfigs[s];
-        busConfigs[s] = new BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode);
+        busConfigs[s] = new BusConfig(ledType, pins, start, length, colorOrder, reversed, skipFirst, AWmode, freqkHz, useGlobalLedBuffer);
         busesChanged = true;
       }
       s++;

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -141,7 +141,7 @@
 			let len = parseInt(d.getElementsByName("LC"+n)[0].value);
 			len += parseInt(d.getElementsByName("SL"+n)[0].value); // skipped LEDs are allocated too
 			let dbl = 0;
-			if (d.Sf.LD.checked) dbl = len * 3;	// double buffering
+			if (d.Sf.LD.checked) dbl = len * 4;	// double buffering
 			if (t < 32) {
 				if (t==26 || t==29) len *= 2; // 16 bit LEDs
 				if (maxM < 10000 && d.getElementsByName("L0"+n)[0].value == 3) { //8266 DMA uses 5x the mem

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1089,13 +1089,13 @@ bool serveLiveLeds(AsyncWebServerRequest* request, uint32_t wsClient)
   for (size_t i= 0; i < used; i += n)
   {
     uint32_t c = strip.getPixelColor(i);
-    uint8_t r = useGlobalLedBuffer ? scale8(R(c), strip.getBrightness()) : R(c);
-    uint8_t g = useGlobalLedBuffer ? scale8(G(c), strip.getBrightness()) : G(c);
-    uint8_t b = useGlobalLedBuffer ? scale8(B(c), strip.getBrightness()) : B(c);
-    uint8_t w = useGlobalLedBuffer ? scale8(W(c), strip.getBrightness()) : W(c);
-    r = qadd8(w, r); //R, add white channel to RGB channels as a simple RGBW -> RGB map
-    g = qadd8(w, g); //G
-    b = qadd8(w, b); //B
+    uint8_t r = R(c);
+    uint8_t g = G(c);
+    uint8_t b = B(c);
+    uint8_t w = W(c);
+    r = scale8(qadd8(w, r), strip.getBrightness()); //R, add white channel to RGB channels as a simple RGBW -> RGB map
+    g = scale8(qadd8(w, g), strip.getBrightness()); //G
+    b = scale8(qadd8(w, b), strip.getBrightness()); //B
     olen += sprintf(obuf + olen, "\"%06X\",", RGBW32(r,g,b,0));
   }
   olen -= 1;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1089,9 +1089,13 @@ bool serveLiveLeds(AsyncWebServerRequest* request, uint32_t wsClient)
   for (size_t i= 0; i < used; i += n)
   {
     uint32_t c = strip.getPixelColor(i);
-    uint8_t r = qadd8(W(c), R(c)); //add white channel to RGB channels as a simple RGBW -> RGB map
-    uint8_t g = qadd8(W(c), G(c));
-    uint8_t b = qadd8(W(c), B(c));
+    uint8_t r = useGlobalLedBuffer ? scale8(R(c), strip.getBrightness()) : R(c);
+    uint8_t g = useGlobalLedBuffer ? scale8(G(c), strip.getBrightness()) : G(c);
+    uint8_t b = useGlobalLedBuffer ? scale8(B(c), strip.getBrightness()) : B(c);
+    uint8_t w = useGlobalLedBuffer ? scale8(W(c), strip.getBrightness()) : W(c);
+    r = qadd8(w, r); //R, add white channel to RGB channels as a simple RGBW -> RGB map
+    g = qadd8(w, g); //G
+    b = qadd8(w, b); //B
     olen += sprintf(obuf + olen, "\"%06X\",", RGBW32(r,g,b,0));
   }
   olen -= 1;

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -194,7 +194,7 @@ void handleTransitions()
       applyFinalBri();
       return;
     }
-    if (tper - tperLast < 0.004) return;
+    if (tper - tperLast < 0.004f) return;
     tperLast = tper;
     briT = briOld + ((bri - briOld) * tper);
 
@@ -204,7 +204,7 @@ void handleTransitions()
 
 
 // legacy method, applies values from col, effectCurrent, ... to selected segments
-void colorUpdated(byte callMode){
+void colorUpdated(byte callMode) {
   applyValuesToSelectedSegs();
   stateUpdated(callMode);
 }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -91,7 +91,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     Bus::setCCTBlend(strip.cctBlending);
     Bus::setGlobalAWMode(request->arg(F("AW")).toInt());
     strip.setTargetFps(request->arg(F("FR")).toInt());
-    strip.useGlobalLedBuffer = request->hasArg(F("LD"));
+    useGlobalLedBuffer = request->hasArg(F("LD"));
 
     bool busesChanged = false;
     for (uint8_t s = 0; s < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; s++) {

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -153,7 +153,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       // actual finalization is done in WLED::loop() (removing old busses and adding new)
       // this may happen even before this loop is finished so we do "doInitBusses" after the loop
       if (busConfigs[s] != nullptr) delete busConfigs[s];
-      busConfigs[s] = new BusConfig(type, pins, start, length, colorOrder | (channelSwap<<4), request->hasArg(cv), skip, awmode, freqHz);
+      busConfigs[s] = new BusConfig(type, pins, start, length, colorOrder | (channelSwap<<4), request->hasArg(cv), skip, awmode, freqHz, useGlobalLedBuffer);
       busesChanged = true;
     }
     //doInitBusses = busesChanged; // we will do that below to ensure all input data is processed

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -91,7 +91,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     Bus::setCCTBlend(strip.cctBlending);
     Bus::setGlobalAWMode(request->arg(F("AW")).toInt());
     strip.setTargetFps(request->arg(F("FR")).toInt());
-    strip.useLedsArray = request->hasArg(F("LD"));
+    strip.useGlobalLedBuffer = request->hasArg(F("LD"));
 
     bool busesChanged = false;
     for (uint8_t s = 0; s < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; s++) {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -151,11 +151,16 @@ void WLED::loop()
     DEBUG_PRINTLN(F("Re-init busses."));
     bool aligned = strip.checkSegmentAlignment(); //see if old segments match old bus(ses)
     busses.removeAll();
-    uint32_t mem = 0;
+    uint32_t mem = 0, globalBufMem = 0;
+    uint16_t maxlen = 0;
     for (uint8_t i = 0; i < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; i++) {
       if (busConfigs[i] == nullptr) break;
       mem += BusManager::memUsage(*busConfigs[i]);
-      if (mem <= MAX_LED_MEMORY) {
+      if (strip.useGlobalLedBuffer && busConfigs[i]->start + busConfigs[i]->count > maxlen) {
+          maxlen = busConfigs[i]->start + busConfigs[i]->count;
+          globalBufMem = maxlen * 4;
+      }
+      if (mem + globalBufMem <= MAX_LED_MEMORY) {
         busses.add(*busConfigs[i]);
       }
       delete busConfigs[i]; busConfigs[i] = nullptr;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -156,7 +156,7 @@ void WLED::loop()
     for (uint8_t i = 0; i < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; i++) {
       if (busConfigs[i] == nullptr) break;
       mem += BusManager::memUsage(*busConfigs[i]);
-      if (strip.useGlobalLedBuffer && busConfigs[i]->start + busConfigs[i]->count > maxlen) {
+      if (useGlobalLedBuffer && busConfigs[i]->start + busConfigs[i]->count > maxlen) {
           maxlen = busConfigs[i]->start + busConfigs[i]->count;
           globalBufMem = maxlen * 4;
       }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -35,6 +35,10 @@ void WLED::reset()
 void WLED::loop()
 {
   #ifdef WLED_DEBUG
+  static unsigned long lastRun = 0;
+  size_t loopDelay = (millis() - lastRun);
+  if (lastRun == 0) loopDelay=0; // startup - don't have valid data from last run.
+  if (loopDelay > 2) DEBUG_PRINTF("Loop delayed more than %dms.\n", loopDelay);
   static unsigned long maxUsermodMillis = 0;
   static size_t        avgUsermodMillis = 0;
   static unsigned long maxStripMillis = 0;
@@ -146,7 +150,7 @@ void WLED::loop()
 
   //LED settings have been saved, re-init busses
   //This code block causes severe FPS drop on ESP32 with the original "if (busConfigs[0] != nullptr)" conditional. Investigate!
-  if (busConfigs[0] != nullptr) {
+  if (doInitBusses) {
     doInitBusses = false;
     DEBUG_PRINTLN(F("Re-init busses."));
     bool aligned = strip.checkSegmentAlignment(); //see if old segments match old bus(ses)
@@ -217,6 +221,7 @@ void WLED::loop()
     debugTime = millis();
   }
   loops++;
+  lastRun = millis();
 #endif        // WLED_DEBUG
   toki.resetTick();
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -35,19 +35,12 @@ void WLED::reset()
 void WLED::loop()
 {
   #ifdef WLED_DEBUG
-  static unsigned      serviceCount = 0;
   static unsigned long maxUsermodMillis = 0;
   static size_t        avgUsermodMillis = 0;
   static unsigned long maxStripMillis = 0;
   static size_t        avgStripMillis = 0;
-  static size_t        avgHandlingMillis = 0;
-  static size_t        avgHandling2Millis = 0;
-  static size_t        avgHandling3Millis = 0;
   #endif
 
-  #ifdef WLED_DEBUG
-  unsigned long handlingMillis = millis();
-  #endif
   handleTime();
   #ifndef WLED_DISABLE_INFRARED
   handleIR();        // 2nd call to function needed for ESP32 to return valid results -- should be good for ESP8266, too
@@ -60,10 +53,6 @@ void WLED::loop()
 #ifdef WLED_ENABLE_DMX
   handleDMX();
 #endif
-  #ifdef WLED_DEBUG
-  handlingMillis = millis() - handlingMillis;
-  avgHandlingMillis += handlingMillis;
-  #endif
   userLoop();
 
   #ifdef WLED_DEBUG
@@ -76,9 +65,6 @@ void WLED::loop()
   if (usermodMillis > maxUsermodMillis) maxUsermodMillis = usermodMillis;
   #endif
 
-  #ifdef WLED_DEBUG
-  unsigned long handling2Millis = millis();
-  #endif
   yield();
   handleIO();
   #ifndef WLED_DISABLE_INFRARED
@@ -86,10 +72,6 @@ void WLED::loop()
   #endif
   #ifndef WLED_DISABLE_ALEXA
   handleAlexa();
-  #endif
-  #ifdef WLED_DEBUG
-  handling2Millis = millis() - handling2Millis;
-  avgHandling2Millis += handling2Millis;
   #endif
 
   if (doCloseFile) {
@@ -195,16 +177,9 @@ void WLED::loop()
   yield();
   if (doSerializeConfig) serializeConfig();
 
-  #ifdef WLED_DEBUG
-  unsigned long handling3Millis = millis();
-  #endif
   yield();
   handleWs();
   handleStatusLED();
-  #ifdef WLED_DEBUG
-  handling3Millis = millis() - handling3Millis;
-  avgHandling3Millis += handling3Millis;
-  #endif
 
 // DEBUG serial logging (every 30s)
 #ifdef WLED_DEBUG
@@ -232,9 +207,6 @@ void WLED::loop()
       DEBUG_PRINT(F("Loops/sec: "));       DEBUG_PRINTLN(loops / 30);
       DEBUG_PRINT(F("UM time[ms]: "));     DEBUG_PRINT(avgUsermodMillis/loops); DEBUG_PRINT("/");DEBUG_PRINTLN(maxUsermodMillis);
       DEBUG_PRINT(F("Strip time[ms]: "));  DEBUG_PRINT(avgStripMillis/loops); DEBUG_PRINT("/"); DEBUG_PRINTLN(maxStripMillis);
-      DEBUG_PRINT(F("Handling 1 time[ms]: ")); DEBUG_PRINTLN(avgHandlingMillis/loops);
-      DEBUG_PRINT(F("Handling 2 time[ms]: ")); DEBUG_PRINTLN(avgHandling2Millis/loops);
-      DEBUG_PRINT(F("Handling 3 time[ms]: ")); DEBUG_PRINTLN(avgHandling3Millis/loops);
     }
     strip.printSize();
     loops = 0;
@@ -242,9 +214,6 @@ void WLED::loop()
     maxStripMillis = 0;
     avgUsermodMillis = 0;
     avgStripMillis = 0;
-    avgHandlingMillis = 0;
-    avgHandling2Millis = 0;
-    avgHandling3Millis = 0;
     debugTime = millis();
   }
   loops++;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2307050
+#define VERSION 2307060
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2306240
+#define VERSION 23062490
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG
@@ -331,12 +331,13 @@ WLED_GLOBAL byte bootPreset   _INIT(0);                   // save preset to load
 //if true, a segment per bus will be created on boot and LED settings save
 //if false, only one segment spanning the total LEDs is created,
 //but not on LED settings save if there is more than one segment currently
-WLED_GLOBAL bool autoSegments    _INIT(false);
-WLED_GLOBAL bool correctWB       _INIT(false); // CCT color correction of RGB color
-WLED_GLOBAL bool cctFromRgb      _INIT(false); // CCT is calculated from RGB instead of using seg.cct
-WLED_GLOBAL bool gammaCorrectCol _INIT(true ); // use gamma correction on colors
-WLED_GLOBAL bool gammaCorrectBri _INIT(false); // use gamma correction on brightness
-WLED_GLOBAL float gammaCorrectVal _INIT(2.8f); // gamma correction value
+WLED_GLOBAL bool autoSegments       _INIT(false);
+WLED_GLOBAL bool useGlobalLedBuffer _INIT(true);
+WLED_GLOBAL bool correctWB          _INIT(false); // CCT color correction of RGB color
+WLED_GLOBAL bool cctFromRgb         _INIT(false); // CCT is calculated from RGB instead of using seg.cct
+WLED_GLOBAL bool gammaCorrectCol    _INIT(true);  // use gamma correction on colors
+WLED_GLOBAL bool gammaCorrectBri    _INIT(false); // use gamma correction on brightness
+WLED_GLOBAL float gammaCorrectVal   _INIT(2.8f);  // gamma correction value
 
 WLED_GLOBAL byte col[]    _INIT_N(({ 255, 160, 0, 0 }));  // current RGB(W) primary color. col[] should be updated if you want to change the color.
 WLED_GLOBAL byte colSec[] _INIT_N(({ 0, 0, 0, 0 }));      // current RGB(W) secondary color

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 23062490
+#define VERSION 2307020
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2307020
+#define VERSION 2307050
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG
@@ -332,7 +332,11 @@ WLED_GLOBAL byte bootPreset   _INIT(0);                   // save preset to load
 //if false, only one segment spanning the total LEDs is created,
 //but not on LED settings save if there is more than one segment currently
 WLED_GLOBAL bool autoSegments       _INIT(false);
-WLED_GLOBAL bool useGlobalLedBuffer _INIT(true);
+#ifdef ESP8266
+WLED_GLOBAL bool useGlobalLedBuffer _INIT(false); // double buffering disabled on ESP8266
+#else
+WLED_GLOBAL bool useGlobalLedBuffer _INIT(true);  // double buffering enabled on ESP32
+#endif
 WLED_GLOBAL bool correctWB          _INIT(false); // CCT color correction of RGB color
 WLED_GLOBAL bool cctFromRgb         _INIT(false); // CCT is calculated from RGB instead of using seg.cct
 WLED_GLOBAL bool gammaCorrectCol    _INIT(true);  // use gamma correction on colors

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -166,14 +166,15 @@ bool sendLiveLedsWs(uint32_t wsClient)
   size_t n = ((used -1)/MAX_LIVE_LEDS_WS) +1; //only serve every n'th LED if count over MAX_LIVE_LEDS_WS
   size_t pos = (strip.isMatrix ? 4 : 2);  // start of data
   size_t bufSize = pos + (used/n)*3;
-  size_t skipLines = 0;
 
   AsyncWebSocketMessageBuffer * wsBuf = ws.makeBuffer(bufSize);
   if (!wsBuf) return false; //out of memory
   uint8_t* buffer = wsBuf->get();
   buffer[0] = 'L';
   buffer[1] = 1; //version
+
 #ifndef WLED_DISABLE_2D
+  size_t skipLines = 0;
   if (strip.isMatrix) {
     buffer[1] = 2; //version
     buffer[2] = Segment::maxWidth;
@@ -198,13 +199,13 @@ bool sendLiveLedsWs(uint32_t wsClient)
     }
 #endif
     uint32_t c = strip.getPixelColor(i);
-    uint8_t r = useGlobalLedBuffer ? scale8(R(c), strip.getBrightness()) : R(c);
-    uint8_t g = useGlobalLedBuffer ? scale8(G(c), strip.getBrightness()) : G(c);
-    uint8_t b = useGlobalLedBuffer ? scale8(B(c), strip.getBrightness()) : B(c);
-    uint8_t w = useGlobalLedBuffer ? scale8(W(c), strip.getBrightness()) : W(c);
-    buffer[pos++] = qadd8(w, r); //R, add white channel to RGB channels as a simple RGBW -> RGB map
-    buffer[pos++] = qadd8(w, g); //G
-    buffer[pos++] = qadd8(w, b); //B
+    uint8_t r = R(c);
+    uint8_t g = G(c);
+    uint8_t b = B(c);
+    uint8_t w = W(c);
+    buffer[pos++] = scale8(qadd8(w, r), strip.getBrightness()); //R, add white channel to RGB channels as a simple RGBW -> RGB map
+    buffer[pos++] = scale8(qadd8(w, g), strip.getBrightness()); //G
+    buffer[pos++] = scale8(qadd8(w, b), strip.getBrightness()); //B
   }
 
   wsc->binary(wsBuf);

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -178,11 +178,11 @@ bool sendLiveLedsWs(uint32_t wsClient)
     buffer[1] = 2; //version
     buffer[2] = Segment::maxWidth;
     buffer[3] = Segment::maxHeight;
-    if (Segment::maxWidth * Segment::maxHeight > MAX_LIVE_LEDS_WS*4) {
+    if (used > MAX_LIVE_LEDS_WS*4) {
       buffer[2] = Segment::maxWidth/4;
       buffer[3] = Segment::maxHeight/4;
       skipLines = 3;
-    } else if (Segment::maxWidth * Segment::maxHeight > MAX_LIVE_LEDS_WS) {
+    } else if (used > MAX_LIVE_LEDS_WS) {
       buffer[2] = Segment::maxWidth/2;
       buffer[3] = Segment::maxHeight/2;
       skipLines = 1;
@@ -198,9 +198,13 @@ bool sendLiveLedsWs(uint32_t wsClient)
     }
 #endif
     uint32_t c = strip.getPixelColor(i);
-    buffer[pos++] = qadd8(W(c), R(c)); //R, add white channel to RGB channels as a simple RGBW -> RGB map
-    buffer[pos++] = qadd8(W(c), G(c)); //G
-    buffer[pos++] = qadd8(W(c), B(c)); //B
+    uint8_t r = useGlobalLedBuffer ? scale8(R(c), strip.getBrightness()) : R(c);
+    uint8_t g = useGlobalLedBuffer ? scale8(G(c), strip.getBrightness()) : G(c);
+    uint8_t b = useGlobalLedBuffer ? scale8(B(c), strip.getBrightness()) : B(c);
+    uint8_t w = useGlobalLedBuffer ? scale8(W(c), strip.getBrightness()) : W(c);
+    buffer[pos++] = qadd8(w, r); //R, add white channel to RGB channels as a simple RGBW -> RGB map
+    buffer[pos++] = qadd8(w, g); //G
+    buffer[pos++] = qadd8(w, b); //B
   }
 
   wsc->binary(wsBuf);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -404,7 +404,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("CB"),strip.cctBlending);
     sappend('v',SET_F("FR"),strip.getTargetFps());
     sappend('v',SET_F("AW"),Bus::getGlobalAWMode());
-    sappend('c',SET_F("LD"),strip.useGlobalLedBuffer);
+    sappend('c',SET_F("LD"),useGlobalLedBuffer);
 
     for (uint8_t s=0; s < busses.getNumBusses(); s++) {
       Bus* bus = busses.getBus(s);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -431,7 +431,7 @@ void getSettingsJS(byte subPage, char* dest)
       sappend('v',lt,bus->getType());
       sappend('v',co,bus->getColorOrder() & 0x0F);
       sappend('v',ls,bus->getStart());
-      sappend('c',cv,bus->reversed);
+      sappend('c',cv,bus->isReversed());
       sappend('v',sl,bus->skippedLeds());
       sappend('c',rf,bus->isOffRefreshRequired());
       sappend('v',aw,bus->getAutoWhiteMode());

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -404,7 +404,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("CB"),strip.cctBlending);
     sappend('v',SET_F("FR"),strip.getTargetFps());
     sappend('v',SET_F("AW"),Bus::getGlobalAWMode());
-    sappend('c',SET_F("LD"),strip.useLedsArray);
+    sappend('c',SET_F("LD"),strip.useGlobalLedBuffer);
 
     for (uint8_t s=0; s < busses.getNumBusses(); s++) {
       Bus* bus = busses.getBus(s);


### PR DESCRIPTION
Global buffer implementation in BusDigital

- Memory efficient as only as many color channels as needed are allocated (3 bytes for RGB and 4 bytes for RGBW)
- about 5% lower FPS than WS2812FX global buffer

Closes #3272 
Resolves #3264 