### PR TITLE
Usermod SSDR - allow configurable leading zero

### DIFF
--- a/usermods/seven_segment_display_reloaded/readme.md
+++ b/usermods/seven_segment_display_reloaded/readme.md
@@ -24,6 +24,9 @@ Enables the inverted mode in which the background should be enabled and the digi
 ### Colon-blinking
 Enables the blinking colon(s) if they are defined
 
+### Leading-Zero
+Shows the leading zero of the hour if it exists (i.e. shows `07` instead of `7`)
+
 ### enable-auto-brightness
 Enables the auto brightness feature. Can be used only when the usermod SN_Photoresistor is installed.
 

--- a/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
+++ b/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
@@ -17,6 +17,7 @@ private:
   bool umSSDRDisplayTime = false;
   bool umSSDRInverted = false;
   bool umSSDRColonblink = true;
+  bool umSSDRLeadingZero = true;
   bool umSSDREnableLDR = false;
   String umSSDRHours = "";
   String umSSDRMinutes = "";
@@ -79,6 +80,7 @@ private:
   static const char _str_timeEnabled[];
   static const char _str_inverted[];
   static const char _str_colonblink[];
+  static const char _str_leadingZero[];
   static const char _str_displayMask[];
   static const char _str_hours[];
   static const char _str_minutes[];
@@ -105,15 +107,15 @@ private:
       switch (umSSDRDisplayMask[index]) {
         case 'h':
           timeVar = hourFormat12(localTime);
-          _showElements(&umSSDRHours, timeVar, 0, 1);
+          _showElements(&umSSDRHours, timeVar, 0, !umSSDRLeadingZero);
           break;
         case 'H':
           timeVar = hour(localTime);
-          _showElements(&umSSDRHours, timeVar, 0, 1);
+          _showElements(&umSSDRHours, timeVar, 0, !umSSDRLeadingZero);
           break;
         case 'k':
           timeVar = hour(localTime) + 1;
-          _showElements(&umSSDRHours, timeVar, 0, 0);
+          _showElements(&umSSDRHours, timeVar, 0, !umSSDRLeadingZero);
           break;
         case 'm':
           timeVar = minute(localTime);
@@ -309,6 +311,9 @@ private:
     if (_cmpIntSetting_P(topic, payload, _str_colonblink, &umSSDRColonblink)) {
       return true;
     }
+    if (_cmpIntSetting_P(topic, payload, _str_leadingZero, &umSSDRLeadingZero)) {
+      return true;
+    }
     if (strcmp_P(topic, _str_displayMask) == 0) {
       umSSDRDisplayMask = String(payload);
       _publishMQTTstr_P(_str_displayMask, umSSDRDisplayMask);
@@ -323,6 +328,7 @@ private:
     _publishMQTTint_P(_str_ldrEnabled, umSSDREnableLDR);
     _publishMQTTint_P(_str_inverted, umSSDRInverted);
     _publishMQTTint_P(_str_colonblink, umSSDRColonblink);
+    _publishMQTTint_P(_str_leadingZero, umSSDRLeadingZero);
 
     _publishMQTTstr_P(_str_hours, umSSDRHours);
     _publishMQTTstr_P(_str_minutes, umSSDRMinutes);
@@ -347,6 +353,7 @@ private:
     ssdrObj[FPSTR(_str_ldrEnabled)] = umSSDREnableLDR;
     ssdrObj[FPSTR(_str_inverted)] = umSSDRInverted;
     ssdrObj[FPSTR(_str_colonblink)] = umSSDRColonblink;
+    ssdrObj[FPSTR(_str_leadingZero)] = umSSDRLeadingZero;
     ssdrObj[FPSTR(_str_displayMask)] = umSSDRDisplayMask;
     ssdrObj[FPSTR(_str_hours)] = umSSDRHours;
     ssdrObj[FPSTR(_str_minutes)] = umSSDRMinutes;
@@ -425,6 +432,8 @@ public:
     invert.add(umSSDRInverted);
     JsonArray blink = user.createNestedArray("Blinking colon");
     blink.add(umSSDRColonblink);
+    JsonArray zero = user.createNestedArray("Show the hour leading zero");
+    zero.add(umSSDRLeadingZero);
     JsonArray ldrEnable = user.createNestedArray("Auto Brightness enabled");
     ldrEnable.add(umSSDREnableLDR);
 
@@ -454,6 +463,7 @@ public:
       umSSDREnableLDR = ssdrObj[FPSTR(_str_ldrEnabled)] | umSSDREnableLDR;
       umSSDRInverted = ssdrObj[FPSTR(_str_inverted)] | umSSDRInverted;
       umSSDRColonblink = ssdrObj[FPSTR(_str_colonblink)] | umSSDRColonblink;
+      umSSDRLeadingZero = ssdrObj[FPSTR(_str_leadingZero)] | umSSDRLeadingZero;
       umSSDRDisplayMask = ssdrObj[FPSTR(_str_displayMask)] | umSSDRDisplayMask;
     }
   }
@@ -516,6 +526,7 @@ public:
     umSSDREnableLDR        = (top[FPSTR(_str_ldrEnabled)] | umSSDREnableLDR);
     umSSDRInverted         = (top[FPSTR(_str_inverted)] | umSSDRInverted);
     umSSDRColonblink       = (top[FPSTR(_str_colonblink)] | umSSDRColonblink);
+    umSSDRLeadingZero      = (top[FPSTR(_str_leadingZero)] | umSSDRLeadingZero);
 
     umSSDRDisplayMask      = top[FPSTR(_str_displayMask)] | umSSDRDisplayMask;
     umSSDRHours            = top[FPSTR(_str_hours)] | umSSDRHours;
@@ -546,6 +557,7 @@ const char UsermodSSDR::_str_name[]        PROGMEM = "UsermodSSDR";
 const char UsermodSSDR::_str_timeEnabled[] PROGMEM = "enabled";
 const char UsermodSSDR::_str_inverted[]    PROGMEM = "inverted";
 const char UsermodSSDR::_str_colonblink[]  PROGMEM = "Colon-blinking";
+const char UsermodSSDR::_str_leadingZero[] PROGMEM = "Leading-Zero";
 const char UsermodSSDR::_str_displayMask[] PROGMEM = "Display-Mask";
 const char UsermodSSDR::_str_hours[]       PROGMEM = "LED-Numbers-Hours";
 const char UsermodSSDR::_str_minutes[]     PROGMEM = "LED-Numbers-Minutes";

--- a/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
+++ b/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
@@ -17,7 +17,7 @@ private:
   bool umSSDRDisplayTime = false;
   bool umSSDRInverted = false;
   bool umSSDRColonblink = true;
-  bool umSSDRLeadingZero = true;
+  bool umSSDRLeadingZero = false;
   bool umSSDREnableLDR = false;
   String umSSDRHours = "";
   String umSSDRMinutes = "";


### PR DESCRIPTION
#2445 has removed the leading zeros from the hour number, but some might like leading zeros and the documentation states that `h` and `H` are in `0X-XX` format.

This PR fixes those inconsistencies by adding a boolean setting that toggles the leading zero on or off.