### PR TITLE
Scroll to first search result on search

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -2722,8 +2722,10 @@ function search(field, listId = null) {
 	field.nextElementSibling.style.display = (field.value !== '') ? 'block' : 'none';
 	if (!listId) return;
 
+	const search = field.value !== '';
+
 	// clear filter if searching in fxlist
-	if (listId === 'fxlist' && field.value !== '') {
+	if (listId === 'fxlist' && search) {
 		gId("filters").querySelectorAll("input[type=checkbox]").forEach((e) => { e.checked = false; });
 	}
 
@@ -2757,6 +2759,12 @@ function search(field, listId = null) {
 	sortedListItems.forEach(item => {
 		gId(listId).append(item);
 	});
+
+	// scroll to first search result
+	const firstVisibleItem = sortedListItems.find(item => item.style.display !== 'none' && !item.classList.contains('sticky') && !item.classList.contains('selected'));
+	if (firstVisibleItem && search) {
+		firstVisibleItem.scrollIntoView({ behavior: "instant", block: "center" });
+	}
 }
 
 function clean(clearButton) {


### PR DESCRIPTION
If you scrolled down a list (palette, effects, or preset list) and then started searching, the search results list was still scrolled down. This is a fix for that.

Before | Now
-------- | --------
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/076dc2a9-93e7-4b62-9583-af8081f62dea)   | ![grafik](https://github.com/Aircoookie/WLED/assets/27882680/65d08da9-6bfa-4493-ae05-cf386fbca91b)