### PR TITLE
Create new stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 120
+          days-before-close: 7
+          exempt-issue-labels: 'pinned,keep,enhancement,confirmed'
+          exempt-pr-labels: 'pinned,keep,enhancement,confirmed'
+          stale-issue-message: >
+            Hey! This issue has been open for quite some time without any new comments now.
+            It will be closed automatically in a week if no further activity occurs.
+            
+            Thank you for using WLED! ✨
+          stale-pr-message: >
+            Hey! This pull request has been open for quite some time without any new comments now.
+            It will be closed automatically in a week if no further activity occurs.
+            
+            Thank you for using WLED! ✨
+          debug-only: true


### PR DESCRIPTION
This uses the new [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) GitHub Action.

To see if everything is working correctly, I have enabled [`debug-only`](https://github.com/marketplace/actions/close-stale-issues#debug-only), which means that **no GitHub API calls will be made that could change your issues and pull requests**.

This action will run every day at 12:00 UTC. You can also [run it manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow).

After the action has run, we can look at the log, and if everything looks fine, we can remove `debug-only: true` to let stale do its work.