### PR TITLE
Disable custom CSS by default

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -30,7 +30,7 @@ var cfg = {
 	theme:{base:"dark", bg:{url:"", rnd: false, rndGrayscale: false, rndBlur: false}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
 	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
 		  labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:false,
-		  css:true, hdays:false, fxdef:true, on:0, off:0, idsort: false}
+		  css:false, hdays:false, fxdef:true, on:0, off:0, idsort: false}
 };
 // [year, month (0 -> January, 11 -> December), day, duration in days, image url]
 var hol = [


### PR DESCRIPTION
This will disable custom CSS by default.
I see no reason to have this enabled by default since there is no default skin.css file.
This just costs an unnecessary request on every load.
If someone wants to use custom CSS then they can enable it.