### PR TITLE
Switch to willmmiles fork of AsyncWebServer (0_15)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -144,7 +144,7 @@ lib_deps =
     fastled/FastLED @ 3.6.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.7.5
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.7
+    https://github.com/willmmiles/ESPAsyncWebServer.git#master
   # for I2C interface
     ;Wire
   # ESP-NOW library

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Some web server stress tests
+#
+# Perform a large number of parallel requests, stress testing the web server
+# TODO: some kind of performance metrics
+
+
+TARGET=$1
+
+JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
+FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
+CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 2"
+
+# TODO: argument parsing
+
+# Test static file targets
+TARGETS=(${JSON_TARGETS[@]})
+#TARGETS=(${FILE_TARGETS[@]})
+
+# Expand target URLS to full arguments for curl
+FULL_OPTIONS=$(printf "http://${TARGET}/%s -o /dev/null " "${TARGETS[@]}")
+
+#echo ${FULL_OPTIONS}
+time curl ${CURL_ARGS} ${FULL_OPTIONS}

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -7,15 +7,24 @@
 
 TARGET=$1
 
+CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 50"
+
 JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
-CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 2"
+
+# Replicate one target many times
+function replicate() {
+  printf "${1}?%d " {1..8}
+}
+read -a JSON_LARGE_TARGETS <<< $(replicate "json/si")
+read -a JSON_LARGER_TARGETS <<< $(replicate "json/fxdata")
 
 # TODO: argument parsing
 
 # Test static file targets
-TARGETS=(${JSON_TARGETS[@]})
+#TARGETS=(${JSON_TARGETS[@]})
 #TARGETS=(${FILE_TARGETS[@]})
+TARGETS=(${JSON_LARGER_TARGETS[@]})
 
 # Expand target URLS to full arguments for curl
 FULL_OPTIONS=$(printf "http://${TARGET}/%s -o /dev/null " "${TARGETS[@]}")

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -492,8 +492,17 @@
   #endif
 #endif
 
-//#define MIN_HEAP_SIZE (8k for AsyncWebServer)
-#define MIN_HEAP_SIZE 8192
+//#define MIN_HEAP_SIZE
+#define MIN_HEAP_SIZE 2048
+
+// Web server limits
+#ifdef ESP8266
+  #define WLED_MAX_CONCURRENT_REQUESTS 2
+  #define WLED_MAX_QUEUED_REQUESTS 6
+#else
+  #define WLED_MAX_CONCURRENT_REQUESTS 6
+  #define WLED_MAX_QUEUED_REQUESTS 12
+#endif
 
 // Maximum size of node map (list of other WLED instances)
 #ifdef ESP8266

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -367,7 +367,7 @@ void sappend(char stype, const char* key, int val);
 void sappends(char stype, const char* key, char* val);
 void prepareHostname(char* hostname);
 bool isAsterisksOnly(const char* str, byte maxLen);
-bool requestJSONBufferLock(uint8_t module=255);
+bool requestJSONBufferLock(uint8_t module=255, bool yield_ok = true);
 void releaseJSONBufferLock();
 uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLen);
 uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxLen, uint8_t *var = nullptr);

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -378,20 +378,7 @@ void updateFSInfo() {
 //Un-comment any file types you need
 static String getContentType(AsyncWebServerRequest* request, String filename){
   if(request->hasArg(F("download")))     return SET_F("application/octet-stream");
-  else if(filename.endsWith(F(".htm")))  return SET_F("text/html");
-  else if(filename.endsWith(F(".html"))) return SET_F("text/html");
-  else if(filename.endsWith(F(".css")))  return SET_F("text/css");
-  else if(filename.endsWith(F(".js")))   return SET_F("application/javascript");
-  else if(filename.endsWith(F(".json"))) return SET_F("application/json");
-  else if(filename.endsWith(F(".png")))  return SET_F("image/png");
-  else if(filename.endsWith(F(".gif")))  return SET_F("image/gif");
-  else if(filename.endsWith(F(".jpg")))  return SET_F("image/jpeg");
-  else if(filename.endsWith(F(".ico")))  return SET_F("image/x-icon");
-//  else if(filename.endsWith(F(".xml")))   return SET_F("text/xml");
-//  else if(filename.endsWith(F(".pdf")))   return SET_F("application/x-pdf");
-//  else if(filename.endsWith(F(".zip")))   return SET_F("application/x-zip");
-//  else if(filename.endsWith(F(".gz")))    return SET_F("application/x-gzip");
-  return "text/plain";
+  return contentTypeFor(filename);
 }
 
 #if defined(BOARD_HAS_PSRAM) && defined(WLED_USE_PSRAM)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1023,14 +1023,26 @@ void serializeModeNames(JsonArray arr)
 
 // Global buffer locking response helper class (to make sure lock is released when AsyncJsonResponse is destroyed)
 class LockedJsonResponse: public AsyncJsonResponse {
+  bool _holding_lock;
   public:
   // WARNING: constructor assumes requestJSONBufferLock() was successfully acquired externally/prior to constructing the instance
   // Not a good practice with C++. Unfortunately AsyncJsonResponse only has 2 constructors - for dynamic buffer or existing buffer,
   // with existing buffer it clears its content during construction
   // if the lock was not acquired (using JSONBufferGuard class) previous implementation still cleared existing buffer
-  inline LockedJsonResponse(JsonDocument *doc, bool isArray) : AsyncJsonResponse(doc, isArray) {};
+  inline LockedJsonResponse(JsonDocument* doc, bool isArray) : AsyncJsonResponse(doc, isArray), _holding_lock(true) {};
+
+  virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) { 
+    size_t result = AsyncJsonResponse::_fillBuffer(buf, maxLen);
+    // Release lock as soon as we're done filling content
+    if (((result + _sentLength) >= (_contentLength)) && _holding_lock) {
+      releaseJSONBufferLock();
+      _holding_lock = false;
+    }
+    return result;
+  }
+
   // destructor will remove JSON buffer lock when response is destroyed in AsyncWebServer
-  virtual ~LockedJsonResponse() { releaseJSONBufferLock(); };
+  virtual ~LockedJsonResponse() { if (_holding_lock) releaseJSONBufferLock(); };
 };
 
 void serveJson(AsyncWebServerRequest* request)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1075,7 +1075,7 @@ void serveJson(AsyncWebServerRequest* request)
     return;
   }
 
-  if (!requestJSONBufferLock(17)) {
+  if (!requestJSONBufferLock(17, false)) {
     serveJsonError(request, 503, ERR_NOBUF);
     return;
   }

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1076,7 +1076,7 @@ void serveJson(AsyncWebServerRequest* request)
   }
 
   if (!requestJSONBufferLock(17, false)) {
-    serveJsonError(request, 503, ERR_NOBUF);
+    request->deferResponse();    
     return;
   }
   // releaseJSONBufferLock() will be called when "response" is destroyed (from AsyncWebServer)

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1064,7 +1064,7 @@ void serveJson(AsyncWebServerRequest* request)
   }
   #endif
   else if (url.indexOf("pal") > 0) {
-    request->send_P(200, F("application/json"), JSON_palette_names);
+    request->send_P(200, FPSTR(CONTENT_TYPE_JSON), JSON_palette_names);
     return;
   }
   else if (url.indexOf("cfg") > 0 && handleFileRead(request, F("/cfg.json"))) {
@@ -1184,7 +1184,7 @@ bool serveLiveLeds(AsyncWebServerRequest* request, uint32_t wsClient)
 #endif
   oappend("}");
   if (request) {
-    request->send(200, F("application/json"), buffer);
+    request->send(200, FPSTR(CONTENT_TYPE_JSON), buffer);
   }
   #ifdef WLED_ENABLE_WEBSOCKETS
   else {

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -701,16 +701,16 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
         // so checkboxes have one or two fields (first is always "false", existence of second depends on checkmark and may be "true")
         if (subObj[name].isNull()) {
           // the first occurrence of the field describes the parameter type (used in next loop)
-          if (value == "false") subObj[name] = false; // checkboxes may have only one field
+          if (value == F("false")) subObj[name] = false; // checkboxes may have only one field
           else                  subObj[name] = value;
         } else {
           String type = subObj[name].as<String>();  // get previously stored value as a type
           if (subObj[name].is<bool>())   subObj[name] = true;   // checkbox/boolean
-          else if (type == "number") {
+          else if (type == F("number")) {
             value.replace(",",".");      // just in case conversion
             if (value.indexOf(".") >= 0) subObj[name] = value.toFloat();  // we do have a float
             else                         subObj[name] = value.toInt();    // we may have an int
-          } else if (type == "int")      subObj[name] = value.toInt();
+          } else if (type == F("int"))      subObj[name] = value.toInt();
           else                           subObj[name] = value;  // text fields
         }
         DEBUG_PRINT(F(" = ")); DEBUG_PRINTLN(value);
@@ -771,7 +771,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 //HTTP API request parser
 bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
 {
-  if (!(req.indexOf("win") >= 0)) return false;
+  if (!(req.indexOf(F("win")) >= 0)) return false;
 
   int pos = 0;
   DEBUG_PRINT(F("API req: "));

--- a/wled00/src/dependencies/async-mqtt-client/AsyncMqttClient.cpp
+++ b/wled00/src/dependencies/async-mqtt-client/AsyncMqttClient.cpp
@@ -40,7 +40,7 @@ AsyncMqttClient::AsyncMqttClient()
   sprintf(_generatedClientId, "esp32%06x", (uint32_t)ESP.getEfuseMac());
   _xSemaphore = xSemaphoreCreateMutex();
 #elif defined(ESP8266)
-  sprintf(_generatedClientId, "esp8266%06x", (uint32_t)ESP.getChipId());
+  sprintf_P(_generatedClientId, PSTR("esp8266%06x"), (uint32_t)ESP.getChipId());
 #endif
   _clientId = _generatedClientId;
 

--- a/wled00/src/dependencies/json/AsyncJson-v6.h
+++ b/wled00/src/dependencies/json/AsyncJson-v6.h
@@ -21,8 +21,6 @@
   #define DYNAMIC_JSON_DOCUMENT_SIZE 16384
 #endif
 
-constexpr const char* JSON_MIMETYPE = "application/json";
-
 /*
  * Json Response
  * */
@@ -66,7 +64,7 @@ class AsyncJsonResponse: public AsyncAbstractResponse {
 
     AsyncJsonResponse(JsonDocument *ref, bool isArray=false) : _jsonBuffer(1), _isValid{false} {
       _code = 200;
-      _contentType = JSON_MIMETYPE;
+      _contentType = FPSTR(CONTENT_TYPE_JSON);
       if(isArray)
         _root = ref->to<JsonArray>();
       else
@@ -75,7 +73,7 @@ class AsyncJsonResponse: public AsyncAbstractResponse {
 
     AsyncJsonResponse(size_t maxJsonBufferSize = DYNAMIC_JSON_DOCUMENT_SIZE, bool isArray=false) : _jsonBuffer(maxJsonBufferSize), _isValid{false} {
       _code = 200;
-      _contentType = JSON_MIMETYPE;
+      _contentType = FPSTR(CONTENT_TYPE_JSON);
       if(isArray)
         _root = _jsonBuffer.createNestedArray();
       else

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -207,7 +207,7 @@ bool isAsterisksOnly(const char* str, byte maxLen)
 
 
 //threading/network callback details: https://github.com/Aircoookie/WLED/pull/2336#discussion_r762276994
-bool requestJSONBufferLock(uint8_t module)
+bool requestJSONBufferLock(uint8_t module, bool yield_ok)
 {
   if (pDoc == nullptr) {
     DEBUG_PRINTLN(F("ERROR: JSON buffer not allocated!"));
@@ -215,7 +215,7 @@ bool requestJSONBufferLock(uint8_t module)
   }
   unsigned long now = millis();
 
-  while (jsonBufferLock && millis()-now < 100) delay(1); // wait for fraction for buffer lock
+  while (jsonBufferLock && yield_ok && (millis()-now < 100)) delay(1); // wait for fraction for buffer lock
 
   if (jsonBufferLock) {
     DEBUG_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -157,11 +157,11 @@ void WLED::loop()
   if (millis() - heapTime > 15000) {
     uint32_t heap = ESP.getFreeHeap();
     if (heap < MIN_HEAP_SIZE && lastHeap < MIN_HEAP_SIZE) {
-      DEBUG_PRINT(F("Heap too low! ")); DEBUG_PRINTLN(heap);
+      DEBUG_PRINT(F("\n***** Heap too low, forcing reconnect! ")); DEBUG_PRINTLN(heap);
       forceReconnect = true;
       strip.resetSegments(); // remove all but one segments from memory
     } else if (heap < MIN_HEAP_SIZE) {
-      DEBUG_PRINTLN(F("Heap low, purging segments."));
+      DEBUG_PRINTLN(F("\n***** Heap low, purging segments."));
       strip.purgeSegments();
     }
     lastHeap = heap;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -265,6 +265,7 @@ void WLED::loop()
       DEBUG_PRINT(F("Strip time[ms]: "));  DEBUG_PRINT(avgStripMillis/loops); DEBUG_PRINT("/"); DEBUG_PRINTLN(maxStripMillis);
     }
     strip.printSize();
+    server.dumpStatus();
     loops = 0;
     maxLoopMillis = 0;
     maxUsermodMillis = 0;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -713,7 +713,7 @@ WLED_GLOBAL bool ledStatusState _INIT(false); // the current LED state
 #endif
 
 // server library objects
-WLED_GLOBAL AsyncWebServer server _INIT_N(((80)));
+WLED_GLOBAL AsyncWebServer server _INIT_N(((80, WLED_MAX_CONCURRENT_REQUESTS, WLED_MAX_QUEUED_REQUESTS)));
 #ifdef WLED_ENABLE_WEBSOCKETS
 WLED_GLOBAL AsyncWebSocket ws _INIT_N((("/ws")));
 #endif

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -234,54 +234,57 @@ void initServer()
 
 #ifdef WLED_ENABLE_WEBSOCKETS
   #ifndef WLED_DISABLE_2D 
-  server.on(SET_F("/liveview2D"), HTTP_GET, [](AsyncWebServerRequest *request) {
+  server.on(F("/liveview2D"), HTTP_GET, [](AsyncWebServerRequest *request) {
     handleStaticContent(request, "", 200, FPSTR(s_html), PAGE_liveviewws2D, PAGE_liveviewws2D_length);
   });
   #endif
 #endif
-  server.on(SET_F("/liveview"), HTTP_GET, [](AsyncWebServerRequest *request) {
+  server.on(F("/liveview"), HTTP_GET, [](AsyncWebServerRequest *request) {
     handleStaticContent(request, "", 200, FPSTR(s_html), PAGE_liveview, PAGE_liveview_length);
   });
 
   //settings page
-  server.on(SET_F("/settings"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/settings"), HTTP_GET, [](AsyncWebServerRequest *request){
     serveSettings(request);
   });
 
   // "/settings/settings.js&p=x" request also handled by serveSettings()
-
-  server.on(SET_F("/style.css"), HTTP_GET, [](AsyncWebServerRequest *request) {
-    handleStaticContent(request, F("/style.css"), 200, FPSTR(s_css), PAGE_settingsCss, PAGE_settingsCss_length);
+  const static char STYLE_CSS[] PROGMEM = "/style.css";
+  server.on(FPSTR(STYLE_CSS), HTTP_GET, [](AsyncWebServerRequest *request) {
+    handleStaticContent(request, FPSTR(STYLE_CSS), 200, FPSTR(s_css), PAGE_settingsCss, PAGE_settingsCss_length);
   });
 
-  server.on(SET_F("/favicon.ico"), HTTP_GET, [](AsyncWebServerRequest *request) {
-    handleStaticContent(request, F("/favicon.ico"), 200, F("image/x-icon"), favicon, favicon_length, false);
+  const static char FAVICON_ICO[] PROGMEM = "/favicon.ico";
+  server.on(FPSTR(FAVICON_ICO), HTTP_GET, [](AsyncWebServerRequest *request) {
+    handleStaticContent(request, FPSTR(FAVICON_ICO), 200, FPSTR(CONTENT_TYPE_XICON), favicon, favicon_length, false);
   });
 
-  server.on(SET_F("/skin.css"), HTTP_GET, [](AsyncWebServerRequest *request) {
-    if (handleFileRead(request, F("/skin.css"))) return;
+  const static char SKIN_CSS[] PROGMEM = "/skin.css";
+  server.on(FPSTR(SKIN_CSS), HTTP_GET, [](AsyncWebServerRequest *request) {
+    if (handleFileRead(request, FPSTR(SKIN_CSS))) return;
     AsyncWebServerResponse *response = request->beginResponse(200, FPSTR(s_css));
     request->send(response);
   });
 
-  server.on(SET_F("/welcome"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/welcome"), HTTP_GET, [](AsyncWebServerRequest *request){
     serveSettings(request);
   });
 
-  server.on(SET_F("/reset"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/reset"), HTTP_GET, [](AsyncWebServerRequest *request){
     serveMessage(request, 200,F("Rebooting now..."),F("Please wait ~10 seconds..."),129);
     doReboot = true;
   });
 
-  server.on(SET_F("/settings"), HTTP_POST, [](AsyncWebServerRequest *request){
+  server.on(F("/settings"), HTTP_POST, [](AsyncWebServerRequest *request){
     serveSettings(request, true);
   });
 
-  server.on(SET_F("/json"), HTTP_GET, [](AsyncWebServerRequest *request){
+  const static char JSON[] PROGMEM = "/json";
+  server.on(FPSTR(JSON), HTTP_GET, [](AsyncWebServerRequest *request){
     serveJson(request);
   });
 
-  AsyncCallbackJsonWebHandler* handler = new AsyncCallbackJsonWebHandler(F("/json"), [](AsyncWebServerRequest *request) {
+  AsyncCallbackJsonWebHandler* handler = new AsyncCallbackJsonWebHandler(FPSTR(JSON), [](AsyncWebServerRequest *request) {
     bool verboseResponse = false;
     bool isConfig = false;
 
@@ -333,15 +336,15 @@ void initServer()
   }, JSON_BUFFER_SIZE);
   server.addHandler(handler);
 
-  server.on(SET_F("/version"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/version"), HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, FPSTR(s_plain), (String)VERSION);
   });
 
-  server.on(SET_F("/uptime"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/uptime"), HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, FPSTR(s_plain), (String)millis());
   });
 
-  server.on(SET_F("/freeheap"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/freeheap"), HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, FPSTR(s_plain), (String)ESP.getFreeHeap());
   });
 
@@ -351,11 +354,11 @@ void initServer()
   });
 #endif
 
-  server.on(SET_F("/teapot"), HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on(F("/teapot"), HTTP_GET, [](AsyncWebServerRequest *request){
     serveMessage(request, 418, F("418. I'm a teapot."), F("(Tangible Embedded Advanced Project Of Twinkling)"), 254);
   });
 
-  server.on(SET_F("/upload"), HTTP_POST, [](AsyncWebServerRequest *request) {},
+  server.on(F("/upload"), HTTP_POST, [](AsyncWebServerRequest *request) {},
         [](AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data,
                       size_t len, bool final) {handleUpload(request, filename, index, data, len, final);}
   );

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -18,11 +18,11 @@ static const char s_unlock_ota [] PROGMEM = "Please unlock OTA in security setti
 static const char s_unlock_cfg [] PROGMEM = "Please unlock settings using PIN code!";
 static const char s_notimplemented[] PROGMEM = "Not implemented";
 static const char s_accessdenied[]   PROGMEM = "Access Denied";
-static const char s_javascript[]     PROGMEM = "application/javascript";
-static const char s_json[]           PROGMEM = "application/json";
-static const char s_html[]           PROGMEM = "text/html";
-static const char s_plain[]          PROGMEM = "text/plain";
-static const char s_css[]            PROGMEM = "text/css";
+static const char* s_javascript = CONTENT_TYPE_JAVASCRIPT;
+static const char* s_json = CONTENT_TYPE_JSON;
+static const char* s_html = CONTENT_TYPE_HTML;
+static const char* s_plain = CONTENT_TYPE_PLAIN;
+static const char* s_css = CONTENT_TYPE_CSS;
 
 //Is this an IP?
 static bool isIp(String str) {

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -102,7 +102,6 @@ void wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
 void sendDataWs(AsyncWebSocketClient * client)
 {
   if (!ws.count()) return;
-  AsyncWebSocketMessageBuffer * buffer;
 
   if (!requestJSONBufferLock(12)) {
     if (client) {
@@ -129,7 +128,7 @@ void sendDataWs(AsyncWebSocketClient * client)
     return;
   }
   #endif
-  buffer = ws.makeBuffer(len); // will not allocate correct memory sometimes on ESP8266
+  AsyncWebSocketSharedBuffer buffer = std::make_shared<DynamicBuffer>(len); // will not allocate correct memory sometimes on ESP8266
   #ifdef ESP8266
   size_t heap2 = ESP.getFreeHeap();
   DEBUG_PRINT(F("heap ")); DEBUG_PRINTLN(ESP.getFreeHeap());
@@ -141,23 +140,18 @@ void sendDataWs(AsyncWebSocketClient * client)
     DEBUG_PRINTLN(F("WS buffer allocation failed."));
     ws.closeAll(1013); //code 1013 = temporary overload, try again later
     ws.cleanupClients(0); //disconnect all clients to release memory
-    ws._cleanBuffers();
     return; //out of memory
   }
-
-  buffer->lock();
-  serializeJson(*pDoc, (char *)buffer->get(), len);
+  serializeJson(*pDoc, (char *)buffer->data(), len);
 
   DEBUG_PRINT(F("Sending WS data "));
   if (client) {
-    client->text(buffer);
+    client->text(std::move(buffer));
     DEBUG_PRINTLN(F("to a single client."));
   } else {
     ws.textAll(buffer);
     DEBUG_PRINTLN(F("to multiple clients."));
   }
-  buffer->unlock();
-  ws._cleanBuffers();
 
   releaseJSONBufferLock();
 }
@@ -187,11 +181,10 @@ bool sendLiveLedsWs(uint32_t wsClient)
 #endif
   size_t bufSize = pos + (used/n)*3;
 
-  AsyncWebSocketMessageBuffer * wsBuf = ws.makeBuffer(bufSize);
+  AsyncWebSocketSharedBuffer wsBuf = std::make_shared<DynamicBuffer>(bufSize);
   if (!wsBuf) return false; //out of memory
-  uint8_t* buffer = wsBuf->get();
+  uint8_t* buffer = reinterpret_cast<uint8_t*>(wsBuf->data());
   if (!buffer) return false; //out of memory
-  wsBuf->lock();  // protect buffer from being cleaned by another WS instance
   buffer[0] = 'L';
   buffer[1] = 1; //version
 
@@ -218,9 +211,7 @@ bool sendLiveLedsWs(uint32_t wsClient)
     buffer[pos++] = scale8(qadd8(w, b), strip.getBrightness()); //B
   }
 
-  wsc->binary(wsBuf);
-  wsBuf->unlock();     // un-protect buffer
-  ws._cleanBuffers();
+  wsc->binary(std::move(wsBuf));
   return true;
 }
 

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -131,7 +131,7 @@ void appendGPIOinfo() {
     oappend(","); oappend(itoa(spi_sclk,nS,10));
   }
   // usermod pin reservations will become unnecessary when settings pages will read cfg.json directly
-  if (requestJSONBufferLock(6)) {
+  if (requestJSONBufferLock(6, false)) {
     // if we can't allocate JSON buffer ignore usermod pins
     JsonObject mods = pDoc->createNestedObject(F("um"));
     usermods.addToConfig(mods);


### PR DESCRIPTION
As for #3740, but on 0_15.

Switch WLED to use the willmmiles fork of AsyncWebServer, with the following improvements:

- Merge some open PRs from upstream
- Fix longstanding use-after-free in AsyncWebServerRequest::_removeNotInterestingHeaders
- Move many static strings to PROGMEM, reducing RAM usage by ~1k
- Add a simple response queue, reducing peak RAM usage
   -  Note: this is not a hard limit unfortunately - memory usage is still unbounded with a SYM flood or large POST, as I have yet to find a practical solution to throttle inbound traffic.
- Some small reductions in allocator usage during operation

This should be considered an alpha-quality work in progress; I'm offering it here for early testing and feedback.  Version number is not pinned yet.