### PR TITLE
update esp32 platform to arduino-esp32 v2.0.9

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -233,8 +233,8 @@ AR_lib_deps = kosme/arduinoFFT @ 2.0.0
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
-platform = espressif32@5.3.0
-platform_packages =
+platform = espressif32@ ~6.3.2
+platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
   -DARDUINO_ARCH_ESP32 -DESP32
@@ -248,8 +248,8 @@ lib_deps =
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = espressif32@ ~6.3.2
+platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -267,8 +267,8 @@ lib_deps =
 
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = espressif32@ ~6.3.2
+platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32C3
@@ -284,8 +284,8 @@ lib_deps =
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
-platform = espressif32@5.3.0
-platform_packages =
+platform = espressif32@ ~6.3.2
+platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -DESP32
   -DARDUINO_ARCH_ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -221,6 +221,7 @@ build_flags = -g
 tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 extended_partitions = tools/WLED_ESP32_4MB_700k_FS.csv
+big_partitions = tools/WLED_ESP32_4MB_256KB_FS.csv     ;; 1.8MB firmware, 256KB filesystem, coredump support
 large_partitions = tools/WLED_ESP32_8MB.csv
 extreme_partitions = tools/WLED_ESP32_16MB_9MB_FS.csv
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -174,7 +174,7 @@ lib_deps =
   # SHT85
     ;robtillaart/SHT85@~0.3.3
   # Audioreactive usermod
-    ;kosme/arduinoFFT @ 2.0.0
+    ;kosme/arduinoFFT @ 2.0.1
 
 extra_scripts = ${scripts_defaults.extra_scripts}
 
@@ -218,14 +218,18 @@ build_flags = -g
   #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
   -D LOROL_LITTLEFS
   ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
+tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+extended_partitions = tools/WLED_ESP32_4MB_700k_FS.csv
+large_partitions = tools/WLED_ESP32_8MB.csv
+extreme_partitions = tools/WLED_ESP32_16MB_9MB_FS.csv
 lib_deps =
   https://github.com/lorol/LITTLEFS.git
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
 # additional build flags for audioreactive
 AR_build_flags = -D USERMOD_AUDIOREACTIVE
-AR_lib_deps = kosme/arduinoFFT @ 2.0.0
+AR_lib_deps = kosme/arduinoFFT @ 2.0.1
 
 [esp32_idf_V4]
 ;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
@@ -250,7 +254,6 @@ lib_deps =
 ;; generic definitions for all ESP32-S2 boards
 platform = espressif32@ ~6.3.2
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32S2
@@ -296,7 +299,6 @@ build_flags = -g
   -DCO
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_MODE, ARDUINO_USB_CDC_ON_BOOT
-
 lib_deps =
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
@@ -391,7 +393,7 @@ platform = ${esp32.platform}
 board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-board_build.partitions = tools/WLED_ESP32-wrover_4MB.csv
+board_build.partitions = ${esp32.extended_partitions}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
@@ -404,7 +406,7 @@ platform = ${esp32c3.platform}
 platform_packages = ${esp32c3.platform_packages}
 framework = arduino
 board = esp32-c3-devkitm-1
-board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+board_build.partitions = ${esp32.default_partitions}
 build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3
   -D WLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this
@@ -428,7 +430,7 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   ${esp32.AR_build_flags}
 lib_deps = ${esp32s3.lib_deps}
   ${esp32.AR_lib_deps}
-board_build.partitions = tools/WLED_ESP32_8MB.csv
+board_build.partitions = ${esp32.large_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 ; board_build.flash_mode = dio   ;; try this if you have problems at startup
@@ -450,7 +452,7 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   ${esp32.AR_build_flags}
 lib_deps = ${esp32s3.lib_deps}
   ${esp32.AR_lib_deps}
-board_build.partitions = tools/WLED_ESP32_8MB.csv
+board_build.partitions = ${esp32.large_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 monitor_filters = esp32_exception_decoder
@@ -470,7 +472,7 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   ${esp32.AR_build_flags}
 lib_deps = ${esp32s3.lib_deps}
   ${esp32.AR_lib_deps}
-board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 monitor_filters = esp32_exception_decoder
@@ -479,7 +481,7 @@ monitor_filters = esp32_exception_decoder
 platform = ${esp32s2.platform}
 platform_packages = ${esp32s2.platform_packages}
 board = lolin_s2_mini
-board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+board_build.partitions = ${esp32.default_partitions}
 ;board_build.flash_mode = qio
 ;board_build.f_flash = 80000000L
 build_unflags = ${common.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -390,16 +390,20 @@ lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
 
 [env:esp32_wrover]
-platform = ${esp32.platform}
+extends = esp32_idf_V4
+platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32_idf_V4.platform_packages}
 board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = ${esp32.extended_partitions}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER
+build_flags = ${common.build_flags_esp32_V4} -D WLED_RELEASE_NAME=ESP32_WROVER
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
   -D LEDPIN=25
-lib_deps = ${esp32.lib_deps}
+  ; ${esp32.AR_build_flags}
+lib_deps = ${esp32_idf_V4.lib_deps}
+  ; ${esp32.AR_lib_deps}
 
 [env:esp32c3dev]
 extends = esp32c3

--- a/tools/WLED_ESP32_4MB_256KB_FS.csv
+++ b/tools/WLED_ESP32_4MB_256KB_FS.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1D0000,
+app1,     app,  ota_1,   0x1E0000,0x1D0000,
+spiffs,   data, spiffs,  0x3B0000,0x40000,
+coredump, data, coredump,,64K

--- a/tools/WLED_ESP32_4MB_700k_FS.csv
+++ b/tools/WLED_ESP32_4MB_700k_FS.csv
@@ -1,0 +1,6 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x1A0000,
+app1,     app,  ota_1,   0x1B0000,0x1A0000,
+spiffs,   data, spiffs,  0x350000,0xB0000,

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -71,7 +71,7 @@
  * if you want to receive two channels, one is the actual data from microphone and another channel is suppose to receive 0, it's different data in two channels, you need to choose I2S_CHANNEL_FMT_RIGHT_LEFT in this case.
 */
 
-#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)) && (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 4, 4))
+#if (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)) && (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(4, 4, 6))
 // espressif bug: only_left has no sound, left and right are swapped 
 // https://github.com/espressif/esp-idf/issues/9635  I2S mic not working since 4.4 (IDFGH-8138)
 // https://github.com/espressif/esp-idf/issues/8538  I2S channel selection issue? (IDFGH-6918)


### PR DESCRIPTION
This PR upgrades the arduino-esp32 framework from v2.0.6 to 2.0.9.
I would suggest staying with this version, as later versions of arduino-esp32 (i.e. 2.0.10 thru 2.0.14) have new bugs and they create new problems with audioreactive.

I've used v2.0.9 on my development boards for some time now,  and did not find new issues. 

arduino-esp32 v2.0.9 fixes some very nasty memory leaks in the `WiFiUDP` class, that lead to low memory and spurious exception crashes.

In principle, we could even upgrade to `platform = espressif32@ 6.6.0` while still forcing arduino-esp32 2.0.9 with platform_packages=... -> to be discussed. Just that I haven't tested the combination of platform 6.6.0 / arduino-esp32 2.0.9.

<br/>

#### esp32 "V4"
```
PLATFORM: Espressif 32 (6.3.2)
PACKAGES:
 - framework-arduinoespressif32 @ 3.20009.0 (2.0.9)
 - tool-esptoolpy @ 1.40501.0 (4.5.1)
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5
```

#### esp32-S3
```
PLATFORM: Espressif 32 (6.3.2)
PACKAGES:
 - framework-arduinoespressif32 @ 3.20009.0 (2.0.9)
 - tool-esptoolpy @ 1.40501.0 (4.5.1)
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
 - toolchain-xtensa-esp32s3 @ 8.4.0+2021r2-patch5
```

#### esp32-S2
```
PLATFORM: Espressif 32 (6.3.2)
PACKAGES:
 - framework-arduinoespressif32 @ 3.20009.0 (2.0.9)
 - tool-esptoolpy @ 1.40501.0 (4.5.1)
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
 - toolchain-xtensa-esp32s2 @ 8.4.0+2021r2-patch5
 ```

#### esp32-C3
```
PLATFORM: Espressif 32 (6.3.2)
PACKAGES:
 - framework-arduinoespressif32 @ 3.20009.0 (2.0.9)
 - tool-esptoolpy @ 1.40501.0 (4.5.1)
 - toolchain-riscv32-esp @ 8.4.0+2021r2-patch5
 ```
