### PR TITLE
Use correct start index for Art-Net in proxy mode

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -93,11 +93,14 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
     return;
   }
 
+  // DMX data in Art-Net packet starts at index 0, for E1.31 at index 1
+  int8_t artnetOffset = (protocol == P_ARTNET) ? -1 : 0;
+
   #ifdef WLED_ENABLE_DMX
   // does not act on out-of-order packets yet
   if (e131ProxyUniverse > 0 && uni == e131ProxyUniverse) {
     for (uint16_t i = 1; i <= dmxChannels; i++)
-      dmx.write(i, e131_data[i]);
+      dmx.write(i, e131_data[i+artnetOffset]);
     dmx.update();
   }
   #endif
@@ -135,9 +138,8 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP, byte protocol){
     availDMXLen = (dmxChannels - DMXAddress) + dmxLenOffset;
   }
 
-  // DMX data in Art-Net packet starts at index 0, for E1.31 at index 1
-  if (protocol == P_ARTNET && dataOffset > 0) {
-    dataOffset--;
+  if (dataOffset > 0) {
+    dataOffset += artnetOffset;
   }
 
   switch (DMXMode) {


### PR DESCRIPTION
Art-Net data doesn't contain a start byte. This is currently only taken into account when using regular LED output.
With this commit it also works when using DMX proxy mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DMX data alignment across Art-Net and E1.31 lighting protocols for proper channel synchronization and correct data handling when using multiple protocol paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->