### PR TITLE
Set stale lable to 'stale' and increase operations-per-run in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
           exempt-issue-labels: 'pinned,keep,enhancement,confirmed'
           exempt-pr-labels: 'pinned,keep,enhancement,confirmed'
           exempt-all-milestones: true
-          operations-per-run: 150
+          operations-per-run: 1000
           stale-issue-message: >
             Hey! This issue has been open for quite some time without any new comments now.
             It will be closed automatically in a week if no further activity occurs.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,8 @@ jobs:
         with:
           days-before-stale: 120
           days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
           exempt-issue-labels: 'pinned,keep,enhancement,confirmed'
           exempt-pr-labels: 'pinned,keep,enhancement,confirmed'
           exempt-all-milestones: true


### PR DESCRIPTION
It turned out that the previous increase in operations-per-run still wasn't enough, so we can increase it again.

Also the last time the action was executed some errors were thrown:
![grafik](https://github.com/Aircoookie/WLED/assets/27882680/547be5f9-9738-4b32-a54e-c1980c6c7848)
Setting the lable to stale could be a fix for that.

I'm sorry to have to do another PR, but I can't really test things with the stale action in my own repository. 