### PR TITLE
Switch AsyncWebServer to willmmiles/2.1.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -144,7 +144,7 @@ lib_deps =
     fastled/FastLED @ 3.6.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.7.5
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.7
+    https://github.com/willmmiles/ESPAsyncWebServer.git @ 2.1.0
   # for I2C interface
     ;Wire
   # ESP-NOW library


### PR DESCRIPTION
This brings in a number of key bug fixes:
- Merging several upstream PRs
- Fix for use-after-free in web server response handling
- Fix for memory corruption in web sockets
- Fix for memory leaking in web sockets