### PR TITLE
Add link to Aircoookie in Info

### DIFF
--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -351,7 +351,7 @@
 		<button class="btn infobtn" id="resetbtn" onclick="cnfReset()">Reboot WLED</button>
 	</div>
 	<br>
-	<span class="h">Made with <span id="heart">&#10084;&#xFE0E;</span> by Aircoookie and the <a href="https://wled.discourse.group/" target="_blank">WLED community</a></span>
+	<span class="h">Made with <span id="heart">&#10084;&#xFE0E;</span> by <a href="https://github.com/Aircoookie/" target="_blank">Aircoookie</a> and the <a href="https://wled.discourse.group/" target="_blank">WLED community</a></span>
 </div>
 
 <div id="nodes" class="modal">


### PR DESCRIPTION
Since there is already a link to the WLED community, I thought it only makes sense to have a link for Aircoookie as well.
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/99d5ade0-f147-40c6-ae59-2a5d27c8a955)
