### PR TITLE
Add SSD1309_64 I2C Support for FLD Usermod

### DIFF
--- a/usermods/usermod_v2_four_line_display_ALT/readme.md
+++ b/usermods/usermod_v2_four_line_display_ALT/readme.md
@@ -1,4 +1,4 @@
-# I2C 4 Line Display Usermod ALT
+# I2C/SPI 4 Line Display Usermod ALT
 
 Thank you to the authors of the original version of these usermods. It would not have been possible without them!
 "usermod_v2_four_line_display"
@@ -8,21 +8,20 @@ The core of these usermods are a copy of the originals. The main changes are to 
 The display usermod UI has been completely changed.
 
 
-The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod. 
-Without the display it, functions identical to the original.
+The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod.
+Without the display, it functions identical to the original.
 The original "usermod_v2_auto_save" will not work with the display just yet.
 
 Press the encoder to cycle through the options:
-    *Brightness
-    *Speed
-    *Intensity
-    *Palette
-    *Effect
-    *Main Color (only if display is used)
-    *Saturation (only if display is used)
+* Brightness
+* Speed
+* Intensity
+* Palette
+* Effect
+* Main Color (only if display is used)
+* Saturation (only if display is used)
 
-Press and hold the encoder to display Network Info
-    if AP is active, it will display AP, SSID and password
+Press and hold the encoder to display Network Info. If AP is active, it will display AP, SSID and password
 
 Also shows if the timer is enabled
 
@@ -30,9 +29,45 @@ Also shows if the timer is enabled
 
 ## Installation
 
-Please refer to the original `usermod_v2_rotary_encoder_ui` readme for the main instructions
-Then to activate this alternative usermod add `#define USE_ALT_DISPlAY` to the `usermods_list.cpp` file,
+Please refer to the original `usermod_v2_rotary_encoder_ui` readme for the main instructions.
+
+Copy the example `platformio_override.sample.ini` from the usermod_v2_rotary_encoder_ui_ALT folder to the root directory of your particular build and rename it to `platformio_override.ini`.
+
+This file should be placed in the same directory as `platformio.ini`.
+
+Then, to activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE SENSITIVE) to the `usermods_list.cpp` file,
                                         or add `-D USE_ALT_DISPlAY` to the original `platformio_override.ini.sample` file
+
+
+## Configuration
+
+These options are configurable in Config > Usermods
+
+### Usermod Setup
+
+* Global I2C GPIOs (HW) - Set the SDA and SCL pins
+
+### 4LineDisplay
+
+* `enabled` - enable/disable usermod
+* `type` - display type in numeric format
+    * 1 = I2C SSD1306 128x32
+    * 2 = I2C SH1106 128x32
+    * 3 = I2C SSD1306 128x64 (4 double-height lines)
+    * 4 = I2C SSD1305 128x32
+    * 5 = I2C SSD1305 128x64 (4 double-height lines)
+    * 6 = I2C SSD1309 128x64 (4 double-height lines)
+    * 7 = SPI SSD1306 128x32
+    * 8 = SPI SSD1306 128x64 (4 double-height lines)
+    * 9 = SPI SSD1309 128x64 (4 double-height lines)
+* `pin` - GPIO pins used for display; SPI displays can use SCK, MOSI, CS, DC & RST
+* `flip` - flip/rotate display 180°
+* `contrast` - set display contrast (higher contrast may reduce display lifetime)
+* `screenTimeOutSec` - screen saver time-out in seconds
+* `sleepMode` - enable/disable screen saver
+* `clockMode` - enable/disable clock display in screen saver mode
+* `showSeconds` - Show seconds on the clock display
+* `i2c-freq-kHz` - I2C clock frequency in kHz (may help reduce dropped frames, range: 400-3400)
 
 
 ### PlatformIO requirements

--- a/usermods/usermod_v2_four_line_display_ALT/readme.md
+++ b/usermods/usermod_v2_four_line_display_ALT/readme.md
@@ -56,10 +56,10 @@ These options are configurable in Config > Usermods
     * 3 = I2C SSD1306 128x64 (4 double-height lines)
     * 4 = I2C SSD1305 128x32
     * 5 = I2C SSD1305 128x64 (4 double-height lines)
-    * 6 = I2C SSD1309 128x64 (4 double-height lines)
-    * 7 = SPI SSD1306 128x32
-    * 8 = SPI SSD1306 128x64 (4 double-height lines)
-    * 9 = SPI SSD1309 128x64 (4 double-height lines)
+    * 6 = SPI SSD1306 128x32
+    * 7 = SPI SSD1306 128x64 (4 double-height lines)
+    * 8 = SPI SSD1309 128x64 (4 double-height lines)
+    * 9 = I2C SSD1309 128x64 (4 double-height lines)
 * `pin` - GPIO pins used for display; SPI displays can use SCK, MOSI, CS, DC & RST
 * `flip` - flip/rotate display 180°
 * `contrast` - set display contrast (higher contrast may reduce display lifetime)

--- a/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
+++ b/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
@@ -87,10 +87,10 @@ typedef enum {
   SSD1306_64,       // U8X8_SSD1306_128X64_NONAME_HW_I2C
   SSD1305,          // U8X8_SSD1305_128X32_ADAFRUIT_HW_I2C
   SSD1305_64,       // U8X8_SSD1305_128X64_ADAFRUIT_HW_I2C
-  SSD1309_64,       // U8X8_SSD1309_128X64_NONAME0_HW_I2C
   SSD1306_SPI,      // U8X8_SSD1306_128X32_NONAME_HW_SPI
   SSD1306_SPI64,    // U8X8_SSD1306_128X64_NONAME_HW_SPI
-  SSD1309_SPI64     // U8X8_SSD1309_128X64_NONAME0_4W_HW_SPI
+  SSD1309_SPI64,    // U8X8_SSD1309_128X64_NONAME0_4W_HW_SPI
+  SSD1309_64        // U8X8_SSD1309_128X64_NONAME0_HW_I2C
 } DisplayType;
 
 
@@ -1207,10 +1207,10 @@ void FourLineDisplayUsermod::appendConfigData() {
   oappend(SET_F("addOption(dd,'SSD1306 128x64',3);"));
   oappend(SET_F("addOption(dd,'SSD1305',4);"));
   oappend(SET_F("addOption(dd,'SSD1305 128x64',5);"));
-  oappend(SET_F("addOption(dd,'SSD1309 128x64',6);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI',7);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI 128x64',8);"));
-  oappend(SET_F("addOption(dd,'SSD1309 SPI 128x64',9);"));
+  oappend(SET_F("addOption(dd,'SSD1309 128x64',9);"));
+  oappend(SET_F("addOption(dd,'SSD1306 SPI',6);"));
+  oappend(SET_F("addOption(dd,'SSD1306 SPI 128x64',7);"));
+  oappend(SET_F("addOption(dd,'SSD1309 SPI 128x64',8);"));
   oappend(SET_F("addInfo('4LineDisplay:type',1,'<br><i class=\"warn\">Change may require reboot</i>','');"));
   oappend(SET_F("addInfo('4LineDisplay:pin[]',0,'','SPI CS');"));
   oappend(SET_F("addInfo('4LineDisplay:pin[]',1,'','SPI DC');"));

--- a/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
+++ b/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
@@ -17,7 +17,7 @@
 // for WLED.
 //
 // Dependencies
-// * This Usermod works best, by far, when coupled 
+// * This Usermod works best, by far, when coupled
 //   with RotaryEncoderUI ALT Usermod.
 //
 // Make sure to enable NTP and set your time zone in WLED Config | Time.
@@ -87,6 +87,7 @@ typedef enum {
   SSD1306_64,       // U8X8_SSD1306_128X64_NONAME_HW_I2C
   SSD1305,          // U8X8_SSD1305_128X32_ADAFRUIT_HW_I2C
   SSD1305_64,       // U8X8_SSD1305_128X64_ADAFRUIT_HW_I2C
+  SSD1309_64,       // U8X8_SSD1309_128X64_NONAME0_HW_I2C
   SSD1306_SPI,      // U8X8_SSD1306_128X32_NONAME_HW_SPI
   SSD1306_SPI64,    // U8X8_SSD1306_128X64_NONAME_HW_SPI
   SSD1309_SPI64     // U8X8_SSD1309_128X64_NONAME0_4W_HW_SPI
@@ -235,7 +236,7 @@ class FourLineDisplayUsermod : public Usermod {
     void updateSpeed();
     void updateIntensity();
     void drawStatusIcons();
-    
+
     /**
      * marks the position of the arrow showing
      * the current setting being changed
@@ -246,8 +247,8 @@ class FourLineDisplayUsermod : public Usermod {
     //Draw the arrow for the current setting being changed
     void drawArrow();
 
-    //Display the current effect or palette (desiredEntry) 
-    // on the appropriate line (row). 
+    //Display the current effect or palette (desiredEntry)
+    // on the appropriate line (row).
     void showCurrentEffectOrPalette(int inputEffPal, const char *qstring, uint8_t row);
 
     /**
@@ -314,14 +315,14 @@ class FourLineDisplayUsermod : public Usermod {
      * addToConfig() can be used to add custom persistent settings to the cfg.json file in the "um" (usermod) object.
      * It will be called by WLED when settings are actually saved (for example, LED settings are saved)
      * If you want to force saving the current state, use serializeConfig() in your loop().
-     * 
+     *
      * CAUTION: serializeConfig() will initiate a filesystem write operation.
      * It might cause the LEDs to stutter and will cause flash wear if called too often.
      * Use it sparingly and always in the loop, never in network callbacks!
-     * 
+     *
      * addToConfig() will also not yet add your setting to one of the settings pages automatically.
      * To make that work you still have to add the setting to the HTML, xml.cpp and set.cpp manually.
-     * 
+     *
      * I highly recommend checking out the basics of ArduinoJson serialization and deserialization in order to use custom settings!
      */
     void addToConfig(JsonObject& root) override;
@@ -329,7 +330,7 @@ class FourLineDisplayUsermod : public Usermod {
     /*
      * readFromConfig() can be used to read back the custom settings you added with addToConfig().
      * This is called by WLED when settings are loaded (currently this only happens once immediately after boot)
-     * 
+     *
      * readFromConfig() is called BEFORE setup(). This means you can use your persistent values in setup() (e.g. pin assignments, buffer sizes),
      * but also that if you want to write persistent values to a dynamic buffer, you'd need to allocate it here instead of in setup.
      * If you don't know what that is, don't fret. It most likely doesn't affect your use case :)
@@ -494,7 +495,7 @@ void FourLineDisplayUsermod::showTime() {
     }
     if (knownHour != hourCurrent) {
       // only update date when hour changes
-      sprintf_P(lineBuffer, PSTR("%s %2d "), monthShortStr(month(localTime)), day(localTime)); 
+      sprintf_P(lineBuffer, PSTR("%s %2d "), monthShortStr(month(localTime)), day(localTime));
       draw2x2String(2, lineHeight==1 ? 0 : lineHeight, lineBuffer); // adjust for 8 line displays, draw month and day
     }
     sprintf_P(lineBuffer,PSTR("%2d:%02d"), (useAMPM ? AmPmHour : hourCurrent), minuteCurrent);
@@ -556,6 +557,7 @@ void FourLineDisplayUsermod::setup() {
     case SSD1306_64:    u8x8 = (U8X8 *) new U8X8_SSD1306_128X64_NONAME_HW_I2C();    break;
     case SSD1305:       u8x8 = (U8X8 *) new U8X8_SSD1305_128X32_ADAFRUIT_HW_I2C();  break;
     case SSD1305_64:    u8x8 = (U8X8 *) new U8X8_SSD1305_128X64_ADAFRUIT_HW_I2C();  break;
+    case SSD1309_64:    u8x8 = (U8X8 *) new U8X8_SSD1309_128X64_NONAME0_HW_I2C();   break;
     // U8X8 uses global SPI variable that is attached to VSPI bus on ESP32
     case SSD1306_SPI:   u8x8 = (U8X8 *) new U8X8_SSD1306_128X32_UNIVISION_4W_HW_SPI(ioPin[0], ioPin[1], ioPin[2]); break; // Pins are cs, dc, reset
     case SSD1306_SPI64: u8x8 = (U8X8 *) new U8X8_SSD1306_128X64_NONAME_4W_HW_SPI(ioPin[0], ioPin[1], ioPin[2]);    break; // Pins are cs, dc, reset
@@ -581,7 +583,7 @@ void FourLineDisplayUsermod::setup() {
 // gets called every time WiFi is (re-)connected. Initialize own network
 // interfaces here
 void FourLineDisplayUsermod::connected() {
-  knownSsid = WiFi.SSID();       //apActive ? apSSID : WiFi.SSID(); //apActive ? WiFi.softAPSSID() : 
+  knownSsid = WiFi.SSID();       //apActive ? apSSID : WiFi.SSID(); //apActive ? WiFi.softAPSSID() :
   knownIp   = Network.localIP(); //apActive ? IPAddress(4, 3, 2, 1) : Network.localIP();
   networkOverlay(PSTR("NETWORK INFO"),7000);
 }
@@ -637,7 +639,7 @@ void FourLineDisplayUsermod::redraw(bool forceRedraw) {
     powerON = !powerON;
     drawStatusIcons();
     return;
-  } else if (knownnightlight != nightlightActive) {   //trigger moon icon 
+  } else if (knownnightlight != nightlightActive) {   //trigger moon icon
     knownnightlight = nightlightActive;
     drawStatusIcons();
     if (knownnightlight) {
@@ -652,7 +654,7 @@ void FourLineDisplayUsermod::redraw(bool forceRedraw) {
     return;
   } else if (knownMode != effectCurrent || knownPalette != effectPalette) {
     if (displayTurnedOff) needRedraw = true;
-    else { 
+    else {
       if (knownPalette != effectPalette) { showCurrentEffectOrPalette(effectPalette, JSON_palette_names, 2); knownPalette = effectPalette; }
       if (knownMode    != effectCurrent) { showCurrentEffectOrPalette(effectCurrent, JSON_mode_names, 3); knownMode = effectCurrent; }
       lastRedraw = now;
@@ -703,7 +705,7 @@ void FourLineDisplayUsermod::redraw(bool forceRedraw) {
   drawArrow();
   drawStatusIcons();
 
-  // Second row 
+  // Second row
   updateBrightness();
   updateSpeed();
   updateIntensity();
@@ -805,8 +807,8 @@ void FourLineDisplayUsermod::drawArrow() {
   lockRedraw = false;
 }
 
-//Display the current effect or palette (desiredEntry) 
-// on the appropriate line (row). 
+//Display the current effect or palette (desiredEntry)
+// on the appropriate line (row).
 void FourLineDisplayUsermod::showCurrentEffectOrPalette(int inputEffPal, const char *qstring, uint8_t row) {
 #if defined(ARDUINO_ARCH_ESP32) && defined(FLD_ESP32_USE_THREADS)
   unsigned long now = millis();
@@ -857,7 +859,7 @@ void FourLineDisplayUsermod::showCurrentEffectOrPalette(int inputEffPal, const c
         while (smallChars1 < (MAX_MODE_LINE_SPACE-1)) smallBuffer1[smallChars1++]=' ';
         smallBuffer1[smallChars1] = 0;
         drawString(1, row*lineHeight, smallBuffer1, true);
-        while (smallChars2 < (MAX_MODE_LINE_SPACE-1)) smallBuffer2[smallChars2++]=' '; 
+        while (smallChars2 < (MAX_MODE_LINE_SPACE-1)) smallBuffer2[smallChars2++]=' ';
         smallBuffer2[smallChars2] = 0;
         drawString(1, row*lineHeight+1, smallBuffer2, true);
       }
@@ -1150,7 +1152,7 @@ void FourLineDisplayUsermod::onUpdateBegin(bool init) {
       xTaskCreatePinnedToCore(
         [](void * par) {                  // Function to implement the task
           // see https://www.freertos.org/vtaskdelayuntil.html
-          const TickType_t xFrequency = REFRESH_RATE_MS * portTICK_PERIOD_MS / 2;  
+          const TickType_t xFrequency = REFRESH_RATE_MS * portTICK_PERIOD_MS / 2;
           TickType_t xLastWakeTime = xTaskGetTickCount();
           for(;;) {
             delay(1); // DO NOT DELETE THIS LINE! It is needed to give the IDLE(0) task enough time and to keep the watchdog happy.
@@ -1205,9 +1207,10 @@ void FourLineDisplayUsermod::appendConfigData() {
   oappend(SET_F("addOption(dd,'SSD1306 128x64',3);"));
   oappend(SET_F("addOption(dd,'SSD1305',4);"));
   oappend(SET_F("addOption(dd,'SSD1305 128x64',5);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI',6);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI 128x64',7);"));
-  oappend(SET_F("addOption(dd,'SSD1309 SPI 128x64',8);"));
+  oappend(SET_F("addOption(dd,'SSD1309 128x64',6);"));
+  oappend(SET_F("addOption(dd,'SSD1306 SPI',7);"));
+  oappend(SET_F("addOption(dd,'SSD1306 SPI 128x64',8);"));
+  oappend(SET_F("addOption(dd,'SSD1309 SPI 128x64',9);"));
   oappend(SET_F("addInfo('4LineDisplay:type',1,'<br><i class=\"warn\">Change may require reboot</i>','');"));
   oappend(SET_F("addInfo('4LineDisplay:pin[]',0,'','SPI CS');"));
   oappend(SET_F("addInfo('4LineDisplay:pin[]',1,'','SPI DC');"));
@@ -1218,14 +1221,14 @@ void FourLineDisplayUsermod::appendConfigData() {
   * addToConfig() can be used to add custom persistent settings to the cfg.json file in the "um" (usermod) object.
   * It will be called by WLED when settings are actually saved (for example, LED settings are saved)
   * If you want to force saving the current state, use serializeConfig() in your loop().
-  * 
+  *
   * CAUTION: serializeConfig() will initiate a filesystem write operation.
   * It might cause the LEDs to stutter and will cause flash wear if called too often.
   * Use it sparingly and always in the loop, never in network callbacks!
-  * 
+  *
   * addToConfig() will also not yet add your setting to one of the settings pages automatically.
   * To make that work you still have to add the setting to the HTML, xml.cpp and set.cpp manually.
-  * 
+  *
   * I highly recommend checking out the basics of ArduinoJson serialization and deserialization in order to use custom settings!
   */
 void FourLineDisplayUsermod::addToConfig(JsonObject& root) {
@@ -1252,7 +1255,7 @@ void FourLineDisplayUsermod::addToConfig(JsonObject& root) {
 /*
   * readFromConfig() can be used to read back the custom settings you added with addToConfig().
   * This is called by WLED when settings are loaded (currently this only happens once immediately after boot)
-  * 
+  *
   * readFromConfig() is called BEFORE setup(). This means you can use your persistent values in setup() (e.g. pin assignments, buffer sizes),
   * but also that if you want to write persistent values to a dynamic buffer, you'd need to allocate it here instead of in setup.
   * If you don't know what that is, don't fret. It most likely doesn't affect your use case :)
@@ -1344,6 +1347,10 @@ bool FourLineDisplayUsermod::readFromConfig(JsonObject& root) {
           break;
         case SSD1305_64:
           u8x8_Setup(u8x8->getU8x8(), u8x8_d_ssd1305_128x64_adafruit, u8x8_cad_ssd13xx_fast_i2c, u8x8_byte_arduino_hw_i2c, u8x8_gpio_and_delay_arduino);
+          u8x8_SetPin_HW_I2C(u8x8->getU8x8(), U8X8_PIN_NONE, U8X8_PIN_NONE, U8X8_PIN_NONE);
+          break;
+        case SSD1309_64:
+          u8x8_Setup(u8x8->getU8x8(), u8x8_d_ssd1309_128x64_noname0, u8x8_cad_ssd13xx_fast_i2c, u8x8_byte_arduino_hw_i2c, u8x8_gpio_and_delay_arduino);
           u8x8_SetPin_HW_I2C(u8x8->getU8x8(), U8X8_PIN_NONE, U8X8_PIN_NONE, U8X8_PIN_NONE);
           break;
         case SSD1306_SPI:

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/platformio–override.sample.ini
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/platformio–override.sample.ini
@@ -1,0 +1,17 @@
+[platformio]
+default_envs = esp32dev
+
+[env:esp32dev]
+board = esp32dev
+platform = ${esp32.platform}
+build_unflags = ${common.build_unflags}
+build_flags =
+    ${common.build_flags_esp32}
+    -D USERMOD_FOUR_LINE_DISPLAY -D USE_ALT_DISPlAY
+    -D USERMOD_ROTARY_ENCODER_UI -D ENCODER_DT_PIN=18 -D ENCODER_CLK_PIN=5 -D ENCODER_SW_PIN=19
+upload_speed = 460800
+lib_deps =
+    ${esp32.lib_deps}
+    U8g2@~2.34.4
+    Wire
+

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/readme.md
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/readme.md
@@ -8,18 +8,18 @@ The core of these usermods are a copy of the originals. The main changes are to 
 The display usermod UI has been completely changed.
 
 
-The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod. 
+The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod.
 Without the display, it functions identical to the original.
 The original "usermod_v2_auto_save" will not work with the display just yet.
 
 Press the encoder to cycle through the options:
-    *Brightness
-    *Speed
-    *Intensity
-    *Palette
-    *Effect
-    *Main Color (only if display is used)
-    *Saturation (only if display is used)
+* Brightness
+* Speed
+* Intensity
+* Palette
+* Effect
+* Main Color (only if display is used)
+* Saturation (only if display is used)
 
 Press and hold the encoder to display Network Info
     if AP is active, it will display the AP, SSID and Password
@@ -30,10 +30,23 @@ Also shows if the timer is enabled.
 
 ## Installation
 
-Please refer to the original `usermod_v2_rotary_encoder_ui` readme for the main instructions.<br/>
-To activate this alternative usermod, add `#define USE_ALT_DISPlAY` to the `usermods_list.cpp` file,
-or add `-D USE_ALT_DISPlAY` to the original `platformio_override.ini.sample` file.
+Copy the example `platformio_override.sample.ini` to the root directory of your particular build and rename it to `platformio_override.ini`.
 
+To activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE SENSITIVE) to the `usermods_list.cpp` file, or add `-D USE_ALT_DISPlAY` to your `platformio_override.ini` file
+
+### Define Your Options
+
+* `USERMOD_ROTARY_ENCODER_UI`       - define this to have this user mod included wled00\usermods_list.cpp
+* `USERMOD_FOUR_LINE_DISPLAY`       - define this to have this the Four Line Display mod included wled00\usermods_list.cpp
+                                        also tells this usermod that the display is available
+                                        (see the Four Line Display usermod `readme.md` for more details)
+* `USE_ALT_DISPlAY`                 - Mandatory to use Four Line Display
+* `ENCODER_DT_PIN`                  - defaults to 18
+* `ENCODER_CLK_PIN`                 - defaults to 5
+* `ENCODER_SW_PIN`                  - defaults to 19
+* `USERMOD_ROTARY_ENCODER_GPIO`     - GPIO functionality:
+                                        `INPUT_PULLUP` to use internal pull-up
+                                        `INPUT` to use pull-up on the PCB
 
 ### PlatformIO requirements
 

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -265,8 +265,8 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
     } else return 0;
   }
 
-  if (src == JSON_palette_names && mode > GRADIENT_PALETTE_COUNT) {
-    snprintf_P(dest, maxLen, PSTR("~ Custom %d~"), 255-mode);
+  if (src == JSON_palette_names && mode > (GRADIENT_PALETTE_COUNT + 13)) {
+    snprintf_P(dest, maxLen, PSTR("~ Custom %d ~"), 255-mode);
     dest[maxLen-1] = '\0';
     return strlen(dest);
   }


### PR DESCRIPTION
Adds support for SSD1309_64 I2C display to the FLD Usermod.

Fixes an issue where palettes with an ID > 58 but not a custom palette did not display the palette name on the display.

There are quite a bit of whitespace diffs caused by trailing spaces being removed before commit.