### PR TITLE
Add information about which branch is being used for the device

### DIFF
--- a/pio-scripts/set_version.py
+++ b/pio-scripts/set_version.py
@@ -6,3 +6,7 @@ PACKAGE_FILE = "package.json"
 with open(PACKAGE_FILE, "r") as package:
     version = json.load(package)["version"]
     env.Append(BUILD_FLAGS=[f"-DWLED_VERSION={version}"])
+    if "-b" in version:
+        env.Append(BUILD_FLAGS=[f"-DWLED_BRANCH=beta"])
+    else:
+        env.Append(BUILD_FLAGS=[f"-DWLED_BRANCH=stable"])

--- a/usermods/smartnest/usermod_smartnest.h
+++ b/usermods/smartnest/usermod_smartnest.h
@@ -150,6 +150,8 @@ public:
     delay(100);
     sendToBroker("report/firmware", versionString); // Reports the firmware version
     delay(100);
+    sendToBroker("report/branch", branchString); // Reports the firmware branch
+    delay(100);
     sendToBroker("report/ip", (char *)WiFi.localIP().toString().c_str()); // Reports the ip
     delay(100);
     sendToBroker("report/network", (char *)WiFi.SSID().c_str()); // Reports the network name

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -603,6 +603,7 @@ void serializeInfo(JsonObject root)
 {
   root[F("ver")] = versionString;
   root[F("vid")] = VERSION;
+  root[F("branch")] = branchString;
   //root[F("cn")] = WLED_CODENAME;
 
   JsonObject leds = root.createNestedObject("leds");

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -313,6 +313,8 @@ void WLED::setup()
   DEBUG_PRINT(versionString);
   DEBUG_PRINT(" ");
   DEBUG_PRINT(VERSION);
+  DEBUG_PRINT(" ");
+  DEBUG_PRINT(branchString);
   DEBUG_PRINTLN(F(" INIT---"));
 #ifdef ARDUINO_ARCH_ESP32
   DEBUG_PRINT(F("esp32 "));

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -254,8 +254,13 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
   #define WLED_VERSION "dev"
 #endif
 
+#ifndef WLED_BRANCH
+  #define WLED_BRANCH "dev"
+#endif
+
 // Global Variable definitions
 WLED_GLOBAL char versionString[] _INIT(TOSTRING(WLED_VERSION));
+WLED_GLOBAL char branchString[] _INIT(TOSTRING(WLED_BRANCH));
 #define WLED_CODENAME "Hoshi"
 
 // AP and OTA default passwords (for maximum security change them!)


### PR DESCRIPTION
Add the information about which software branch, beta or stable, is being used on this device. This is accessible through both the JSON API and MQTT, just like the version string. This will automatically detect if it is a beta or not based on the release version configured in package.json to make sure it is always set properly.

This could be really useful for any consumer of the API that wants to make sure to check the correct channel to know potentially if a device is using the most recent version, for example and also to match it to the correct branch (beta, soundreactive, ...).