### PR TITLE
add env for esp32 pico d4 with valid ledpin to prevent bootloops

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -403,6 +403,17 @@ lib_deps = ${esp32.lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
 
+[env:esp32picod4]
+board = esp32dev
+upload_speed = 921600
+platform = ${esp32.platform}
+platform_packages = ${esp32.platform_packages}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 -D LEDPIN=4 #-D WLED_DISABLE_BROWNOUT_DET # -D WLED_MAX_BUTTONS=6 
+lib_deps = ${esp32.lib_deps}
+monitor_filters = esp32_exception_decoder
+board_build.partitions = ${esp32.default_partitions}
+
 [env:esp32dev_audioreactive]
 board = esp32dev
 platform = ${esp32.platform}


### PR DESCRIPTION
In recent versions of WLED GPIO 16 is used as the default LEDPIN. This causes bootloops on ESP32 Pico D4 because GPIO 16 is connected to the embedded flash (see notes in ESP32 Pico D4 Datasheet Section 2.2: "Pins IO16, IO17, CMD, CLK, SD0 and SD1 are used to connect the embedded flash, and can not be used for other purposes. For details, please see Section 6 Schematics.").
Added a new environment for Pico D4 (esp32picod4) to platformio.ini with LEDPIN 4 defined as the default (gpio 4 matches my own hardware project, GPIO 2 will also cause no problems). Also changed upload Speed to max. for this env.