### PR TITLE
Fix that color picker is not centered on screens with width between 1024px and 1249px

### DIFF
--- a/wled00/data/index.css
+++ b/wled00/data/index.css
@@ -785,7 +785,7 @@ input[type=range]::-moz-range-thumb {
 
 #picker {
 	margin-top: 8px !important;
-	max-width: 260px;
+	max-width: max-content;
 }
 
 /* buttons */
@@ -1565,9 +1565,6 @@ dialog {
 		width: 100%;
 		max-width: 280px;
 		font-size: 18px;
-	}
-	#picker {
-		width: 230px;
 	}
 	#putil .btn-s {
 		width: 114px;


### PR DESCRIPTION
This fixes that the Color Picker is not centerd on screens with width between 1024px and 1249px.

| Before | Now |
|--------|--------|
| ![Screenshot 2024-01-08 at 14-31-20 (L) WLED](https://github.com/Aircoookie/WLED/assets/27882680/122394db-f7ad-469c-a47c-9126a88ba762) | ![Screenshot 2024-01-08 at 14-31-13 WLED](https://github.com/Aircoookie/WLED/assets/27882680/42e35c68-1812-4b38-a414-8288f0b0ab68) |