### PR TITLE
Limit number of LEDS shown in Liveview to pixel width of canvas

### DIFF
--- a/wled00/data/liveview.htm
+++ b/wled00/data/liveview.htm
@@ -25,10 +25,11 @@
     var ctx;
     function draw(start, skip, leds, fill) {
       c.width = d.documentElement.clientWidth;
-      let w = (c.width * skip) / (leds.length - start);
-      for (let i = start; i < leds.length; i += skip) {
-        ctx.fillStyle = fill(leds,i);
-        ctx.fillRect(Math.round((i - start) * w / skip), 0, Math.ceil(w), c.height);
+      var len = Math.min((leds.length - start) / skip, c.width) //limit LEDs to pixel width of canvas
+      var w = c.width / len;
+      for (i = 0; i < len; i++) {
+        ctx.fillStyle = fill(leds, (i * skip) + start);
+        ctx.fillRect(i * w, 0, w + 1, c.height); // Make each strip overlap by 1 pixel to avoid round-off errors
       }
     }
     function update() { // via HTTP (/json/live)


### PR DESCRIPTION
Avoids aliasing errors on narrow screens (such as on mobile). Follow-on to discussion in #3621 , but broken out into a separate pull request.

For example, when displaying the colors from the C9 palette:
![image](https://github.com/Aircoookie/WLED/assets/797985/995a62fc-2bc6-4c38-883f-8f1209c9aa6d)

The current 0_15 branch code looks like the following with 1024 LEDs on a mobile screen that's 915 pixels wide:
![image](https://github.com/Aircoookie/WLED/assets/797985/e460339b-fced-464d-a154-3fc34fbe0150)

Limiting it to the width of the canvas results in the following:
![image](https://github.com/Aircoookie/WLED/assets/797985/f2736ba0-2105-4d87-a684-a83b49068137)
