### PR TITLE
Use product name to identify OTA-compatible releases

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,10 @@
 # CI/release binaries
 default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3_4M_PSRAM_qspi, esp32_wrover
 
+# Note that the combination of WLED_BRAND_NAME, WLED_PRODUCT_NAME and ESP architecture
+# (JSON API info fields: "brand", "product", "arch") must identify OTA-compatible official releases.
+# This may be used by third-party tools to automate identifying and applying OTA updates.
+
 src_dir  = ./wled00
 data_dir = ./wled00/data
 build_cache_dir = ~/.buildcache
@@ -311,14 +315,14 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266 #-DWLED_DISABLE_2D
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266 -D WLED_PRODUCT_NAME=FOSS #-DWLED_DISABLE_2D
 lib_deps = ${esp8266.lib_deps}
 monitor_filters = esp8266_exception_decoder
 
 [env:nodemcuv2_160]
 extends = env:nodemcuv2
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266_160 #-DWLED_DISABLE_2D
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266_160 -D WLED_PRODUCT_NAME=FOSS_OC #-DWLED_DISABLE_2D
 
 [env:esp8266_2m]
 board = esp_wroom_02
@@ -326,13 +330,13 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02 -D WLED_PRODUCT_NAME=FOSS
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp8266_2m_160]
 extends = env:esp8266_2m
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02_160
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02_160 -D WLED_PRODUCT_NAME=FOSS_OC
 
 [env:esp01_1m_full]
 board = esp01_1m
@@ -340,14 +344,14 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01 -D WLED_DISABLE_OTA
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01 -D WLED_PRODUCT_NAME=FOSS -D WLED_DISABLE_OTA
   ; -D WLED_USE_UNREAL_MATH ;; may cause wrong sunset/sunrise times, but saves 7064 bytes FLASH and 975 bytes RAM
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp01_1m_full_160]
 extends = env:esp01_1m_full
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01_160 -D WLED_DISABLE_OTA
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01_160 -D WLED_PRODUCT_NAME=FOSS_OC -D WLED_DISABLE_OTA
   ; -D WLED_USE_UNREAL_MATH ;; may cause wrong sunset/sunrise times, but saves 7064 bytes FLASH and 975 bytes RAM
 
 [env:esp32dev]
@@ -355,7 +359,7 @@ board = esp32dev
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 #-D WLED_DISABLE_BROWNOUT_DET
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 -D WLED_PRODUCT_NAME=FOSS #-D WLED_DISABLE_BROWNOUT_DET
 lib_deps = ${esp32.lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
@@ -365,7 +369,7 @@ board = esp32dev
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_audioreactive #-D WLED_DISABLE_BROWNOUT_DET
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_audioreactive -D WLED_PRODUCT_NAME=FOSS_AR #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
 lib_deps = ${esp32.lib_deps}
   ${esp32.AR_lib_deps}
@@ -380,7 +384,7 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D WLED_PRODUCT_NAME=FOSS_Eth -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
 lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
@@ -392,7 +396,7 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = tools/WLED_ESP32-wrover_4MB.csv
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER -D WLED_PRODUCT_NAME=FOSS_PSRAM
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
   -D LEDPIN=25
 lib_deps = ${esp32.lib_deps}
@@ -404,7 +408,7 @@ platform_packages = ${esp32c3.platform_packages}
 framework = arduino
 board = esp32-c3-devkitm-1
 board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
-build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3
+build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3 -D WLED_PRODUCT_NAME=FOSS
   -D WLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
@@ -420,7 +424,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600 ; or  460800
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB -D WLED_PRODUCT_NAME=FOSS
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   ;-D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1 ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -441,7 +445,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB_PSRAM_opi
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB_PSRAM_opi -D WLED_PRODUCT_NAME=FOSS_PSRAM
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -462,7 +466,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_PSRAM_qspi
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_PSRAM_qspi -D WLED_PRODUCT_NAME=FOSS_PSRAM
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -482,7 +486,7 @@ board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 ;board_build.flash_mode = qio
 ;board_build.f_flash = 80000000L
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2
+build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2 -D WLED_PRODUCT_NAME=FOSS_PSRAM
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DARDUINO_USB_MSC_ON_BOOT=0
   -DARDUINO_USB_DFU_ON_BOOT=0

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -21,7 +21,7 @@
   #define WLED_BRAND "WLED"
 #endif
 #ifndef WLED_PRODUCT_NAME
-  #define WLED_PRODUCT_NAME "FOSS"
+  #define WLED_PRODUCT_NAME "DIY"
 #endif
 
 //Defaults


### PR DESCRIPTION
Aim to make it easier for third-party apps, like https://github.com/frenck/python-wled, to identify which release can be used for OTA updates for official builds without guessing. Non-official builds from WLED source code now have product name = "DIY" by default.

Partially addresses: https://github.com/Aircoookie/WLED/issues/3497
Follows from: https://github.com/Aircoookie/WLED/pull/3750

More direct solution would be to add to add a new field in the JSON API, but this solution avoid complicating the API.

Official product names:

* FOSS = basic build
* FOSS_OC = overclocked build (for ESP8266)
* FOSS_AR = audioreactive build
* FOSS_Eth = Ethernet build
* FOSS_PSRAM = build with PSRAM