### PR TITLE
Rotating 2D Palette effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1933,49 +1933,39 @@ uint16_t mode_palette() {
   using mathType = int32_t;
   using wideMathType = int64_t;
   using angleType = uint16_t;
-  constexpr mathType sInt16Scale = 0x7FFF;
-  constexpr mathType maxAngle = 0xFFFF;
-  constexpr mathType staticRotationScale = 256;
-  constexpr mathType animatedRotationScale = 1;
+  constexpr mathType sInt16Scale             = 0x7FFF;
+  constexpr mathType maxAngle                = 0xFFFF;
+  constexpr mathType staticRotationScale     = 256;
+  constexpr mathType animatedRotationScale   = 1;
   constexpr int16_t (*sinFunction)(uint16_t) = &sin16;
   constexpr int16_t (*cosFunction)(uint16_t) = &cos16;
 #else
   using mathType = float;
   using wideMathType = float;
   using angleType = float;
-  constexpr mathType sInt16Scale = 1.0f;
-  constexpr mathType maxAngle = M_TWOPI / 256.0;
-  constexpr mathType staticRotationScale = 1.0f;
+  constexpr mathType sInt16Scale           = 1.0f;
+  constexpr mathType maxAngle              = M_TWOPI / 256.0;
+  constexpr mathType staticRotationScale   = 1.0f;
   constexpr mathType animatedRotationScale = M_TWOPI / double(0xFFFF);
-  constexpr float (*sinFunction)(float) = &sin_t;
-  constexpr float (*cosFunction)(float) = &cos_t;
+  constexpr float (*sinFunction)(float)    = &sin_t;
+  constexpr float (*cosFunction)(float)    = &cos_t;
 #endif
   const bool isMatrix = strip.isMatrix;
   const int cols = SEGMENT.virtualWidth();
   const int rows = isMatrix ? SEGMENT.virtualHeight() : strip.getSegmentsNum();
 
-  const int inputShift = SEGMENT.speed;
-  const int inputSize = SEGMENT.intensity;
-  const int inputRotation = SEGMENT.custom1;
-  const bool inputAnimateShift = SEGMENT.check1;
+  const int  inputShift           = SEGMENT.speed;
+  const int  inputSize            = SEGMENT.intensity;
+  const int  inputRotation        = SEGMENT.custom1;
+  const bool inputAnimateShift    = SEGMENT.check1;
   const bool inputAnimateRotation = SEGMENT.check2;
-  const bool inputAssumeSquare = SEGMENT.check3;
+  const bool inputAssumeSquare    = SEGMENT.check3;
 
   const int paletteOffset = (!inputAnimateShift) ? (inputShift) : (((strip.now * ((inputShift >> 3) +1)) & 0xFFFF) >> 8);
 
-  mathType sinTheta;
-  mathType cosTheta;
-  if (rows <= 1) {
-    sinTheta = 0;
-    cosTheta = sInt16Scale;
-  } else if (cols <= 1) {
-    sinTheta = sInt16Scale;
-    cosTheta = 0;
-  } else {
-    const angleType theta = (!inputAnimateRotation) ? (inputRotation * maxAngle / staticRotationScale) : (((strip.now * ((inputRotation >> 4) +1)) & 0xFFFF) * animatedRotationScale);
-    sinTheta = sinFunction(theta);
-    cosTheta = cosFunction(theta);
-  }
+  const angleType theta = (!inputAnimateRotation) ? (inputRotation * maxAngle / staticRotationScale) : (((strip.now * ((inputRotation >> 4) +1)) & 0xFFFF) * animatedRotationScale);
+  const mathType sinTheta = sinFunction(theta);
+  const mathType cosTheta = cosFunction(theta);
 
   const mathType maxX = std::max(1, cols-1);
   const mathType maxY = std::max(1, rows-1);
@@ -2011,7 +2001,7 @@ uint16_t mode_palette() {
   }
   return FRAMETIME;
 }
-static const char _data_FX_MODE_PALETTE[] PROGMEM = "Palette@Shift,Size,Rotation,,,Animate Shift,Animate Rotation,Physical Square;;!;12;o1=1,o2=1";
+static const char _data_FX_MODE_PALETTE[] PROGMEM = "Palette@Shift,Size,Rotation,,,Animate Shift,Animate Rotation,Physical Square;;!;12;c1=64,o1=1,o2=1,o3=0";
 
 
 // WLED limitation: Analog Clock overlay will NOT work when Fire2012 is active


### PR DESCRIPTION
I implemented a new effect that is similar to Palette/Rainbow:

[palette.webm](https://github.com/Aircoookie/WLED/assets/2760830/76d26fa7-0fff-4cc4-b6a9-96e4e1f90917)

If you like it too, let's talk a bit about it:

## Compatibility

I noticed that the Rainbow effect is *almost* a perfect superset of the Palette effect, so I replaced the Palette effect with my new effect. It provides similar functionality, but is not fully backwards compatible. So it might be better to make this a new effect ("Palette 2D" maybe?). I wanted to leave that judgement up to you.

Breaking changes are:
1. It is now a 2D effect and will therefore ignore a configured 1D FX expansion.
2. This new effect is segment-aware and will assume that a segmented 1D setup is actually a physical matrix, like you would have set it up prior to 0.14. So 1D setups with segments will now look differently.
3. The same speed input will result in slower palette shifting.
4. Compared to Rainbow (not Palette), the size parameter works differently and produces a different scaling for each possible input.


## Parameter Description

I'm going to describe what each parameter does here, so you can come up with better names if you don't like mine:

1. Shift (uint8):
   1. In static shift mode, this will determine how far the palette is "shifted". A shift of 0 will display the palette as it is, a shift of 128 will start at the middle of the palette until it hits the end, then start from the beginning again.
   2. In animated shift mode, this will determine how fast the palette is shifted.
2. Size (uint8): Size will scale the palette, similar to the Size parameter in the Rainbow effect.
3. Rotation (uint8):
   1. In static rotation mode, this will determine the angle of the rotation. 0 is 0°, 256 is 360°.
   2. In animated rotation mode, this will determine the rotation speed.
4. Animate Shift (bool): This will switch between static and animated shift mode, so either animate palette shifting, or keep it static.
5. Animate Rotation (bool): This will switch between static and animated rotation mode, so either animate rotation, or keep it static.
6. Physical Square (bool): See next section.


## Anamorphic Mode

For the setup I want to use this effect with, I have a set of LEDs that roughly cover a square area, but their numbers are not a square. There is a greater distance between LEDs in y than in x direction. So my setup is anamorphic, if you want.

Therefore, the Physical Square setting changes between assuming all physical LEDs are arranged in an equally spaced grid, and assuming the spacing is different in one direction than the other. There are other ways to look at this (and is interesting for equally spaced non-square setups as well) but this way of thinking made sense to me mathematically, when I implemented it.

This setting has no effect when the matrix has the same number of LEDs in x and y direction.

Here are two images at 45° that have identical settings apart from Physical Square.  
Non-square mode:  
![non-square mode](https://github.com/Aircoookie/WLED/assets/2760830/5e7be8c6-4773-4880-95e9-8119920c03a9)

Square mode:  
![square mode](https://github.com/Aircoookie/WLED/assets/2760830/3baff0cc-0d52-4af1-a67c-426a82edd316)


## 2D Emulation

### Motivation

I have a setup with 6 strips of 115 LEDs each, they light my ceiling. The distance between the strips is roughly 70 cm, while the distance between LEDs on a strip is about 3 cm. I have been using an ESP8266 so far, starting from WLED 0.13. I managed to put some rainbows on it, both along the strip direction and orthogonal to it, but I always wanted a diagonal rainbow, too.

With WLED 0.14 came matrix setups, but my poor 8266 becomes unresponsive immediately when I try to set it up with the above dimensions. I'm planning to replace it with an ESP32, on which that is no issue.

But during the development of my effect, I realized that is is entirely possible to achieve the same result with my existing 1D setup.

### 1D Matrix Setup

Prior to 0.14, I assume this button in the segment setup was used to configure matrix displays:  
![Repeat until the end](https://github.com/Aircoookie/WLED/assets/2760830/453b7f94-74aa-4785-b7b7-56adb2be7799)

For me, this results in the following segmentation, which I have been using.
<details>
<summary>Click to expand</summary>

![segments](https://github.com/Aircoookie/WLED/assets/2760830/971f9908-3984-4645-add6-ccdf876a656c)

</details>

Obviously this is not the only way you can use segments. My 2D emulation assumes this kind of setup. It simply might not look correctly in other scenarios.

### How it works

Now that we assume a certain anatomy of the setup, we can derive matrix dimensions from the number and length's of segments. We can also derive the y coordinate in the matrix from the current segment's index. Finally, the x coordinate is just the LED index in the current segment.

Laid out in one line, like the peek preview in the web UI does, a 45° rotation using `color_wheel` with the setup described above looks like this:  
![line](https://github.com/Aircoookie/WLED/assets/2760830/ea917c24-5219-4121-82c0-a0e9bf8a292e)

If we reverse every second segment, line them up vertically instead of horizontally, and scale them a bit (through the magic of gimp, or through the magic of having the LEDs physically ordered like that) we get this:  
![2D emulation](https://github.com/Aircoookie/WLED/assets/2760830/0ac99bae-3ff5-424c-9671-103b6353d931)

### Notes

 - If the segment setup is different or does not represent a matrix, this might not look correctly.
 - I don't iterate over segments. If a segment is missing or configured differently, it will simply be missing/look different from the picture above.
 - Using this 2D emulation results in one call per line instead of one call per matrix (as it would be with a 2D setup).
 - The only way (I found) to distinguish between 1D setups, and 2D setups with 1D segments is reading `strip.isMatrix`. Other effects use this information too, so I though it was fine.


## Floating Point Math

You will notice that my code is actually two versions, one for floating point math, one for integer math. I decided to use the float version on ESP32 for the better results, and the int version on ESP8266 for better performance.

I had to use two 64-bit multiplications in int mode to stay within the int range. It might be possible to get rid of them by halfing all other int sizes. But the int version already produces slightly lower quality results anyway, and I didn't want to further decrease quality, so I didn't try. (And besides the 64 bit multiplication appears to be only 2x slower than other int multiplications.)

The int version is a bit faster on the ESP32 and more so in the ESP8266 (which doesn't have an FPU I think?). I made some measurements, but I'm not sure what version of sin_t/cos_t they used. If you are interested in numbers, I can take some new measurements.

(The sin_t implementation is relevant because I when benchmarked different sin implementations, the Taylor version was about 24x (ESP32) / 11x (ESP8266) slower than the Arduino version. But there are only two trigonometry computations per call, so it might not matter that much. Btw. builds without the Taylor version are not only faster, but smaller too.)


## Other Thoughts

This transformation of the Palette effect from 1D to 2D might be interesting as a general 1D FX expansion. However it would need parameters. I didn't see any expansions that have parameters at the moment, so I didn't look into that.