### PR TITLE
Usermod Klipper Percentage: Fix

### DIFF
--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -170,7 +170,7 @@
 #endif
 
 #ifdef USERMOD_KLIPPER_PERCENTAGE
-  #include "..\usermods\usermod_v2_klipper_percentage\usermod_v2_klipper_percentage.h"
+  #include "../usermods/usermod_v2_klipper_percentage/usermod_v2_klipper_percentage.h"
 #endif
 
 #ifdef USERMOD_BOBLIGHT


### PR DESCRIPTION
Due to the difference handling of slash vs. backslash on different OS, there was an issue with the Discord Bot
