### PR TITLE
Add support for Olimex ESP32-POE-WROVER.

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -292,19 +292,20 @@
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES       11
+#define WLED_NUM_ETH_TYPES        12
 
-#define WLED_ETH_NONE             0
-#define WLED_ETH_WT32_ETH01       1
-#define WLED_ETH_ESP32_POE        2
-#define WLED_ETH_WESP32           3
-#define WLED_ETH_QUINLED          4
-#define WLED_ETH_TWILIGHTLORD     5
-#define WLED_ETH_ESP32DEUX        6
-#define WLED_ETH_ESP32ETHKITVE    7
-#define WLED_ETH_QUINLED_OCTA     8
-#define WLED_ETH_ABCWLEDV43ETH    9
-#define WLED_ETH_SERG74          10
+#define WLED_ETH_NONE              0
+#define WLED_ETH_WT32_ETH01        1
+#define WLED_ETH_ESP32_POE         2
+#define WLED_ETH_WESP32            3
+#define WLED_ETH_QUINLED           4
+#define WLED_ETH_TWILIGHTLORD      5
+#define WLED_ETH_ESP32DEUX         6
+#define WLED_ETH_ESP32ETHKITVE     7
+#define WLED_ETH_QUINLED_OCTA      8
+#define WLED_ETH_ABCWLEDV43ETH     9
+#define WLED_ETH_SERG74           10
+#define WLED_ETH_ESP32_POE_WROVER 11
 
 //Hue error codes
 #define HUE_ERROR_INACTIVE        0

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -215,6 +215,7 @@
 				<option value="0">None</option>
 				<option value="9">ABC! WLED V43 & compatible</option>
 				<option value="2">ESP32-POE</option>
+				<option value="11">ESP32-POE-WROVER</option>
 				<option value="6">ESP32Deux</option>
 				<option value="7">KIT-VE</option>
 				<option value="8">QuinLED-Dig-Octa & T-ETH-POE</option>

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -123,6 +123,16 @@ const ethernet_settings ethernetBoards[] = {
     18,                   // eth_mdio,
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
+  },
+
+  // ESP32-POE-WROVER
+  {
+    0,                    // eth_address,
+    12,                   // eth_power,
+    23,                   // eth_mdc,
+    18,                   // eth_mdio,
+    ETH_PHY_LAN8720,      // eth_type,
+    ETH_CLOCK_GPIO0_OUT   // eth_clk_mode
   }
 };
 #endif


### PR DESCRIPTION
There is a version of the Olimex ESP32-POE board (https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware) with an ESP32-WROVER module which has a the ethernet clock connected to a different IO than the version with an ESP32-WROOM module.  

This pull request adds a new runtime selectable variant for the WROVER version.