### PR TITLE
getSettingsJS: Fix missing DISABLE_INFRARED guard

### DIFF
--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -471,8 +471,10 @@ void getSettingsJS(byte subPage, char* dest)
     }
     sappend('c',SET_F("IP"),disablePullUp);
     sappend('v',SET_F("TT"),touchThreshold);
+#ifndef WLED_DISABLE_INFRARED
     sappend('v',SET_F("IR"),irPin);
     sappend('v',SET_F("IT"),irEnabled);
+#endif    
     sappend('c',SET_F("MSO"),!irApplyToAllSelected);
   }
 


### PR DESCRIPTION
Fix a missing `#ifndef WLED_DISABLE_INFRARED` in getSettingsJS() -- we don't have `irPin` or `irEnabled` with it.