### PR TITLE
Show 2D Configuration button by default

### DIFF
--- a/wled00/data/settings.htm
+++ b/wled00/data/settings.htm
@@ -80,7 +80,7 @@
 <button type=submit id="b" onclick="window.location=getURL('/')">Back</button>
 <button type="submit" onclick="window.location=getURL('/settings/wifi')">WiFi Setup</button>
 <button type="submit" onclick="window.location=getURL('/settings/leds')">LED Preferences</button>
-<button id="2dbtn" style="display:none;" type="submit" onclick="window.location=getURL('/settings/2D')">2D Configuration</button>
+<button id="2dbtn" type="submit" onclick="window.location=getURL('/settings/2D')">2D Configuration</button>
 <button type="submit" onclick="window.location=getURL('/settings/ui')">User Interface</button>
 <button id="dmxbtn" style="display:none;" type="submit" onclick="window.location=getURL('/settings/dmx')">DMX Output</button>
 <button type="submit" onclick="window.location=getURL('/settings/sync')">Sync Interfaces</button>

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -238,8 +238,8 @@ void getSettingsJS(byte subPage, char* dest)
 
   if (subPage == SUBPAGE_MENU)
   {
-  #ifndef WLED_DISABLE_2D // include only if 2D is compiled in
-    oappend(PSTR("gId('2dbtn').style.display='';"));
+  #ifdef WLED_DISABLE_2D // include only if 2D is not compiled in
+    oappend(PSTR("gId('2dbtn').style.display='none';"));
   #endif
   #ifdef WLED_ENABLE_DMX // include only if DMX is enabled
     oappend(PSTR("gId('dmxbtn').style.display='';"));


### PR DESCRIPTION
The problem was that when the settings page loaded, the "2D Configuration" button appeared a few milliseconds later than the other buttons. This meant that sometimes you would accidentally make incorrect input. If you were fast and wanted to press a button quickly, the button would appear just before you pressed it, causing the rest of the buttons to move as well, and you would press the wrong button.