### PR TITLE
Move CTT calculation from BusPwm to Bus class.

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -9,10 +9,6 @@
 #include "bus_wrapper.h"
 #include "bus_manager.h"
 
-//colors.cpp
-uint32_t colorBalanceFromKelvin(uint16_t kelvin, uint32_t rgb);
-uint16_t approximateKelvinFromRGB(uint32_t rgb);
-void colorRGBtoRGBW(byte* rgb);
 
 //udp.cpp
 uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, byte *buffer, uint8_t bri=255, bool isRGBW=false);
@@ -328,29 +324,10 @@ void BusPwm::setPixelColor(uint16_t pix, uint32_t c) {
   uint8_t g = G(c);
   uint8_t b = B(c);
   uint8_t w = W(c);
-  uint8_t cct = 0; //0 - full warm white, 255 - full cold white
-  if (_cct > -1) {
-    if (_cct >= 1900)    cct = (_cct - 1900) >> 5;
-    else if (_cct < 256) cct = _cct;
-  } else {
-    cct = (approximateKelvinFromRGB(c) - 1900) >> 5;
-  }
-
+  
   uint8_t ww, cw;
-  #ifdef WLED_USE_IC_CCT
-  ww = w;
-  cw = cct;
-  #else
-  //0 - linear (CCT 127 = 50% warm, 50% cold), 127 - additive CCT blending (CCT 127 = 100% warm, 100% cold)
-  if (cct       < _cctBlend) ww = 255;
-  else ww = ((255-cct) * 255) / (255 - _cctBlend);
-
-  if ((255-cct) < _cctBlend) cw = 255;
-  else                       cw = (cct * 255) / (255 - _cctBlend);
-
-  ww = (w * ww) / 255; //brightness scaling
-  cw = (w * cw) / 255;
-  #endif
+  
+  calculateCCT(c, ww, cw);
 
   switch (_type) {
     case TYPE_ANALOG_1CH: //one channel (white), relies on auto white calculation

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -9,6 +9,9 @@
 #include "bus_wrapper.h"
 #include "bus_manager.h"
 
+//colors.cpp
+uint32_t colorBalanceFromKelvin(uint16_t kelvin, uint32_t rgb);
+void colorRGBtoRGBW(byte* rgb);
 
 //udp.cpp
 uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, byte *buffer, uint8_t bri=255, bool isRGBW=false);

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -8,9 +8,7 @@
 #include "const.h"
 
 //colors.cpp
-uint32_t colorBalanceFromKelvin(uint16_t kelvin, uint32_t rgb);
 uint16_t approximateKelvinFromRGB(uint32_t rgb);
-void colorRGBtoRGBW(byte* rgb);
 
 #define GET_BIT(var,bit)    (((var)>>(bit))&0x01)
 #define SET_BIT(var,bit)    ((var)|=(uint16_t)(0x0001<<(bit)))
@@ -175,6 +173,28 @@ class Bus {
         if (_cctBlend > WLED_MAX_CCT_BLEND) _cctBlend = WLED_MAX_CCT_BLEND;
       #endif
     }
+    inline        void    setAutoWhiteMode(uint8_t m) { if (m < 5) _autoWhiteMode = m; }
+    inline        uint8_t getAutoWhiteMode()          { return _autoWhiteMode; }
+    inline static void    setGlobalAWMode(uint8_t m)  { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
+    inline static uint8_t getGlobalAWMode()           { return _gAWM; }
+
+  protected:
+    uint8_t  _type;
+    uint8_t  _bri;
+    uint16_t _start;
+    uint16_t _len;
+    bool     _reversed;
+    bool     _valid;
+    bool     _needsRefresh;
+    uint8_t  _autoWhiteMode;
+    uint8_t  *_data;
+    static uint8_t _gAWM;
+    static int16_t _cct;
+    static uint8_t _cctBlend;
+
+    uint32_t autoWhiteCalc(uint32_t c);
+    uint8_t *allocData(size_t size = 1);
+    void     freeData() { if (_data != nullptr) free(_data); _data = nullptr; }
     static void calculateCCT(uint32_t c, uint8_t &ww, uint8_t &cw) {
       uint8_t cct = 0; //0 - full warm white, 255 - full cold white
       uint8_t w = byte(c >> 24);
@@ -201,28 +221,6 @@ class Bus {
       cw = (w * cw) / 255;
       #endif
     }
-    inline        void    setAutoWhiteMode(uint8_t m) { if (m < 5) _autoWhiteMode = m; }
-    inline        uint8_t getAutoWhiteMode()          { return _autoWhiteMode; }
-    inline static void    setGlobalAWMode(uint8_t m)  { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
-    inline static uint8_t getGlobalAWMode()           { return _gAWM; }
-
-  protected:
-    uint8_t  _type;
-    uint8_t  _bri;
-    uint16_t _start;
-    uint16_t _len;
-    bool     _reversed;
-    bool     _valid;
-    bool     _needsRefresh;
-    uint8_t  _autoWhiteMode;
-    uint8_t  *_data;
-    static uint8_t _gAWM;
-    static int16_t _cct;
-    static uint8_t _cctBlend;
-
-    uint32_t autoWhiteCalc(uint32_t c);
-    uint8_t *allocData(size_t size = 1);
-    void     freeData() { if (_data != nullptr) free(_data); _data = nullptr; }
 };
 
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -7,6 +7,11 @@
 
 #include "const.h"
 
+//colors.cpp
+uint32_t colorBalanceFromKelvin(uint16_t kelvin, uint32_t rgb);
+uint16_t approximateKelvinFromRGB(uint32_t rgb);
+void colorRGBtoRGBW(byte* rgb);
+
 #define GET_BIT(var,bit)    (((var)>>(bit))&0x01)
 #define SET_BIT(var,bit)    ((var)|=(uint16_t)(0x0001<<(bit)))
 #define UNSET_BIT(var,bit)  ((var)&=(~(uint16_t)(0x0001<<(bit))))
@@ -168,6 +173,32 @@ class Bus {
       //compile-time limiter for hardware that can't power both white channels at max
       #ifdef WLED_MAX_CCT_BLEND
         if (_cctBlend > WLED_MAX_CCT_BLEND) _cctBlend = WLED_MAX_CCT_BLEND;
+      #endif
+    }
+    static void calculateCCT(uint32_t c, uint8_t &ww, uint8_t &cw) {
+      uint8_t cct = 0; //0 - full warm white, 255 - full cold white
+      uint8_t w = byte(c >> 24);
+
+      if (_cct > -1) {
+        if (_cct >= 1900)    cct = (_cct - 1900) >> 5;
+        else if (_cct < 256) cct = _cct;
+      } else {
+        cct = (approximateKelvinFromRGB(c) - 1900) >> 5;
+      }
+      
+      #ifdef WLED_USE_IC_CCT
+      ww = w;
+      cw = cct;
+      #else
+      //0 - linear (CCT 127 = 50% warm, 50% cold), 127 - additive CCT blending (CCT 127 = 100% warm, 100% cold)
+      if (cct       < _cctBlend) ww = 255;
+      else ww = ((255-cct) * 255) / (255 - _cctBlend);
+
+      if ((255-cct) < _cctBlend) cw = 255;
+      else                       cw = (cct * 255) / (255 - _cctBlend);
+
+      ww = (w * ww) / 255; //brightness scaling
+      cw = (w * cw) / 255;
       #endif
     }
     inline        void    setAutoWhiteMode(uint8_t m) { if (m < 5) _autoWhiteMode = m; }


### PR DESCRIPTION
This enable it to other bus types.
Need for adding RGBWW LEDs on digital bus.