### PR TITLE
Pin ArduinoFFT version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -172,7 +172,7 @@ lib_deps =
   # SHT85
     ;robtillaart/SHT85@~0.3.3
   # Audioreactive usermod
-    ;https://github.com/kosme/arduinoFFT#develop @ ^1.9.2
+    ;https://github.com/kosme/arduinoFFT#419d7b04 @ ^1.9.2
 
 extra_scripts = ${scripts_defaults.extra_scripts}
 
@@ -223,7 +223,7 @@ lib_deps =
   ${env.lib_deps}
 # additional build flags for audioreactive
 AR_build_flags = -D USERMOD_AUDIOREACTIVE -D UM_AUDIOREACTIVE_USE_NEW_FFT
-AR_lib_deps = https://github.com/kosme/arduinoFFT#develop @ ^1.9.2
+AR_lib_deps = https://github.com/kosme/arduinoFFT#419d7b04 @ ^1.9.2
 
 [esp32_idf_V4]
 ;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5


### PR DESCRIPTION
The upstream repository has updated the develop branch to v2.0 which is not API compatible.  Pin the last commit before the new version was merged.