### PR TITLE
Allow product information to be specified at build time

### DIFF
--- a/usermods/BH1750_v2/usermod_bh1750.h
+++ b/usermods/BH1750_v2/usermod_bh1750.h
@@ -98,8 +98,8 @@ private:
     JsonObject device = doc.createNestedObject(F("device")); // attach the sensor to the same device
     device[F("name")] = serverDescription;
     device[F("identifiers")] = "wled-sensor-" + String(mqttClientID);
-    device[F("manufacturer")] = F("WLED");
-    device[F("model")] = F("FOSS");
+    device[F("manufacturer")] = F(WLED_BRAND);
+    device[F("model")] = F(WLED_PRODUCT_NAME);
     device[F("sw_version")] = versionString;
 
     String temp;

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -160,8 +160,8 @@ private:
     JsonObject device = doc.createNestedObject(F("device")); // attach the sensor to the same device
     device[F("name")] = serverDescription;
     device[F("identifiers")] = "wled-sensor-" + String(mqttClientID);
-    device[F("manufacturer")] = F("WLED");
-    device[F("model")] = F("FOSS");
+    device[F("manufacturer")] = F(WLED_BRAND);
+    device[F("model")] = F(WLED_PRODUCT_NAME);
     device[F("sw_version")] = versionString;
 
     String temp;

--- a/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
+++ b/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
@@ -312,8 +312,8 @@ void PIRsensorSwitch::publishHomeAssistantAutodiscovery()
     JsonObject device = doc.createNestedObject(F("device")); // attach the sensor to the same device
     device[F("name")] = serverDescription;
     device[F("ids")]  = String(F("wled-sensor-")) + mqttClientID;
-    device[F("mf")]   = "WLED";
-    device[F("mdl")]  = F("FOSS");
+    device[F("mf")]   = F(WLED_BRAND);
+    device[F("mdl")]  = F(WLED_PRODUCT_NAME);
     device[F("sw")]   = versionString;
     
     sprintf_P(buf, PSTR("homeassistant/binary_sensor/%s/config"), uid);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -799,8 +799,8 @@ void serializeInfo(JsonObject root)
   #endif
   root[F("opt")] = os;
 
-  root[F("brand")] = "WLED";
-  root[F("product")] = F("FOSS");
+  root[F("brand")] = F(WLED_BRAND);
+  root[F("product")] = F(WLED_PRODUCT_NAME);
   root["mac"] = escapedMac;
   char s[16] = "";
   if (Network.isConnected())

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -10,6 +10,24 @@
 // version code in format yymmddb (b = daily build)
 #define VERSION 2402060
 
+// You can define custom product info from build flags.
+// This is useful to allow API consumer to identify what type of WLED version
+// they are interacting with. Be aware that changing this might cause some third
+// party API consumers to consider this as a non-WLED device since the values
+// returned by the API and by MQTT will no longer be default. However, most
+// third party only uses mDNS to validate, so this is generally fine to change.
+// For example, Home Assistant will still work fine even with this value changed.
+// Use like this:
+// -D WLED_BRAND="\"Custom Brand\""
+// -D WLED_PRODUCT_NAME="\"Custom Product\""
+#ifndef WLED_BRAND
+  #define WLED_BRAND "WLED"
+#endif
+#ifndef WLED_PRODUCT_NAME
+  #define WLED_PRODUCT_NAME "FOSS"
+#endif
+
+
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG
 


### PR DESCRIPTION
This allow people who make custom builds of WLED (Ex: QuinLED) to specify the details about the product at build time rather than having it hardcoded. The default values of WLED are unchanged.

This is similar to https://github.com/Aircoookie/WLED/pull/3407 and has a similar end goal.

This was originally in https://github.com/Aircoookie/WLED/pull/3441 but it was closed due to the target branch being deleted.