### PR TITLE
Show clock overlay only if all LEDs are solid black

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -507,6 +507,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(analogClock12pixel, ol[F("o12pix")]);
   CJSON(analogClock5MinuteMarks, ol[F("o5m")]);
   CJSON(analogClockSecondsTrail, ol[F("osec")]);
+  CJSON(analogClockSolidBlack, ol[F("osb")]);
 
   //timed macro rules
   JsonObject tm = doc[F("timers")];
@@ -973,6 +974,7 @@ void serializeConfig() {
   ol[F("o12pix")] = analogClock12pixel;
   ol[F("o5m")] = analogClock5MinuteMarks;
   ol[F("osec")] = analogClockSecondsTrail;
+  ol[F("osb")] = analogClockSolidBlack;
 
   JsonObject timers = root.createNestedObject(F("timers"));
 

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -212,6 +212,7 @@
 			12h LED: <input name="OM" type="number" min="0" max="255" required><br>
 			Show 5min marks: <input type="checkbox" name="O5"><br>
 			Seconds (as trail): <input type="checkbox" name="OS"><br>
+			Show clock overlay only if all LEDs are solid black: <input type="checkbox" name="OB"><br>
 		</div>
 		Countdown Mode: <input type="checkbox" name="CE"><br>
 		Countdown Goal:<br>

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -89,6 +89,15 @@ void _overlayAnalogCountdown()
 
 void handleOverlayDraw() {
   usermods.handleOverlayDraw();
+  if (analogClockSolidBlack) {
+    Segment* segments = strip.getSegments();
+    for (uint8_t i = 0; i < strip.getActiveSegmentsNum(); i++) {
+      Segment segment = segments[i];
+      if (segment.mode > 0 || segment.colors[0] > 0) {
+        return;
+      }
+    }
+  }
   if (overlayCurrent == 1) _overlayAnalogClock();
 }
 

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -91,8 +91,9 @@ void handleOverlayDraw() {
   usermods.handleOverlayDraw();
   if (analogClockSolidBlack) {
     const Segment* segments = strip.getSegments();
-    for (uint8_t i = 0; i < strip.getActiveSegmentsNum(); i++) {
+    for (uint8_t i = 0; i < strip.getSegmentsNum(); i++) {
       const Segment& segment = segments[i];
+      if (!segment.isActive()) continue;
       if (segment.mode > 0 || segment.colors[0] > 0) {
         return;
       }

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -90,9 +90,9 @@ void _overlayAnalogCountdown()
 void handleOverlayDraw() {
   usermods.handleOverlayDraw();
   if (analogClockSolidBlack) {
-    Segment* segments = strip.getSegments();
+    const Segment* segments = strip.getSegments();
     for (uint8_t i = 0; i < strip.getActiveSegmentsNum(); i++) {
-      Segment segment = segments[i];
+      const Segment& segment = segments[i];
       if (segment.mode > 0 || segment.colors[0] > 0) {
         return;
       }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -440,6 +440,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     analogClock12pixel = request->arg(F("OM")).toInt();
     analogClock5MinuteMarks = request->hasArg(F("O5"));
     analogClockSecondsTrail = request->hasArg(F("OS"));
+    analogClockSolidBlack = request->hasArg(F("OB"));
 
     countdownMode = request->hasArg(F("CE"));
     countdownYear = request->arg(F("CY")).toInt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -494,6 +494,7 @@ WLED_GLOBAL byte overlayMin _INIT(0), overlayMax _INIT(DEFAULT_LED_COUNT - 1);  
 WLED_GLOBAL byte analogClock12pixel _INIT(0);               // The pixel in your strip where "midnight" would be
 WLED_GLOBAL bool analogClockSecondsTrail _INIT(false);      // Display seconds as trail of LEDs instead of a single pixel
 WLED_GLOBAL bool analogClock5MinuteMarks _INIT(false);      // Light pixels at every 5-minute position
+WLED_GLOBAL bool analogClockSolidBlack _INIT(false);        // Show clock overlay only if all LEDs are solid black (effect is 0 and color is black)
 
 WLED_GLOBAL bool countdownMode _INIT(false);                         // Clock will count down towards date
 WLED_GLOBAL byte countdownYear _INIT(20), countdownMonth _INIT(1);   // Countdown target date, year is last two digits

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -597,6 +597,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("OM"),analogClock12pixel);
     sappend('c',SET_F("OS"),analogClockSecondsTrail);
     sappend('c',SET_F("O5"),analogClock5MinuteMarks);
+    sappend('c',SET_F("OB"),analogClockSolidBlack);
 
     sappend('c',SET_F("CE"),countdownMode);
     sappend('v',SET_F("CY"),countdownYear);


### PR DESCRIPTION
This adds an option to show clock overlay only when all LEDs are solid black.
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/98047594-f5f9-4252-829a-b183d321a9db)

When an effect is active, Clock Overlay is not displayed:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/59bde6bc-801e-47d8-80ff-330a235810f7)

If the color is not black, the clock overlay is not shown:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/a35a832e-f41b-4805-9266-af1fd8f31775)

If the effect is solid and the color is black, the clock overlay is shown:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/e082ca10-bcec-47f7-a9d8-9460504b5ade)

This closes #984.