### PR TITLE
Increase operations-per-run in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: '0 6,12,18 * * *'
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 jobs:
@@ -15,6 +15,7 @@ jobs:
           exempt-issue-labels: 'pinned,keep,enhancement,confirmed'
           exempt-pr-labels: 'pinned,keep,enhancement,confirmed'
           exempt-all-milestones: true
+          operations-per-run: 150
           stale-issue-message: >
             Hey! This issue has been open for quite some time without any new comments now.
             It will be closed automatically in a week if no further activity occurs.


### PR DESCRIPTION
It turned out that we are far from the rate limit, so we can increase the number of [`operations-per-run`](https://github.com/marketplace/actions/close-stale-issues#operations-per-run).
So we don't need to run this action 3 times a day.