### PR TITLE
Expand JSON buffer lock scope to entire web reply

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -360,6 +360,22 @@ um_data_t* simulateSound(uint8_t simulationId);
 void enumerateLedmaps();
 uint8_t get_random_wheel_index(uint8_t pos);
 
+// RAII guard class for the JSON Buffer lock
+// Modeled after std::lock_guard
+class JSONBufferGuard {
+  bool holding_lock;
+  public:
+    inline JSONBufferGuard(uint8_t module=255) : holding_lock(requestJSONBufferLock(module)) {};
+    inline ~JSONBufferGuard() { if (holding_lock) releaseJSONBufferLock(); };
+    inline JSONBufferGuard(const JSONBufferGuard&) = delete; // Noncopyable
+    inline JSONBufferGuard& operator=(const JSONBufferGuard&) = delete;
+    inline JSONBufferGuard(JSONBufferGuard&& r) : holding_lock(r.holding_lock) { r.holding_lock = false; };  // but movable
+    inline JSONBufferGuard& operator=(JSONBufferGuard&& r) { holding_lock |= r.holding_lock; r.holding_lock = false; return *this; };
+    inline bool owns_lock() const { return holding_lock; }
+    explicit inline operator bool() const { return owns_lock(); };
+    inline void release() { if (holding_lock) releaseJSONBufferLock(); holding_lock = false; }
+};
+
 #ifdef WLED_ADD_EEPROM_SUPPORT
 //wled_eeprom.cpp
 void applyMacro(byte index);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1065,6 +1065,7 @@ void serveJson(AsyncWebServerRequest* request)
   if (!response->owns_lock()) {
     serveJsonError(request, 503, ERR_NOBUF);
     servingClient = false;
+    delete response;
     return;
   }
 


### PR DESCRIPTION
When generating a JSON reply, ensure that the global JSON buffer isn't released until the response is completely ack'd by the client.  This fixes some cases where the JSON reply exceeded a single packet and the second packet was corrupted by later users of the global buffer overwriting some of the packet data.

Fixes #3641