### PR TITLE
Fix avgLoopMillis

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -269,6 +269,7 @@ void WLED::loop()
     maxLoopMillis = 0;
     maxUsermodMillis = 0;
     maxStripMillis = 0;
+    avgLoopMillis = 0;
     avgUsermodMillis = 0;
     avgStripMillis = 0;
     debugTime = millis();


### PR DESCRIPTION
The avgLoopMillis counter wasn't getting reset, so it grew continuously until overflow.  Reset it like the other counters.

