### PR TITLE
Allow more compile time settings for multi-relay

### DIFF
--- a/usermods/multi_relay/readme.md
+++ b/usermods/multi_relay/readme.md
@@ -49,16 +49,21 @@ You can override the default maximum number of relays (which is 4) by defining M
 
 Some settings can be defined (defaults) at compile time by setting the following defines:
 
-MULTI_RELAY_HA_DISCOVERY true or false
+```cpp
+// enable or disable HA discovery for externally controlled relays
+#define MULTI_RELAY_HA_DISCOVERY true
+```
 
 The following definitions should be a list of values (maximum number of entries is MULTI_RELAY_MAX_RELAYS) that will be applied to the relays in order:
 (e.g. assuming MULTI_RELAY_MAX_RELAYS=2)
 
-MULTI_RELAY_DELAYS 0,0
-MULTI_RELAY_EXTERNALS false,true
-MULTI_RELAY_INVERTS false,false
-
-These can be set via your platformio_override.ini file or as #define in your my_config.h (remember to set WLED_USE_MY_CONFIG in your platformio_override.ini)
+```cpp
+#define MULTI_RELAY_PINS 12,18
+#define MULTI_RELAY_DELAYS 0,0
+#define MULTI_RELAY_EXTERNALS false,true
+#define MULTI_RELAY_INVERTS false,false
+```
+These can be set via your `platformio_override.ini` file or as `#define` in your `my_config.h` (remember to set `WLED_USE_MY_CONFIG` in your `platformio_override.ini`)
 
 Example **usermods_list.cpp**:
 
@@ -121,3 +126,6 @@ Have fun - @blazoncek
 
 2023-05
 * Added support for PCF8574 I2C port expander (multiple)
+
+2023-11
+* @chrisburrows Added support for compile time defaults for setting DELAY, EXTERNAL, INVERTS and HA discovery

--- a/usermods/multi_relay/readme.md
+++ b/usermods/multi_relay/readme.md
@@ -47,6 +47,19 @@ or
 
 You can override the default maximum number of relays (which is 4) by defining MULTI_RELAY_MAX_RELAYS.
 
+Some settings can be defined (defaults) at compile time by setting the following defines:
+
+MULTI_RELAY_HA_DISCOVERY true or false
+
+The following definitions should be a list of values (maximum number of entries is MULTI_RELAY_MAX_RELAYS) that will be applied to the relays in order:
+(e.g. assuming MULTI_RELAY_MAX_RELAYS=2)
+
+MULTI_RELAY_DELAYS 0,0
+MULTI_RELAY_EXTERNALS false,true
+MULTI_RELAY_INVERTS false,false
+
+These can be set via your platformio_override.ini file or as #define in your my_config.h (remember to set WLED_USE_MY_CONFIG in your platformio_override.ini)
+
 Example **usermods_list.cpp**:
 
 ```cpp

--- a/usermods/multi_relay/usermod_multi_relay.h
+++ b/usermods/multi_relay/usermod_multi_relay.h
@@ -2,6 +2,8 @@
 
 #include "wled.h"
 
+#define COUNT_OF(x) ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
+
 #ifndef MULTI_RELAY_MAX_RELAYS
   #define MULTI_RELAY_MAX_RELAYS 4
 #else
@@ -17,6 +19,22 @@
   #define MULTI_RELAY_ENABLED false
 #else
   #define MULTI_RELAY_ENABLED true
+#endif
+
+#ifndef MULTI_RELAY_HA_DISCOVERY
+  #define MULTI_RELAY_HA_DISCOVERY false
+#endif
+
+#ifndef MULTI_RELAY_DELAYS
+  #define MULTI_RELAY_DELAYS 0
+#endif
+
+#ifndef MULTI_RELAY_EXTERNALS
+  #define MULTI_RELAY_EXTERNALS false
+#endif
+
+#ifndef MULTI_RELAY_INVERTS
+  #define MULTI_RELAY_INVERTS false
 #endif
 
 #define WLED_DEBOUNCE_THRESHOLD 50 //only consider button input of at least 50ms as valid (debouncing)
@@ -343,18 +361,22 @@ MultiRelay::MultiRelay()
   , initDone(false)
   , usePcf8574(USE_PCF8574)
   , addrPcf8574(PCF8574_ADDRESS)
-  , HAautodiscovery(false)
+  , HAautodiscovery(MULTI_RELAY_HA_DISCOVERY)
   , periodicBroadcastSec(60)
   , lastBroadcast(0)
 {
   const int8_t defPins[] = {MULTI_RELAY_PINS};
+  const int8_t relayDelays[] = {MULTI_RELAY_DELAYS};
+  const bool relayExternals[] = {MULTI_RELAY_EXTERNALS};
+  const bool relayInverts[] = {MULTI_RELAY_INVERTS};
+
   for (size_t i=0; i<MULTI_RELAY_MAX_RELAYS; i++) {
-    _relay[i].pin      = i<sizeof(defPins) ? defPins[i] : -1;
-    _relay[i].delay    = 0;
-    _relay[i].invert   = false;
+    _relay[i].pin      = i < COUNT_OF(defPins) ? defPins[i] : -1;
+    _relay[i].delay    = i < COUNT_OF(relayDelays) ? relayDelays[i] : 0;
+    _relay[i].invert   = i < COUNT_OF(relayInverts) ? relayInverts[i] : false;
     _relay[i].active   = false;
     _relay[i].state    = false;
-    _relay[i].external = false;
+    _relay[i].external = i < COUNT_OF(relayExternals) ? relayExternals[i] : false;
     _relay[i].button   = -1;
   }
 }


### PR DESCRIPTION
A small change to allow more characteristics of the relays to be set at compile time. Useful if you have a standard hardware build / config across multiple WLED instances (e.g. always use the same pin for a relay).