### PR TITLE
added improvements to color scaling and blurring

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -582,7 +582,7 @@ typedef struct Segment {
     #endif
     uint32_t getPixelColor(int i);
     // 1D support functions (some implement 2D as well)
-    void blur(uint8_t);
+    void blur(uint8_t, bool smear = false);
     void fill(uint32_t c);
     void fade_out(uint8_t r);
     void fadeToBlackBy(uint8_t fadeBy);
@@ -610,7 +610,7 @@ typedef struct Segment {
     inline void setPixelColorXY(float x, float y, byte r, byte g, byte b, byte w = 0, bool aa = true) { setPixelColorXY(x, y, RGBW32(r,g,b,w), aa); }
     inline void setPixelColorXY(float x, float y, CRGB c, bool aa = true)                             { setPixelColorXY(x, y, RGBW32(c.r,c.g,c.b,0), aa); }
     #endif
-    uint32_t getPixelColorXY(uint16_t x, uint16_t y);
+    uint32_t getPixelColorXY(int x, int y);
     // 2D support functions
     inline void blendPixelColorXY(uint16_t x, uint16_t y, uint32_t color, uint8_t blend) { setPixelColorXY(x, y, color_blend(getPixelColorXY(x,y), color, blend)); }
     inline void blendPixelColorXY(uint16_t x, uint16_t y, CRGB c, uint8_t blend)         { blendPixelColorXY(x, y, RGBW32(c.r,c.g,c.b,0), blend); }
@@ -619,8 +619,8 @@ typedef struct Segment {
     inline void addPixelColorXY(int x, int y, CRGB c, bool fast = false)                             { addPixelColorXY(x, y, RGBW32(c.r,c.g,c.b,0), fast); }
     inline void fadePixelColorXY(uint16_t x, uint16_t y, uint8_t fade)                               { setPixelColorXY(x, y, color_fade(getPixelColorXY(x,y), fade, true)); }
     void box_blur(uint16_t i, bool vertical, fract8 blur_amount); // 1D box blur (with weight)
-    void blurRow(uint16_t row, fract8 blur_amount);
-    void blurCol(uint16_t col, fract8 blur_amount);
+    void blurRow(uint32_t row, fract8 blur_amount, bool smear = false);
+    void blurCol(uint32_t col, fract8 blur_amount, bool smear = false);
     void moveX(int8_t delta, bool wrap = false);
     void moveY(int8_t delta, bool wrap = false);
     void move(uint8_t dir, uint8_t delta, bool wrap = false);
@@ -655,8 +655,8 @@ typedef struct Segment {
     inline void addPixelColorXY(int x, int y, CRGB c, bool fast = false)          { addPixelColor(x, RGBW32(c.r,c.g,c.b,0), fast); }
     inline void fadePixelColorXY(uint16_t x, uint16_t y, uint8_t fade)            { fadePixelColor(x, fade); }
     inline void box_blur(uint16_t i, bool vertical, fract8 blur_amount) {}
-    inline void blurRow(uint16_t row, fract8 blur_amount) {}
-    inline void blurCol(uint16_t col, fract8 blur_amount) {}
+    inline void blurRow(uint32_t row, fract8 blur_amount, bool smear = false) {}
+    inline void blurCol(uint32_t col, fract8 blur_amount, bool smear = false) {}
     inline void moveX(int8_t delta, bool wrap = false) {}
     inline void moveY(int8_t delta, bool wrap = false) {}
     inline void move(uint8_t dir, uint8_t delta, bool wrap = false) {}

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -275,8 +275,7 @@ uint32_t IRAM_ATTR Segment::getPixelColorXY(int x, int y) {
 
 // blurRow: perform a blur on a row of a rectangular matrix
 void Segment::blurRow(uint32_t row, fract8 blur_amount, bool smear){
-  if (!isActive() || blur_amount == 0)
-    return; // not active
+  if (!isActive() || blur_amount == 0) return; // not active
   const uint_fast16_t cols = virtualWidth();
   const uint_fast16_t rows = virtualHeight();
 

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -175,7 +175,7 @@ void IRAM_ATTR Segment::setPixelColorXY(int x, int y, uint32_t col)
 
   uint8_t _bri_t = currentBri();
   if (_bri_t < 255) {
-    col = color_scale(col, _bri_t);
+    col = color_fade(col, _bri_t);
   }
 
   if (reverse  ) x = virtualWidth()  - x - 1;
@@ -274,15 +274,13 @@ uint32_t IRAM_ATTR Segment::getPixelColorXY(int x, int y) {
 }
 
 // blurRow: perform a blur on a row of a rectangular matrix
-void Segment::blurRow(uint32_t row, fract8 blur_amount, bool smear)
-{
+void Segment::blurRow(uint32_t row, fract8 blur_amount, bool smear){
   if (!isActive() || blur_amount == 0)
     return; // not active
   const uint_fast16_t cols = virtualWidth();
   const uint_fast16_t rows = virtualHeight();
 
-  if (row >= rows)
-    return;
+  if (row >= rows) return;
   // blur one row
   uint8_t keep = smear ? 255 : 255 - blur_amount;
   uint8_t seep = blur_amount >> 1;
@@ -292,8 +290,8 @@ void Segment::blurRow(uint32_t row, fract8 blur_amount, bool smear)
   uint32_t curnew;
   for (unsigned x = 0; x < cols; x++) {
     uint32_t cur = getPixelColorXY(x, row);
-    uint32_t part = color_scale(cur, seep);
-    curnew = color_scale(cur, keep);
+    uint32_t part = color_fade(cur, seep);
+    curnew = color_fade(cur, keep);
     if (x > 0) {
       if (carryover)
         curnew = color_add(curnew, carryover, true);
@@ -301,7 +299,7 @@ void Segment::blurRow(uint32_t row, fract8 blur_amount, bool smear)
       if (last != prev) // optimization: only set pixel if color has changed
         setPixelColorXY(x - 1, row, prev);
     }
-    else // first pixel or last pixel
+    else // first pixel
       setPixelColorXY(x, row, curnew);
     lastnew = curnew;
     last = cur; // save original value for comparison on next iteration
@@ -326,8 +324,8 @@ void Segment::blurCol(uint32_t col, fract8 blur_amount, bool smear) {
   uint32_t curnew;
   for (unsigned y = 0; y < rows; y++) {
     uint32_t cur = getPixelColorXY(col, y);
-    uint32_t part = color_scale(cur, seep);
-    curnew = color_scale(cur, keep);
+    uint32_t part = color_fade(cur, seep);
+    curnew = color_fade(cur, keep);
     if (y > 0) {
       if (carryover)
         curnew = color_add(curnew, carryover, true);

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -735,11 +735,7 @@ void IRAM_ATTR Segment::setPixelColor(int i, uint32_t col)
   uint16_t len = length();
   uint8_t _bri_t = currentBri();
   if (_bri_t < 255) {
-    byte r = scale8(R(col), _bri_t);
-    byte g = scale8(G(col), _bri_t);
-    byte b = scale8(B(col), _bri_t);
-    byte w = scale8(W(col), _bri_t);
-    col = RGBW32(r, g, b, w);
+	col = color_scale(col, _bri_t);
   }
 
   // expand pixel (taking into account start, grouping, spacing [and offset])
@@ -995,33 +991,44 @@ void Segment::fadeToBlackBy(uint8_t fadeBy) {
 /*
  * blurs segment content, source: FastLED colorutils.cpp
  */
-void Segment::blur(uint8_t blur_amount) {
+void Segment::blur(uint8_t blur_amount, bool smear) {
   if (!isActive() || blur_amount == 0) return; // optimization: 0 means "don't blur"
 #ifndef WLED_DISABLE_2D
   if (is2D()) {
     // compatibility with 2D
     const unsigned cols = virtualWidth();
     const unsigned rows = virtualHeight();
-    for (unsigned i = 0; i < rows; i++) blurRow(i, blur_amount); // blur all rows
-    for (unsigned k = 0; k < cols; k++) blurCol(k, blur_amount); // blur all columns
+    for (unsigned i = 0; i < rows; i++) blurRow(i, blur_amount, smear); // blur all rows
+    for (unsigned k = 0; k < cols; k++) blurCol(k, blur_amount, smear); // blur all columns
     return;
   }
 #endif
-  uint8_t keep = 255 - blur_amount;
+  uint8_t keep = smear ? 250 : 255 - blur_amount;
   uint8_t seep = blur_amount >> 1;
-  uint32_t carryover = BLACK;
   unsigned vlength = virtualLength();
+  uint32_t carryover = BLACK;
+  uint32_t lastnew;
+  uint32_t last;
+  uint32_t curnew;
   for (unsigned i = 0; i < vlength; i++) {
     uint32_t cur = getPixelColor(i);
-    uint32_t part = color_fade(cur, seep);
-    cur = color_add(color_fade(cur, keep), carryover, true);
-    if (i > 0) {
-      uint32_t c = getPixelColor(i-1);
-      setPixelColor(i-1, color_add(c, part, true));
+    uint32_t part = color_scale(cur, seep);
+    curnew = color_scale(cur, keep);
+    if (i > 0)
+    {
+      if (carryover)
+        curnew = color_add(curnew, carryover, true);
+      uint32_t prev = color_add(lastnew, part, true);
+      if (last != prev) // optimization: only set pixel if color has changed
+        setPixelColor(i - 1, prev);
     }
-    setPixelColor(i, cur);
+    else // first pixel
+      setPixelColor(i, curnew);
+    lastnew = curnew;
+    last = cur; // save original value for comparison on next iteration
     carryover = part;
   }
+  setPixelColor(vlength - 1, curnew);
 }
 
 /*

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -735,7 +735,7 @@ void IRAM_ATTR Segment::setPixelColor(int i, uint32_t col)
   uint16_t len = length();
   uint8_t _bri_t = currentBri();
   if (_bri_t < 255) {
-	col = color_scale(col, _bri_t);
+    col = color_fade(col, _bri_t);
   }
 
   // expand pixel (taking into account start, grouping, spacing [and offset])
@@ -1003,7 +1003,7 @@ void Segment::blur(uint8_t blur_amount, bool smear) {
     return;
   }
 #endif
-  uint8_t keep = smear ? 250 : 255 - blur_amount;
+  uint8_t keep = smear ? 255 : 255 - blur_amount;
   uint8_t seep = blur_amount >> 1;
   unsigned vlength = virtualLength();
   uint32_t carryover = BLACK;
@@ -1012,10 +1012,9 @@ void Segment::blur(uint8_t blur_amount, bool smear) {
   uint32_t curnew;
   for (unsigned i = 0; i < vlength; i++) {
     uint32_t cur = getPixelColor(i);
-    uint32_t part = color_scale(cur, seep);
-    curnew = color_scale(cur, keep);
-    if (i > 0)
-    {
+    uint32_t part = color_fade(cur, seep);
+    curnew = color_fade(cur, keep);
+    if (i > 0) {
       if (carryover)
         curnew = color_add(curnew, carryover, true);
       uint32_t prev = color_add(lastnew, part, true);

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -62,27 +62,39 @@ uint32_t color_add(uint32_t c1, uint32_t c2, bool fast)
 }
 
 /*
+ * color scale function that replaces scale8 for 32bit colors 
+ */
+
+uint32_t color_scale(uint32_t c1, uint8_t scale)
+{
+  uint32_t fixedscale = 1 + scale;
+  uint32_t scaledcolor; //color order is: W R G B from MSB to LSB
+  scaledcolor = ((R(c1) * fixedscale) >> 8) << 16;
+  scaledcolor |= ((G(c1) * fixedscale) >> 8) << 8;
+  scaledcolor |= (B(c1) * fixedscale) >> 8;
+  scaledcolor |= ((W(c1) * fixedscale) >> 8) << 24;
+  return scaledcolor;
+}
+
+/*
  * fades color toward black
  * if using "video" method the resulting color will never become black unless it is already black
  */
+
 uint32_t color_fade(uint32_t c1, uint8_t amount, bool video)
 {
-  uint8_t r = R(c1);
-  uint8_t g = G(c1);
-  uint8_t b = B(c1);
-  uint8_t w = W(c1);
-  if (video) {
-    r = scale8_video(r, amount);
-    g = scale8_video(g, amount);
-    b = scale8_video(b, amount);
-    w = scale8_video(w, amount);
-  } else {
-    r = scale8(r, amount);
-    g = scale8(g, amount);
-    b = scale8(b, amount);
-    w = scale8(w, amount);
+  if (video)
+  {
+    uint8_t r = scale8_video(R(c1), amount);
+    uint8_t g = scale8_video(G(c1), amount);
+    uint8_t b = scale8_video(B(c1), amount);
+    uint8_t w = scale8_video(W(c1), amount);
+    return RGBW32(r, g, b, w);
   }
-  return RGBW32(r, g, b, w);
+  else
+  {
+    return color_scale(c1, amount);
+  }
 }
 
 void setRandomColor(byte* rgb)

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -62,38 +62,32 @@ uint32_t color_add(uint32_t c1, uint32_t c2, bool fast)
 }
 
 /*
- * color scale function that replaces scale8 for 32bit colors 
- */
-
-uint32_t color_scale(uint32_t c1, uint8_t scale)
-{
-  uint32_t fixedscale = 1 + scale;
-  uint32_t scaledcolor; //color order is: W R G B from MSB to LSB
-  scaledcolor = ((R(c1) * fixedscale) >> 8) << 16;
-  scaledcolor |= ((G(c1) * fixedscale) >> 8) << 8;
-  scaledcolor |= (B(c1) * fixedscale) >> 8;
-  scaledcolor |= ((W(c1) * fixedscale) >> 8) << 24;
-  return scaledcolor;
-}
-
-/*
  * fades color toward black
  * if using "video" method the resulting color will never become black unless it is already black
  */
 
 uint32_t color_fade(uint32_t c1, uint8_t amount, bool video)
 {
-  if (video)
-  {
-    uint8_t r = scale8_video(R(c1), amount);
-    uint8_t g = scale8_video(G(c1), amount);
-    uint8_t b = scale8_video(B(c1), amount);
-    uint8_t w = scale8_video(W(c1), amount);
-    return RGBW32(r, g, b, w);
+  uint32_t scaledcolor; // color order is: W R G B from MSB to LSB
+  uint32_t r = R(c1);
+  uint32_t g = G(c1);
+  uint32_t b = B(c1);
+  uint32_t w = W(c1);
+  if (video)  {
+    uint32_t scale = amount; // 32bit for faster calculation
+    scaledcolor = (((r * scale) >> 8) << 16) + ((r && scale) ? 1 : 0);
+    scaledcolor |= (((g * scale) >> 8) << 8) + ((g && scale) ? 1 : 0);
+    scaledcolor |= ((b * scale) >> 8) + ((b && scale) ? 1 : 0);
+    scaledcolor |= (((w * scale) >> 8) << 24) + ((w && scale) ? 1 : 0);
+    return scaledcolor;
   }
-  else
-  {
-    return color_scale(c1, amount);
+  else  {
+    uint32_t scale = 1 + amount;
+    scaledcolor = ((r * scale) >> 8) << 16;
+    scaledcolor |= ((g * scale) >> 8) << 8;
+    scaledcolor |= (b * scale) >> 8;
+    scaledcolor |= ((w * scale) >> 8) << 24;
+    return scaledcolor;
   }
 }
 

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -80,6 +80,7 @@ class NeoGammaWLEDMethod {
 #define gamma8(c)  NeoGammaWLEDMethod::rawGamma8(c)
 uint32_t color_blend(uint32_t,uint32_t,uint16_t,bool b16=false);
 uint32_t color_add(uint32_t,uint32_t, bool fast=false);
+uint32_t color_scale(uint32_t c1, uint8_t scale);
 uint32_t color_fade(uint32_t c1, uint8_t amount, bool video=false);
 CRGBPalette16 generateHarmonicRandomPalette(CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette(void);

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -80,7 +80,6 @@ class NeoGammaWLEDMethod {
 #define gamma8(c)  NeoGammaWLEDMethod::rawGamma8(c)
 uint32_t color_blend(uint32_t,uint32_t,uint16_t,bool b16=false);
 uint32_t color_add(uint32_t,uint32_t, bool fast=false);
-uint32_t color_scale(uint32_t c1, uint8_t scale);
 uint32_t color_fade(uint32_t c1, uint8_t amount, bool video=false);
 CRGBPalette16 generateHarmonicRandomPalette(CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette(void);


### PR DESCRIPTION
- made blurring faster by not writing the color and then reading it back but keeping it as a variable: on a C3, FX black hole goes from 55FPS to 71FPS 
- added optional parameter to blur function (smear) that can be used in combination with SEGMENT.clear(), blurring the frame without dimming the current display (repeated calls without clearing will flood the segment). this is useful to blur without 'motion blurring' being added.
- scale8 is inlined and repeated calls uses flash, plus it is slower than native 32bit, so I added 'color_scale' function which is native 32bit and scales 32bit colors (RGBW).
- bonus: changes save roughly 600bytes of flash memory