### PR TITLE
Allow 9 LED pins with audioreactive

### DIFF
--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1177,8 +1177,12 @@ class PolyBus {
       uint8_t offset = 0; //0 = RMT (num 0-7) 8 = I2S0 9 = I2S1
       #if defined(CONFIG_IDF_TARGET_ESP32S2)
       // ESP32-S2 only has 4 RMT channels
-      if (num > 4) return I_NONE;
-      if (num > 3) offset = 1;  // only one I2S
+      #if defined(USERMOD_AUDIOREACTIVE)      // softhack007 I2S#0 is reserved for audio input
+        if (num > 3) return I_NONE;
+      #else
+        if (num > 4) return I_NONE;
+        if (num > 3) offset = 1;  // only one I2S
+      #endif
       #elif defined(CONFIG_IDF_TARGET_ESP32C3)
       // On ESP32-C3 only the first 2 RMT channels are usable for transmitting
       if (num > 1) return I_NONE;
@@ -1189,8 +1193,13 @@ class PolyBus {
       //if (num > 3) offset = num -4; // I2S not supported yet
       #else
       // standard ESP32 has 8 RMT and 2 I2S channels
-      if (num > 9) return I_NONE;
-      if (num > 7) offset = num -7;
+      #if defined(USERMOD_AUDIOREACTIVE)      // softhack007 I2S#0 is reserved for audio input, but I2S#1 is availeavle as 9th LED pin
+        if (num > 8) return I_NONE;
+        if (num == 8) offset = 2;
+      #else
+        if (num > 9) return I_NONE;
+        if (num > 7) offset = num -7;
+      #endif
       #endif
       switch (busType) {
         case TYPE_WS2812_1CH_X3:

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1190,7 +1190,7 @@ class PolyBus {
       #else
       // standard ESP32 has 8 RMT and 2 I2S channels
       if (num > 9) return I_NONE;
-      if (num == 8) offset = 2;  // first use I2S#1 (so #0stays availeable for audio)
+      if (num == 8) offset = 2;  // first use I2S#1 (so #0 stays available for audio)
       if (num == 9) offset = 1;  // use I2S#0 as the last driver
       #endif
       switch (busType) {

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1177,12 +1177,8 @@ class PolyBus {
       uint8_t offset = 0; //0 = RMT (num 0-7) 8 = I2S0 9 = I2S1
       #if defined(CONFIG_IDF_TARGET_ESP32S2)
       // ESP32-S2 only has 4 RMT channels
-      #if defined(USERMOD_AUDIOREACTIVE)      // softhack007 I2S#0 is reserved for audio input
-        if (num > 3) return I_NONE;
-      #else
-        if (num > 4) return I_NONE;
-        if (num > 3) offset = 1;  // only one I2S
-      #endif
+      if (num > 4) return I_NONE;
+      if (num > 3) offset = 1;  // only one I2S
       #elif defined(CONFIG_IDF_TARGET_ESP32C3)
       // On ESP32-C3 only the first 2 RMT channels are usable for transmitting
       if (num > 1) return I_NONE;
@@ -1193,13 +1189,9 @@ class PolyBus {
       //if (num > 3) offset = num -4; // I2S not supported yet
       #else
       // standard ESP32 has 8 RMT and 2 I2S channels
-      #if defined(USERMOD_AUDIOREACTIVE)      // softhack007 I2S#0 is reserved for audio input, but I2S#1 is availeavle as 9th LED pin
-        if (num > 8) return I_NONE;
-        if (num == 8) offset = 2;
-      #else
-        if (num > 9) return I_NONE;
-        if (num > 7) offset = num -7;
-      #endif
+      if (num > 9) return I_NONE;
+      if (num == 8) offset = 2;  // first use I2S#1 (so #0stays availeable for audio)
+      if (num == 9) offset = 1;  // use I2S#0 as the last driver
       #endif
       switch (busType) {
         case TYPE_WS2812_1CH_X3:

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -44,8 +44,8 @@
       #define WLED_MIN_VIRTUAL_BUSSES 4
     #else
       #if defined(USERMOD_AUDIOREACTIVE)      // requested by @softhack007 https://github.com/blazoncek/WLED/issues/33
-        #define WLED_MAX_BUSSES 8
-        #define WLED_MIN_VIRTUAL_BUSSES 2
+        #define WLED_MAX_BUSSES 9
+        #define WLED_MIN_VIRTUAL_BUSSES 1
       #else
         #define WLED_MAX_BUSSES 10
         #define WLED_MIN_VIRTUAL_BUSSES 0


### PR DESCRIPTION
In response to user feedback - people seem to miss their last two led pins in the audioreactive version. 

NPB cannot use `I2S#0` because audioreactive needs it. But `I2S#1` is still availeable on esp32. So this PR adds`I2S#1` to the digital led driver, allowing for 9 instead of 8 pins.

@blazoncek please review, and if OK for you then I propose to merge it into main. I've (intensively) tested that running audio and in parallel using `I2S#1` for NPB does work.
