### PR TITLE
workaround for #3382

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1080,6 +1080,8 @@ void serveJson(AsyncWebServerRequest* request)
         JsonArray effects = lDoc.createNestedArray(F("effects"));
         serializeModeNames(effects); // remove WLED-SR extensions from effect names
         lDoc[F("palettes")] = serialized((const __FlashStringHelper*)JSON_palette_names);
+      } else {
+          lastInterfaceUpdate = millis();  // softhack007 #3382 - delay re-sending of same JSON in updateInterfaces()
       }
       //lDoc["m"] = lDoc.memoryUsage(); // JSON buffer usage, for remote debugging
   }


### PR DESCRIPTION
On esp32, its possible that two threads (async_tcp, looptask) are sending out JSON via AsyncWebServer in parallel 
- serveJson() responds to json/si, and 
- updateInterfaces() is sending JSON state info using sendDataWs(). 

Assumed root cause: parts of AsyncWebServer are not thread-safe, and the payloads from a second ->send() call may corrupt the previous one if still being sent out. The problem should be solved properly in AsyncWebServer, however until that happens, this PR reduces the frequency of errors.

The workaround uses the INTERFACE_UPDATE_COOLDOWN timer  to delay the second webSocket send command so it does not (usually) interfere with the first.

Changes tested on esp32 with the example config & preset from bug report #3382.
Testing on 8266 still to be done.