### PR TITLE
Switch to willmmiles fork of AsyncWebServer

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -181,7 +181,7 @@ lib_deps =
     fastled/FastLED @ 3.6.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.7.5
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.7
+    https://github.com/willmmiles/ESPAsyncWebServer.git#master
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For compatible OLED display uncomment following

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -448,8 +448,17 @@
   #define JSON_BUFFER_SIZE 24576
 #endif
 
-//#define MIN_HEAP_SIZE (8k for AsyncWebServer)
-#define MIN_HEAP_SIZE 8192
+//#define MIN_HEAP_SIZE
+#define MIN_HEAP_SIZE 2048
+
+// Web server limits
+#ifdef ESP8266
+  #define WLED_MAX_CONCURRENT_REQUESTS 2
+  #define WLED_MAX_QUEUED_REQUESTS 6
+#else
+  #define WLED_MAX_CONCURRENT_REQUESTS 6
+  #define WLED_MAX_QUEUED_REQUESTS 12
+#endif
 
 // Maximum size of node map (list of other WLED instances)
 #ifdef ESP8266

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -689,7 +689,7 @@ WLED_GLOBAL bool ledStatusState _INIT(false); // the current LED state
 #endif
 
 // server library objects
-WLED_GLOBAL AsyncWebServer server _INIT_N(((80)));
+WLED_GLOBAL AsyncWebServer server _INIT_N(((80, WLED_MAX_CONCURRENT_REQUESTS, WLED_MAX_QUEUED_REQUESTS)));
 #ifdef WLED_ENABLE_WEBSOCKETS
 WLED_GLOBAL AsyncWebSocket ws _INIT_N((("/ws")));
 #endif


### PR DESCRIPTION
Switch WLED to use the willmmiles fork of AsyncWebServer, with the following improvements:

- Merge some open PRs from upstream
- Fix longstanding use-after-free in AsyncWebServerRequest::_removeNotInterestingHeaders
- Move many static strings to PROGMEM, reducing RAM usage by ~1k
- Add a simple response queue, reducing peak RAM usage
   -  Note: this is not a hard limit unfortunately - memory usage is still unbounded with a SYM flood or large POST, as I have yet to find a practical solution to throttle inbound traffic.
- Some small reductions in allocator usage during operation

This should be considered an alpha-quality work in progress; I'm offering it here for early testing and feedback.  Version number is not pinned yet.