### PR TITLE
Update setup-node and cache usermods in wled-ci.yml

### DIFF
--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'

--- a/.github/workflows/wled-ci.yml
+++ b/.github/workflows/wled-ci.yml
@@ -45,7 +45,7 @@ jobs:
               ~/.platformio/.cache
               ~/.buildcache
               build_output
-        key: pio-${{ runner.os }}-${{ matrix.environment }}-${{ hashFiles('platformio.ini', 'pio-scripts/output_bins.py') }}-${{ hashFiles('wled00/**') }}
+        key: pio-${{ runner.os }}-${{ matrix.environment }}-${{ hashFiles('platformio.ini', 'pio-scripts/output_bins.py') }}-${{ hashFiles('wled00/**', 'usermods/**') }}
         restore-keys: pio-${{ runner.os }}-${{ matrix.environment }}-${{ hashFiles('platformio.ini', 'pio-scripts/output_bins.py') }}-
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This updates the setup-node action to the latest version.

This fixes this:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/c8a86e5f-744f-40fc-a38e-981360a2682e)

This now also includes usermods in platformio caching.