### PR TITLE
Send empty page if skin.css does not exist

### DIFF
--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -149,6 +149,12 @@ void initServer()
     request->send(response);
   });
 
+  server.on("/skin.css", HTTP_GET, [](AsyncWebServerRequest *request) {
+    if (handleFileRead(request, "/skin.css")) return;
+    AsyncWebServerResponse *response = request->beginResponse(200, "text/css");
+    request->send(response);
+  });
+
   server.on("/favicon.ico", HTTP_GET, [](AsyncWebServerRequest *request){
     if(!handleFileRead(request, "/favicon.ico"))
     {


### PR DESCRIPTION
This has the advantage that we do not need to send the 404 error page every time.

I also had a problem with this in Firefox. Sometimes Firefox used the css of the 404 error page and then the ui looked like this:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/6e4e445a-680a-4b6b-99d4-004bd5bbaea6)

This should no longer happen with this PR.