### PR TITLE
Added #HH for only Hour and ##MM for only Minute in Scrolling Text, s…

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5946,6 +5946,8 @@ uint16_t mode_2Dscrollingtext(void) {
     else if (!strncmp_P(text,PSTR("#MMDD"),5)) sprintf_P(text, zero?PSTR("%02d/%02d")     :PSTR("%d/%d"),      month(localTime), day(localTime));
     else if (!strncmp_P(text,PSTR("#TIME"),5)) sprintf_P(text, zero?PSTR("%02d:%02d%s")   :PSTR("%2d:%02d%s"), AmPmHour,         minute(localTime), sec);
     else if (!strncmp_P(text,PSTR("#HHMM"),5)) sprintf_P(text, zero?PSTR("%02d:%02d")     :PSTR("%d:%02d"),    AmPmHour,         minute(localTime));
+    else if (!strncmp_P(text,PSTR("#HH"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),         AmPmHour);
+    else if (!strncmp_P(text,PSTR("#MM"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),         minute(localTime)); 
   }
 
   const int  numberOfLetters = strlen(text);


### PR DESCRIPTION
…o you can add the hour and minute where you want with maybe without "scrolling", if you want to have a steady show of the hour and minute (especially if you have only 16x16 2d Matrix it comes handy), otherweise it scrolls when hour >=10 even if the font size is the smallest one