### PR TITLE
UM Audioreactive: add two compiler options

### DIFF
--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -73,7 +73,11 @@ static uint8_t audioSyncEnabled = 0;          // bit field: bit 0 - send, bit 1 
 static bool udpSyncConnected = false;         // UDP connection status -> true if connected to multicast group
 
 // user settable parameters for limitSoundDynamics()
-static bool limiterOn = true;                 // bool: enable / disable dynamics limiter
+#ifdef UM_AUDIOREACTIVE_RISE_FALL_LIMITER_OFF
+static bool limiterOn = false;                 // bool: enable / disable dynamics limiter
+#else
+static bool limiterOn = true;
+#endif
 static uint16_t attackTime =  80;             // int: attack time in milliseconds. Default 0.08sec
 static uint16_t decayTime = 1400;             // int: decay time in milliseconds.  Default 1.40sec
 // user settable options for FFTResult scaling
@@ -612,7 +616,12 @@ class AudioReactive : public Usermod {
     };
 
     // set your config variables to their boot default value (this can also be done in readFromConfig() or a constructor if you prefer)
+    #ifdef UM_AUDIOREACTIVE_ENABLE
+    bool     enabled = true;
+    #else
     bool     enabled = false;
+    #endif
+
     bool     initDone = false;
 
     // variables  for UDP sound sync

--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -73,7 +73,7 @@ static uint8_t audioSyncEnabled = 0;          // bit field: bit 0 - send, bit 1 
 static bool udpSyncConnected = false;         // UDP connection status -> true if connected to multicast group
 
 // user settable parameters for limitSoundDynamics()
-#ifdef UM_AUDIOREACTIVE_RISE_FALL_LIMITER_OFF
+#ifdef UM_AUDIOREACTIVE_DYNAMICS_LIMITER_OFF
 static bool limiterOn = false;                 // bool: enable / disable dynamics limiter
 #else
 static bool limiterOn = true;

--- a/usermods/audioreactive/readme.md
+++ b/usermods/audioreactive/readme.md
@@ -57,7 +57,7 @@ If you want to define default GPIOs during compile time, use the following (defa
 
 Other options:
 
-- `-D UM_AUDIOREACTIVE_ENABLE` : makes msermod default enabled
+- `-D UM_AUDIOREACTIVE_ENABLE` : makes usermod default enabled (not the same as include into build option!)
 - `-D UM_AUDIOREACTIVE_RISE_FALL_LIMITER_OFF` : disables rise/fall limiter default
 
 **NOTE** I2S is used for analog audio sampling. Hence, the analog *buttons* (i.e. potentiometers) are disabled when running this usermod with an analog microphone.

--- a/usermods/audioreactive/readme.md
+++ b/usermods/audioreactive/readme.md
@@ -58,7 +58,7 @@ If you want to define default GPIOs during compile time, use the following (defa
 Other options:
 
 - `-D UM_AUDIOREACTIVE_ENABLE` : makes usermod default enabled (not the same as include into build option!)
-- `-D UM_AUDIOREACTIVE_RISE_FALL_LIMITER_OFF` : disables rise/fall limiter default
+- `-D UM_AUDIOREACTIVE_DYNAMICS_LIMITER_OFF` : disables rise/fall limiter default
 
 **NOTE** I2S is used for analog audio sampling. Hence, the analog *buttons* (i.e. potentiometers) are disabled when running this usermod with an analog microphone.
 

--- a/usermods/audioreactive/readme.md
+++ b/usermods/audioreactive/readme.md
@@ -55,6 +55,11 @@ If you want to define default GPIOs during compile time, use the following (defa
 - `-D ES7243_SDAPIN` : GPIO for I2C SDA pin on ES7243 microphone (-1)
 - `-D ES7243_SCLPIN` : GPIO for I2C SCL pin on ES7243 microphone (-1)
 
+Other options:
+
+- `-D UM_AUDIOREACTIVE_ENABLE` : makes msermod default enabled
+- `-D UM_AUDIOREACTIVE_RISE_FALL_LIMITER_OFF` : disables rise/fall limiter default
+
 **NOTE** I2S is used for analog audio sampling. Hence, the analog *buttons* (i.e. potentiometers) are disabled when running this usermod with an analog microphone.
 
 ### Advanced Compile-Time Options


### PR DESCRIPTION
Add two additional compiler options:
UM_AUDIOREACTIVE_ENABLE: makes usermod default enabled
UM_AUDIOREACTIVE_DYNAMICS_LIMITER_OFF: disables rise/fall limiter default