### PR TITLE
Send ArtnetPollReply for Art-Net proxy universe

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -346,7 +346,6 @@ void handleArtnetPollReply(IPAddress ipAddress) {
 
   switch (DMXMode) {
     case DMX_MODE_DISABLED:
-      return;  // nothing to do
       break;
 
     case DMX_MODE_SINGLE_RGB:
@@ -391,9 +390,17 @@ void handleArtnetPollReply(IPAddress ipAddress) {
       break;
   }
 
-  for (uint16_t i = startUniverse; i <= endUniverse; ++i) {
-    sendArtnetPollReply(&artnetPollReply, ipAddress, i);
+  if (DMXMode != DMX_MODE_DISABLED) {
+    for (uint16_t i = startUniverse; i <= endUniverse; ++i) {
+      sendArtnetPollReply(&artnetPollReply, ipAddress, i);
+    }
   }
+
+  #ifdef WLED_ENABLE_DMX
+    if (e131ProxyUniverse > 0 && (DMXMode == DMX_MODE_DISABLED || (e131ProxyUniverse < startUniverse || e131ProxyUniverse > endUniverse))) {
+      sendArtnetPollReply(&artnetPollReply, ipAddress, e131ProxyUniverse);
+    }
+  #endif
 }
 
 void prepareArtnetPollReply(ArtPollReply *reply) {


### PR DESCRIPTION
This commit adds sending an ArtnetPollReply for the e131ProxyUniverse, which is currently not implemented.
It also checks that this universe doesn't overlap with the regular e131Universe, so no duplicate replies are sent.