### PR TITLE
Show custom palettes with non-gamma-corrected colors on the UI

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -887,6 +887,7 @@ class WS2812FX {  // 96 bytes
 
   // end 2D support
 
+    bool loadCustomPalette(CRGBPalette16 &targetPalette, int pal, bool gammaCorrection); // load a custom palette, returns true if the file exists
     void loadCustomPalettes(void); // loads custom palettes from JSON
     CRGBPalette16 _currentPalette; // palette used for current effect (includes transition)
     std::vector<CRGBPalette16> customPalettes; // TODO: move custom palettes out of WS2812FX class

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -924,7 +924,9 @@ void serializePalettes(JsonObject root, int page)
       default:
         {
         if (i>=palettesCount) {
-          setPaletteColors(curPalette, strip.customPalettes[i - palettesCount]);
+          CRGBPalette16 pal;
+          strip.loadCustomPalette(pal, i - palettesCount, false);
+          setPaletteColors(curPalette, pal);
         } else {
           memcpy_P(tcp, (byte*)pgm_read_dword(&(gGradientPalettes[i - 13])), 72);
           setPaletteColors(curPalette, tcp);


### PR DESCRIPTION
This way it would work the same way as the automatic palettes created from the user-defined colors. On the UI the input colors are shown but the actual palettes are created from gamma corrected colors. The UI shows the palettes the same as created on the editor so users won't be confused.

Related to #3399