### PR TITLE
Update to AsyncWebServer v2.2.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -143,7 +143,7 @@ lib_deps =
     fastled/FastLED @ 3.6.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.7.9
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ^2.2.0
+    https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
   # for I2C interface
     ;Wire
   # ESP-NOW library


### PR DESCRIPTION
Fix use-after-free issue and slightly improve code size.  Note that the version is changed to a hard pin, so future updates can be validated before getting picked up by new clones, and old version builds are reproducible.