### PR TITLE
DNA Spiral Effect Speed Fix

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4880,7 +4880,7 @@ static const char _data_FX_MODE_2DDNA[] PROGMEM = "DNA@Scroll speed,Blur;;!;2";
 /////////////////////////
 //     2D DNA Spiral   //
 /////////////////////////
-uint16_t mode_2DDNASpiral() {               // By: ldirko  https://editor.soulmatelights.com/gallery/810 , modified by: Andrew Tuline
+uint16_t mode_2DDNASpiral() {               // By: ldirko  https://editor.soulmatelights.com/gallery/512-dna-spiral-variation , modified by: Andrew Tuline
   if (!strip.isMatrix || !SEGMENT.is2D()) return mode_static(); // not a 2D set-up
 
   const uint16_t cols = SEGMENT.virtualWidth();
@@ -4890,7 +4890,7 @@ uint16_t mode_2DDNASpiral() {               // By: ldirko  https://editor.soulma
     SEGMENT.fill(BLACK);
   }
 
-  uint8_t speeds = SEGMENT.speed/2 + 1;
+  uint8_t speeds = SEGMENT.speed/2 + 7;
   uint8_t freq = SEGMENT.intensity/8;
 
   uint32_t ms = millis() / 20;


### PR DESCRIPTION
- Upping speeds positive offset to match the negative offset in beatsin8 calls further down in the function.  Previously, speed values from the UI under 12 were extremely fast.  This change fixes that.
- Also updating source link - was a copy paste error in the past it seems.