### PR TITLE
fix the 2d drift animation

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5011,14 +5011,17 @@ uint16_t mode_2DDrift() {              // By: Stepko   https://editor.soulmateli
   const uint16_t cols = SEGMENT.virtualWidth();
   const uint16_t rows = SEGMENT.virtualHeight();
 
+  const uint16_t colsCenter = (cols>>1) + (cols%2);
+  const uint16_t rowsCenter = (rows>>1) + (rows%2);
+
   SEGMENT.fadeToBlackBy(128);
   const uint16_t maxDim = MAX(cols, rows)/2;
   unsigned long t = strip.now / (32 - (SEGMENT.speed>>3));
   unsigned long t_20 = t/20; // softhack007: pre-calculating this gives about 10% speedup
   for (float i = 1; i < maxDim; i += 0.25) {
     float angle = radians(t * (maxDim - i));
-    uint16_t myX = (cols>>1) + (uint16_t)(sin_t(angle) * i) + (cols%2);
-    uint16_t myY = (rows>>1) + (uint16_t)(cos_t(angle) * i) + (rows%2);
+    uint16_t myX = colsCenter + (sin_t(angle) * i);
+    uint16_t myY = rowsCenter + (cos_t(angle) * i);
     SEGMENT.setPixelColorXY(myX, myY, ColorFromPalette(SEGPALETTE, (i * 20) + t_20, 255, LINEARBLEND));
   }
   SEGMENT.blur(SEGMENT.intensity>>3);


### PR DESCRIPTION
Fix a wrong cast that broke the 2D drift animation, add a small optimization to the loop.

close #3814 