### PR TITLE
Update cdata.js to rebuild if package.json changes

### DIFF
--- a/tools/cdata-test.js
+++ b/tools/cdata-test.js
@@ -83,6 +83,7 @@ describe('Script', () => {
     // Backup files
     fs.cpSync("wled00/data", "wled00Backup", { recursive: true });
     fs.cpSync("tools/cdata.js", "cdata.bak.js");
+    fs.cpSync("package.json", "package.bak.json");
   });
   after(() => {
     // Restore backup
@@ -90,6 +91,8 @@ describe('Script', () => {
     fs.renameSync("wled00Backup", "wled00/data");
     fs.rmSync("tools/cdata.js");
     fs.renameSync("cdata.bak.js", "tools/cdata.js");
+    fs.rmSync("package.json");
+    fs.renameSync("package.bak.json", "package.json");
   });
 
   // delete all html_*.h files

--- a/tools/cdata-test.js
+++ b/tools/cdata-test.js
@@ -131,7 +131,7 @@ describe('Script', () => {
     // run script cdata.js again and wait for it to finish
     await execPromise('node tools/cdata.js');
 
-    checkIfFileWasNewlyCreated(path.join(folderPath, resultFile));
+    await checkIfFileWasNewlyCreated(path.join(folderPath, resultFile));
   }
 
   describe('should build if', () => {
@@ -181,6 +181,10 @@ describe('Script', () => {
 
     it('cdata.js changes', async () => {
       await testFileModification('tools/cdata.js', 'html_ui.h');
+    });
+
+    it('package.json changes', async () => {
+      await testFileModification('package.json', 'html_ui.h');
     });
   });
 

--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -2,7 +2,7 @@
  * Writes compressed C arrays of data files (web interface)
  * How to use it?
  *
- * 1) Install Node 11+ and npm
+ * 1) Install Node 20+ and npm
  * 2) npm install
  * 3) npm run build
  *
@@ -207,7 +207,7 @@ function isAnyFileInFolderNewerThan(folderPath, time) {
 }
 
 // Check if the web UI is already built
-function isAlreadyBuilt(folderPath) {
+function isAlreadyBuilt(webUIPath, packageJsonPath = "package.json") {
   let lastBuildTime = Infinity;
 
   for (const file of output) {
@@ -220,7 +220,7 @@ function isAlreadyBuilt(folderPath) {
     }
   }
 
-  return !isAnyFileInFolderNewerThan(folderPath, lastBuildTime) && !isFileNewerThan("tools/cdata.js", lastBuildTime);
+  return !isAnyFileInFolderNewerThan(webUIPath, lastBuildTime) && !isFileNewerThan(packageJsonPath, lastBuildTime) && !isFileNewerThan(__filename, lastBuildTime);
 }
 
 // Don't run this script if we're in a test environment


### PR DESCRIPTION
cdata.js now rebuilds the files also if package.json changes.

Before, if only package.json changed, it did not rebuild and told you that the web UI was already built.