### PR TITLE
2D effect improvements: centered 1D->2D Arc mapping, restored 2DFire2012

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -558,17 +558,27 @@ void IRAM_ATTR Segment::setPixelColor(int i, uint32_t col)
         if (vStrip>0) setPixelColorXY(vStrip - 1, vH - i - 1, col);
         else          for (int x = 0; x < vW; x++) setPixelColorXY(x, vH - i - 1, col);
         break;
-      case M12_pArc:
+      case M12_pArc: {
         // expand in circular fashion from center
-        if (i==0)
-          setPixelColorXY(0, 0, col);
+        uint16_t cx = vW/2;
+        uint16_t cy = vH/2;
+        if (i==0) {
+          setPixelColorXY(cx, cy, col);
+          setPixelColorXY(cx - 1, cy, col);
+          setPixelColorXY(cx, cy - 1, col);
+          setPixelColorXY(cx - 1, cy - 1, col);
+        }
         else {
           float step = HALF_PI / (2.85f*i);
           for (float rad = 0.0f; rad <= HALF_PI+step/2; rad += step) {
             // may want to try float version as well (with or without antialiasing)
             int x = roundf(sin_t(rad) * i);
             int y = roundf(cos_t(rad) * i);
-            setPixelColorXY(x, y, col);
+            if (x >= cx || y >= cy) continue;
+            setPixelColorXY(cx + x, cy + y, col);
+            setPixelColorXY(cx - x - 1, cy + y, col);
+            setPixelColorXY(cx + x, cy - y - 1, col);
+            setPixelColorXY(cx - x - 1, cy - y - 1, col);
           }
           // Bresenham’s Algorithm (may not fill every pixel)
           //int d = 3 - (2*i);
@@ -586,6 +596,7 @@ void IRAM_ATTR Segment::setPixelColor(int i, uint32_t col)
           //}
         }
         break;
+      }
       case M12_pCorner:
         for (int x = 0; x <= i; x++) setPixelColorXY(x, i, col);
         for (int y = 0; y <  i; y++) setPixelColorXY(i, y, col);


### PR DESCRIPTION
This PR contains two changes:

1. The Arc mapping of 1D to 2D effects was only drawing, in fact, an arc - and leaving some uninitialized pixels beyond its radius. This change makes it draw full circles concentric with the segment, as long as the segment dimensions are even.

2. Ported the 2DFire2012 effect from the Sound Reactive fork, added slider controls for speed, cooling and sparking. Looks like it was implemented here before but disappeared someday? Not sure, but I don't see a reason to remove it.
