### PR TITLE
Effect blending styles

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -316,6 +316,25 @@
 
 #define MODE_COUNT                     187
 
+
+#define BLEND_STYLE_FADE            0
+#define BLEND_STYLE_FAIRY_DUST      1
+#define BLEND_STYLE_SWIPE_RIGHT     2
+#define BLEND_STYLE_SWIPE_LEFT      3
+#define BLEND_STYLE_PINCH_OUT       4
+#define BLEND_STYLE_INSIDE_OUT      5
+#define BLEND_STYLE_SWIPE_UP        6
+#define BLEND_STYLE_SWIPE_DOWN      7
+#define BLEND_STYLE_OPEN_H          8
+#define BLEND_STYLE_OPEN_V          9
+#define BLEND_STYLE_PUSH_TL         10
+#define BLEND_STYLE_PUSH_TR         11
+#define BLEND_STYLE_PUSH_BR         12
+#define BLEND_STYLE_PUSH_BL         13
+
+#define BLEND_STYLE_COUNT           14
+
+
 typedef enum mapping1D2D {
   M12_Pixels = 0,
   M12_pBar = 1,
@@ -419,6 +438,9 @@ typedef struct Segment {
     static uint16_t _lastPaletteBlend;        // blend palette according to set Transition Delay in millis()%0xFFFF
     #ifndef WLED_DISABLE_MODE_BLEND
     static bool          _modeBlend;          // mode/effect blending semaphore
+    // clipping
+    static uint16_t _clipStart, _clipStop;
+    static uint8_t  _clipStartY, _clipStopY;
     #endif
 
     // transition data, valid only if transitional==true, holds values during transition (72 bytes)
@@ -578,6 +600,10 @@ typedef struct Segment {
     void setPixelColor(float i, uint32_t c, bool aa = true);
     inline void setPixelColor(float i, uint8_t r, uint8_t g, uint8_t b, uint8_t w = 0, bool aa = true) { setPixelColor(i, RGBW32(r,g,b,w), aa); }
     inline void setPixelColor(float i, CRGB c, bool aa = true)                                         { setPixelColor(i, RGBW32(c.r,c.g,c.b,0), aa); }
+    #ifndef WLED_DISABLE_MODE_BLEND
+    inline void setClippingRect(int startX, int stopX, int startY = 0, int stopY = 1) { _clipStart = startX; _clipStop = stopX; _clipStartY = startY; _clipStopY = stopY; };
+    #endif
+    bool isPixelClipped(int i);
     uint32_t getPixelColor(int i);
     // 1D support functions (some implement 2D as well)
     void blur(uint8_t);
@@ -606,6 +632,7 @@ typedef struct Segment {
     void setPixelColorXY(float x, float y, uint32_t c, bool aa = true);
     inline void setPixelColorXY(float x, float y, byte r, byte g, byte b, byte w = 0, bool aa = true) { setPixelColorXY(x, y, RGBW32(r,g,b,w), aa); }
     inline void setPixelColorXY(float x, float y, CRGB c, bool aa = true)                             { setPixelColorXY(x, y, RGBW32(c.r,c.g,c.b,0), aa); }
+    bool isPixelXYClipped(int x, int y);
     uint32_t getPixelColorXY(uint16_t x, uint16_t y);
     // 2D support functions
     inline void blendPixelColorXY(uint16_t x, uint16_t y, uint32_t color, uint8_t blend) { setPixelColorXY(x, y, color_blend(getPixelColorXY(x,y), color, blend)); }
@@ -640,6 +667,7 @@ typedef struct Segment {
     inline void setPixelColorXY(float x, float y, uint32_t c, bool aa = true)     { setPixelColor(x, c, aa); }
     inline void setPixelColorXY(float x, float y, byte r, byte g, byte b, byte w = 0, bool aa = true) { setPixelColor(x, RGBW32(r,g,b,w), aa); }
     inline void setPixelColorXY(float x, float y, CRGB c, bool aa = true)         { setPixelColor(x, RGBW32(c.r,c.g,c.b,0), aa); }
+    inline bool isPixelXYClipped(int x, int y)                                    { return isPixelClipped(x); }
     inline uint32_t getPixelColorXY(uint16_t x, uint16_t y)                       { return getPixelColor(x); }
     inline void blendPixelColorXY(uint16_t x, uint16_t y, uint32_t c, uint8_t blend) { blendPixelColor(x, c, blend); }
     inline void blendPixelColorXY(uint16_t x, uint16_t y, CRGB c, uint8_t blend)  { blendPixelColor(x, RGBW32(c.r,c.g,c.b,0), blend); }

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -167,10 +167,41 @@ uint16_t IRAM_ATTR Segment::XY(uint16_t x, uint16_t y)
   return isActive() ? (x%width) + (y%height) * width : 0;
 }
 
+// pixel is clipped if it falls outside clipping range (_modeBlend==true) or is inside clipping range (_modeBlend==false)
+// if clipping start > stop the clipping range is inverted
+// _modeBlend==true  -> old effect during transition
+// _modeBlend==false -> new effect during transition
+bool IRAM_ATTR Segment::isPixelXYClipped(int x, int y) {
+#ifndef WLED_DISABLE_MODE_BLEND
+  if (_clipStart != _clipStop && blendingStyle > BLEND_STYLE_FADE) {
+    const bool invertX    = _clipStart > _clipStop;
+    const bool invertY    = _clipStartY > _clipStopY;
+    const unsigned startX = invertX ? _clipStop : _clipStart;
+    const unsigned stopX  = invertX ? _clipStart : _clipStop;
+    const unsigned startY = invertY ? _clipStopY : _clipStartY;
+    const unsigned stopY  = invertY ? _clipStartY : _clipStopY;
+    if (blendingStyle == BLEND_STYLE_FAIRY_DUST) {
+      const unsigned width = stopX - startX;          // assumes full segment width (faster than virtualWidth())
+      const unsigned len = width * (stopY - startY);  // assumes full segment height (faster than virtualHeight())
+      if (len < 2) return false;
+      const unsigned shuffled = hashInt(x + y * width) % len;
+      const unsigned pos = (shuffled * 0xFFFFU) / len;
+      return progress() <= pos;
+    }
+    bool xInside = (x >= startX && x < stopX); if (invertX) xInside = !xInside;
+    bool yInside = (y >= startY && y < stopY); if (invertY) yInside = !yInside;
+    const bool clip = (invertX && invertY) ? !_modeBlend : _modeBlend;
+    if (xInside && yInside) return clip; // covers window & corners (inverted)
+    return !clip;
+  }
+#endif
+  return false;
+}
+
 void IRAM_ATTR Segment::setPixelColorXY(int x, int y, uint32_t col)
 {
   if (!isActive()) return; // not active
-  if (x >= virtualWidth() || y >= virtualHeight() || x<0 || y<0) return;  // if pixel would fall out of virtual segment just exit
+  if (x >= virtualWidth() || y >= virtualHeight() || x < 0 || y < 0 || isPixelXYClipped(x,y)) return;  // if pixel would fall out of virtual segment just exit
 
   uint8_t _bri_t = currentBri();
   if (_bri_t < 255) {

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -265,7 +265,25 @@
 		<div id="segutil2">
 			<button class="btn btn-s" id="rsbtn" onclick="rSegs()">Reset segments</button>
 		</div>
-		<p>Transition: <input id="tt" type="number" min="0" max="65.5" step="0.1" value="0.7">&nbsp;s</p>
+		<p>Transition: <input id="tt" type="number" min="0" max="65.5" step="0.1" value="0.7" onchange="parseFloat(this.value)===0?gId('bsp').classList.add('hide'):gId('bsp').classList.remove('hide');">&nbsp;s</p>
+		<p id="bsp">Blend:
+			<select id="bs" class="sel-sg" onchange="requestJson({'bs':parseInt(this.value)})">
+				<option value="0">Fade</option>
+				<option value="1">Fairy Dust</option>
+				<option value="2">Swipe left</option>
+				<option value="3">Swipe right</option>
+				<option value="4">Pinch-out</option>
+				<option value="5">Inside-out</option>
+				<option value="6">Swipe up (2D)</option>
+				<option value="7">Swipe down (2D)</option>
+				<option value="8">Open V (2D)</option>
+				<option value="9">Open H (2D)</option>
+				<option value="10">Push TL (2D)</option>
+				<option value="11">Push TR (2D)</option>
+				<option value="12">Push BR (2D)</option>
+				<option value="13">Push BL (2D)</option>
+			</select>
+		</p>
 		<p id="ledmap" class="hide"></p>
 	</div>
 

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1426,6 +1426,9 @@ function readState(s,command=false)
 
 	tr = s.transition;
 	gId('tt').value = tr/10;
+	gId('bs').value = s.bs || 0;
+	if (tr===0) gId('bsp').classList.add('hide')
+	else gId('bsp').classList.remove('hide')
 
 	populateSegments(s);
 	var selc=0;
@@ -1682,6 +1685,7 @@ function requestJson(command=null)
 			var tn = parseInt(t.value*10);
 			if (tn != tr) command.transition = tn;
 		}
+		//command.bs = parseInt(gId('bs').value);
 		req = JSON.stringify(command);
 		if (req.length > 1340) useWs = false; // do not send very long requests over websocket
 		if (req.length >  500 && lastinfo && lastinfo.arch == "esp8266") useWs = false; // esp8266 can only handle 500 bytes

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -383,6 +383,7 @@ uint16_t crc16(const unsigned char* data_p, size_t length);
 um_data_t* simulateSound(uint8_t simulationId);
 void enumerateLedmaps();
 uint8_t get_random_wheel_index(uint8_t pos);
+uint32_t hashInt(uint32_t s);
 
 // RAII guard class for the JSON Buffer lock
 // Modeled after std::lock_guard

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -355,6 +355,11 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     }
   }
 
+#ifndef WLED_DISABLE_MODE_BLEND
+  blendingStyle = root[F("bs")] | blendingStyle;
+  blendingStyle = constrain(blendingStyle, 0, BLEND_STYLE_COUNT-1);
+#endif
+
   // temporary transition (applies only once)
   tr = root[F("tt")] | -1;
   if (tr >= 0) {
@@ -581,6 +586,9 @@ void serializeState(JsonObject root, bool forPreset, bool includeBri, bool segme
     root["on"] = (bri > 0);
     root["bri"] = briLast;
     root[F("transition")] = transitionDelay/100; //in 100ms
+#ifndef WLED_DISABLE_MODE_BLEND
+    root[F("bs")] = blendingStyle;
+#endif
   }
 
   if (!forPreset) {

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -599,3 +599,10 @@ uint8_t get_random_wheel_index(uint8_t pos) {
   }
   return r;
 }
+
+uint32_t hashInt(uint32_t s) {
+  // borrowed from https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key
+  s = ((s >> 16) ^ s) * 0x45d9f3b;
+  s = ((s >> 16) ^ s) * 0x45d9f3b;
+  return (s >> 16) ^ s;
+}

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2403280
+#define VERSION 2404030
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG
@@ -547,6 +547,7 @@ WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random co
 // transitions
 WLED_GLOBAL bool          fadeTransition           _INIT(true);   // enable crossfading brightness/color
 WLED_GLOBAL bool          modeBlending             _INIT(true);   // enable effect blending
+WLED_GLOBAL uint8_t       blendingStyle            _INIT(0);      // effect blending/transitionig style
 WLED_GLOBAL bool          transitionActive         _INIT(false);
 WLED_GLOBAL uint16_t      transitionDelay          _INIT(750);    // global transition duration
 WLED_GLOBAL uint16_t      transitionDelayDefault   _INIT(750);    // default transition time (stored in cfg.json)


### PR DESCRIPTION
Implements 14 different transitions/blends between different effects/modes.

Alternative to #3669 by @tkadauke with less memory fragmentation and utilisation.
Implemented using clipping rectangles which may not produce same results as original PR (#3669).