### PR TITLE
Fix ESP8266 framework version selection

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,8 +41,7 @@ arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/
 platform_wled_default = ${common.arduino_core_3_1_2}
 # We use 2.7.4.7 for all, includes PWM flicker fix and Wstring optimization
 #platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-platform_packages = platformio/framework-arduinoespressif8266
-                    platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.200502
+platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.200502
                     platformio/tool-esptool #@ ~1.413.0
                     platformio/tool-esptoolpy #@ ~1.30000.0
 


### PR DESCRIPTION
By explicitly listing an unversioned framework dependency in 'platform_packages', we were overriding the framework version selection via the 'platform'.   This was allowing PlatformIO to select any random framework version based on whatever local cache each build system has.

Remove this line to allow 'platform' to add the framework dependency with the expected version.

Ref: #3853