### PR TITLE
fix(esp32c3-2mb): correct flash size for c3 board with only 2MB

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -642,6 +642,8 @@ upload_speed = 115200
 lib_deps = ${esp32c3.lib_deps}
 board_build.partitions = tools/WLED_ESP32_2MB_noOTA.csv
 board_build.flash_mode = dio
+board_upload.flash_size = 2MB
+board_upload.maximum_size = 2097152
 
 [env:wemos_shield_esp32]
 board = esp32dev


### PR DESCRIPTION
Tested using [NWI1125](http://w2.electrodragon.com/Board-dat/NWI/NWI1125-DAT/NWI1125-DAT.md) from https://www.electrodragon.com/product/esp-led-strip-board/