### PR TITLE
Fix preset sorting

### DIFF
--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -133,7 +133,7 @@
 		<p class="labels hd" id="pall"><i class="icons sel-icon" onclick="tglHex()">&#xe2b3;</i> Color palette</p>
 		<div id="palw" class="il">
 			<div class="staytop fnd">
-				<input type="text" placeholder="Search" oninput="search(this,'pallist')" onfocus="search(this,'pallist')" />
+				<input type="text" placeholder="Search" oninput="search(this,'pallist')" />
 				<i class="icons clear-icon" onclick="clean(this)">&#xe38f;</i>
 				<i class="icons search-icon">&#xe0a1;</i>
 			</div>
@@ -155,7 +155,7 @@
 		<div id="fx">
 			<p class="labels hd" id="modeLabel">Effect mode</p>
 			<div class="staytop fnd" id="fxFind" onmousedown="preventBlur(event);">
-				<input type="text" placeholder="Search" oninput="search(this,'fxlist')" onfocus="filterFocus(event);search(this,'fxlist');" onblur="filterFocus(event);">
+				<input type="text" placeholder="Search" oninput="search(this,'fxlist')" onfocus="filterFocus(event);" onblur="filterFocus(event);">
 				<i class="icons clear-icon" onclick="clean(this);">&#xe38f;</i>
 				<i class="icons search-icon" style="cursor:pointer;">&#xe0a1;</i>
 				<div id="filters" class="filter fade">
@@ -274,7 +274,7 @@
 		</div>
 		<p class="labels hd">Presets</p>
 		<div class="staytop fnd" id="psFind">
-			<input type="text" placeholder="Search" oninput="search(this,'pcont')" onfocus="search(this,'pcont')" />
+			<input type="text" placeholder="Search" oninput="search(this,'pcont')" />
 			<i class="icons clear-icon" onclick="clean(this);">&#xe38f;</i>
 			<i class="icons search-icon">&#xe0a1;</i>
 		</div>

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -133,7 +133,7 @@
 		<p class="labels hd" id="pall"><i class="icons sel-icon" onclick="tglHex()">&#xe2b3;</i> Color palette</p>
 		<div id="palw" class="il">
 			<div class="staytop fnd">
-				<input type="text" placeholder="Search" oninput="search(this,'pallist')" />
+				<input type="text" placeholder="Search" oninput="search(this,'pallist')" onfocus="search(this,'pallist')" />
 				<i class="icons clear-icon" onclick="clean(this)">&#xe38f;</i>
 				<i class="icons search-icon">&#xe0a1;</i>
 			</div>
@@ -155,7 +155,7 @@
 		<div id="fx">
 			<p class="labels hd" id="modeLabel">Effect mode</p>
 			<div class="staytop fnd" id="fxFind" onmousedown="preventBlur(event);">
-				<input type="text" placeholder="Search" oninput="search(this,'fxlist')" onfocus="filterFocus(event);" onblur="filterFocus(event);">
+				<input type="text" placeholder="Search" oninput="search(this,'fxlist')" onfocus="filterFocus(event);search(this,'fxlist');" onblur="filterFocus(event);">
 				<i class="icons clear-icon" onclick="clean(this);">&#xe38f;</i>
 				<i class="icons search-icon" style="cursor:pointer;">&#xe0a1;</i>
 				<div id="filters" class="filter fade">
@@ -274,7 +274,7 @@
 		</div>
 		<p class="labels hd">Presets</p>
 		<div class="staytop fnd" id="psFind">
-			<input type="text" placeholder="Search" oninput="search(this,'pcont')" />
+			<input type="text" placeholder="Search" oninput="search(this,'pcont')" onfocus="search(this,'pcont')" />
 			<i class="icons clear-icon" onclick="clean(this);">&#xe38f;</i>
 			<i class="icons search-icon">&#xe0a1;</i>
 		</div>

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -2795,6 +2795,12 @@ function search(field, listId = null) {
 
 	const search = field.value !== '';
 
+	// restore default preset sorting if no search term is entered
+	if (listId === 'pcont' && !search) {
+		populatePresets();
+		return;
+	}
+
 	// clear filter if searching in fxlist
 	if (listId === 'fxlist' && search) {
 		gId("filters").querySelectorAll("input[type=checkbox]").forEach((e) => { e.checked = false; });

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -2794,7 +2794,6 @@ function search(field, listId = null) {
 	if (!listId) return;
 
 	const search = field.value !== '';
-	const presets = listId === 'pcont';
 
 	// clear filter if searching in fxlist
 	if (listId === 'fxlist' && search) {
@@ -2806,7 +2805,7 @@ function search(field, listId = null) {
 
 	const listItems = gId(listId).querySelectorAll('.lstI');
 	// filter list items but leave (Default & Solid) always visible
-	for (i = (presets ? 0 : 1); i < listItems.length; i++) {
+	for (i = (listId === 'pcont' ? 0 : 1); i < listItems.length; i++) {
 		const listItem = listItems[i];
 		const listItemName = listItem.querySelector('.lstIname').innerText.toUpperCase();
 		const searchIndex = listItemName.indexOf(field.value.toUpperCase());
@@ -2814,30 +2813,28 @@ function search(field, listId = null) {
 		listItem.dataset.searchIndex = searchIndex;
 	}
 
-	if (!presets) {
-		// sort list items by search index and name
-		const sortedListItems = Array.from(listItems).sort((a, b) => {
-			const aSearchIndex = parseInt(a.dataset.searchIndex);
-			const bSearchIndex = parseInt(b.dataset.searchIndex);
+	// sort list items by search index and name
+	const sortedListItems = Array.from(listItems).sort((a, b) => {
+		const aSearchIndex = parseInt(a.dataset.searchIndex);
+		const bSearchIndex = parseInt(b.dataset.searchIndex);
 
-			if (aSearchIndex !== bSearchIndex) {
-				return aSearchIndex - bSearchIndex;
-			}
-
-			const aName = a.querySelector('.lstIname').innerText.toUpperCase();
-			const bName = b.querySelector('.lstIname').innerText.toUpperCase();
-
-			return aName.localeCompare(bName);
-		});
-		sortedListItems.forEach(item => {
-			gId(listId).append(item);
-		});
-
-		// scroll to first search result
-		const firstVisibleItem = sortedListItems.find(item => item.style.display !== 'none' && !item.classList.contains('sticky') && !item.classList.contains('selected'));
-		if (firstVisibleItem && search) {
-			firstVisibleItem.scrollIntoView({ behavior: "instant", block: "center" });
+		if (aSearchIndex !== bSearchIndex) {
+			return aSearchIndex - bSearchIndex;
 		}
+
+		const aName = a.querySelector('.lstIname').innerText.toUpperCase();
+		const bName = b.querySelector('.lstIname').innerText.toUpperCase();
+
+		return aName.localeCompare(bName);
+	});
+	sortedListItems.forEach(item => {
+		gId(listId).append(item);
+	});
+
+	// scroll to first search result
+	const firstVisibleItem = sortedListItems.find(item => item.style.display !== 'none' && !item.classList.contains('sticky') && !item.classList.contains('selected'));
+	if (firstVisibleItem && search) {
+		firstVisibleItem.scrollIntoView({ behavior: "instant", block: "center" });
 	}
 }
 


### PR DESCRIPTION
This also adds the _better search_ for presets without the bug that the elements get reordered when you click on the search field.

| Before | Now |
|--------|--------|
| ![grafik](https://github.com/Aircoookie/WLED/assets/27882680/8c90dbd1-5788-4d04-bdcc-42953fab000a) | ![grafik](https://github.com/Aircoookie/WLED/assets/27882680/b5f223f6-52cc-4103-9aa8-ebba5d596a37)| 