### PR TITLE
Effect: modified KITT (Scanner)

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -187,7 +187,7 @@
 #define FX_MODE_LIGHTNING               57
 #define FX_MODE_ICU                     58
 #define FX_MODE_MULTI_COMET             59
-#define FX_MODE_DUAL_LARSON_SCANNER     60
+#define FX_MODE_DUAL_LARSON_SCANNER     60  // candidate for removal (use Scanner with with check 1)
 #define FX_MODE_RANDOM_CHASE            61
 #define FX_MODE_OSCILLATE               62
 #define FX_MODE_PRIDE_2015              63


### PR DESCRIPTION
- add delay
- add dual checkmark
- rename Fade rate to Trail (inverse)
- makes Scanner Dual obsolete

Alternative to #3756. Handles long strips better and uses predictable speed. Adds option to have delay on both sides of scan.