### PR TITLE
new buildenv for esp32s3dev_16MB_PSRAM_opi dev board (LilyGo T7-S3)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,8 +11,8 @@
 
 # CI binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi
-
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3dev_16MB_PSRAM_opi
+; default_envs = esp32s3dev_16MB_PSRAM_opi
 # Release binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
 
@@ -520,6 +520,29 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags}
   -D WLED_USE_PSRAM -DBOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
 lib_deps = ${esp32s3.lib_deps}
 board_build.partitions = tools/WLED_ESP32_8MB.csv
+board_build.f_flash = 80000000L
+board_build.flash_mode = qio
+monitor_filters = esp32_exception_decoder
+
+[env:esp32s3dev_16MB_PSRAM_opi]
+board = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+platform = ${esp32s3.platform}
+platform_packages = ${esp32s3.platform_packages}
+upload_speed = 921600
+framework = arduino
+
+# Configure options for the N16R8V variant
+build_flags= ${common.build_flags} ${esp32s3.build_flags}
+  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
+  -D ARDUINO_USB_CDC_ON_BOOT=0  -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
+  ;-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
+  ; -D WLED_RELEASE_NAME=ESP32-S3_PSRAM
+  -D WLED_USE_PSRAM -DBOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
+  -D BOARD_HAS_PSRAM
+lib_deps = ${esp32s3.lib_deps}
+board_build.partitions = tools/WLED_ESP32_16MB.CSV
+board_upload.flash_size = 16MB
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 monitor_filters = esp32_exception_decoder

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 # CI binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
 default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3dev_16MB_PSRAM_opi
-; default_envs = esp32s3dev_16MB_PSRAM_opi
+
 # Release binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,7 +11,7 @@
 
 # CI binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth # ESP32 variant builds are temporarily excluded from CI due to toolchain issues on the GitHub Actions Linux environment
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3dev_16MB_PSRAM_opi
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi
 
 # Release binaries
 ; default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB
@@ -42,6 +42,7 @@ default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32d
 ; default_envs = esp32s2_saola
 ; default_envs = esp32c3dev
 ; default_envs = lolin_s2_mini
+; default_envs = esp32s3dev_16MB_PSRAM_opi
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
@@ -525,27 +526,9 @@ board_build.flash_mode = qio
 monitor_filters = esp32_exception_decoder
 
 [env:esp32s3dev_16MB_PSRAM_opi]
-board = esp32-s3-devkitc-1
-board_build.arduino.memory_type = qio_opi
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
-upload_speed = 921600
-framework = arduino
-
-# Configure options for the N16R8V variant
-build_flags= ${common.build_flags} ${esp32s3.build_flags}
-  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
-  -D ARDUINO_USB_CDC_ON_BOOT=0  -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
-  ;-D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
-  ; -D WLED_RELEASE_NAME=ESP32-S3_PSRAM
-  -D WLED_USE_PSRAM -DBOARD_HAS_PSRAM ; tells WLED that PSRAM shall be used
-  -D BOARD_HAS_PSRAM
-lib_deps = ${esp32s3.lib_deps}
-board_build.partitions = tools/WLED_ESP32_16MB.CSV
+extends = env:esp32s3dev_8MB_PSRAM_opi
+board_build.partitions = tools/WLED_ESP32_16MB.csv
 board_upload.flash_size = 16MB
-board_build.f_flash = 80000000L
-board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
 
 [env:esp32s3dev_8MB_PSRAM_qspi]
 ;; ESP32-TinyS3 development board, with 8MB FLASH and PSRAM (memory_type: qio_qspi)


### PR DESCRIPTION
 Adds new esp32s3dev_16MB_PSRAM_opi dev board to work with Lily Go T7_s3 ESP32-S3-WROOM-1-N16R8