### PR TITLE
Relay open drain output (allow esp32 to drive 5v relay modules)

### DIFF
--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -56,6 +56,7 @@ build_flags = ${common.build_flags_esp8266}
 ;   -D IRPIN=4
 ;   -D RLYPIN=12
 ;   -D RLYMDE=1
+;   -D RLYODRAIN=0
 ;   -D LED_BUILTIN=2 # GPIO of built-in LED
 ;
 ; Limit max buses

--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -379,7 +379,7 @@ void handleIO()
       esp32RMTInvertIdle();
       #endif
       if (rlyPin>=0) {
-        pinMode(rlyPin, OUTPUT);
+        pinMode(rlyPin, rlyOpenDrain ? OUTPUT_OPEN_DRAIN : OUTPUT);
         digitalWrite(rlyPin, rlyMde);
       }
       offMode = false;
@@ -400,7 +400,7 @@ void handleIO()
       esp32RMTInvertIdle();
       #endif
       if (rlyPin>=0) {
-        pinMode(rlyPin, OUTPUT);
+        pinMode(rlyPin, rlyOpenDrain ? OUTPUT_OPEN_DRAIN : OUTPUT);
         digitalWrite(rlyPin, !rlyMde);
       }
     }

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -335,12 +335,16 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(irApplyToAllSelected, hw["ir"]["sel"]);
 
   JsonObject relay = hw[F("relay")];
+
+  if (relay.containsKey("odrain")) {
+    rlyOpenDrain = relay["odrain"];
+  }
   int hw_relay_pin = relay["pin"] | -2;
   if (hw_relay_pin > -2) {
     pinManager.deallocatePin(rlyPin, PinOwner::Relay);
     if (pinManager.allocatePin(hw_relay_pin,true, PinOwner::Relay)) {
       rlyPin = hw_relay_pin;
-      pinMode(rlyPin, OUTPUT);
+      pinMode(rlyPin, rlyOpenDrain ? OUTPUT_OPEN_DRAIN : OUTPUT);
     } else {
       rlyPin = -1;
     }
@@ -868,6 +872,7 @@ void serializeConfig() {
   JsonObject hw_relay = hw.createNestedObject(F("relay"));
   hw_relay["pin"] = rlyPin;
   hw_relay["rev"] = !rlyMde;
+  hw_relay["odrain"] = rlyOpenDrain;
 
   hw[F("baud")] = serialBaud;
 

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -336,9 +336,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   JsonObject relay = hw[F("relay")];
 
-  if (relay.containsKey("odrain")) {
-    rlyOpenDrain = relay["odrain"];
-  }
+  rlyOpenDrain  = relay[F("odrain")] | rlyOpenDrain;
   int hw_relay_pin = relay["pin"] | -2;
   if (hw_relay_pin > -2) {
     pinManager.deallocatePin(rlyPin, PinOwner::Relay);
@@ -872,7 +870,7 @@ void serializeConfig() {
   JsonObject hw_relay = hw.createNestedObject(F("relay"));
   hw_relay["pin"] = rlyPin;
   hw_relay["rev"] = !rlyMde;
-  hw_relay["odrain"] = rlyOpenDrain;
+  hw_relay[F("odrain")] = rlyOpenDrain;
 
   hw[F("baud")] = serialBaud;
 

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -823,7 +823,7 @@ Swap: <select id="xw${i}" name="XW${i}">
 		Apply IR change to main segment only: <input type="checkbox" name="MSO"><br>
 		<div id="json" style="display:none;">JSON file: <input type="file" name="data" accept=".json"><button type="button" class="sml" onclick="uploadFile('/ir.json')">Upload</button><br></div>
 		<a href="https://kno.wled.ge/interfaces/infrared/" target="_blank">IR info</a><br>
-		Relay GPIO: <input type="number" min="-1" max="48" name="RL" onchange="UI()" class="xs"> Invert <input type="checkbox" name="RM"> Open drain <input type="checkbox" name="RO"><span style="cursor: pointer;" onclick="off('RL')">&nbsp;&#x2715;</span><br>
+		Relay GPIO: <input type="number" min="-1" max="48" name="RL" onchange="UI()" class="xs"><span style="cursor: pointer;" onclick="off('RL')">&nbsp;&#x2715;</span> Invert <input type="checkbox" name="RM"> Open drain <input type="checkbox" name="RO"><br>
 		<hr class="sml">
 		<h3>Defaults</h3>
 		Turn LEDs on after power up/reset: <input type="checkbox" name="BO"><br>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -619,7 +619,8 @@ Swap: <select id="xw${i}" name="XW${i}">
 					}
 					if (c.hw.relay) {
 						d.getElementsByName("RL")[0].value = c.hw.relay.pin;
-						d.getElementsByName("RM")[0].checked = c.hw.relay.inv;
+						d.getElementsByName("RM")[0].checked = c.hw.relay.rev;
+						d.getElementsByName("RO")[0].checked = c.hw.relay.odrain;
 					}
 					UI();
 				}
@@ -822,7 +823,7 @@ Swap: <select id="xw${i}" name="XW${i}">
 		Apply IR change to main segment only: <input type="checkbox" name="MSO"><br>
 		<div id="json" style="display:none;">JSON file: <input type="file" name="data" accept=".json"><button type="button" class="sml" onclick="uploadFile('/ir.json')">Upload</button><br></div>
 		<a href="https://kno.wled.ge/interfaces/infrared/" target="_blank">IR info</a><br>
-		Relay GPIO: <input type="number" min="-1" max="48" name="RL" onchange="UI()" class="xs"> Invert <input type="checkbox" name="RM"><span style="cursor: pointer;" onclick="off('RL')">&nbsp;&#x2715;</span><br>
+		Relay GPIO: <input type="number" min="-1" max="48" name="RL" onchange="UI()" class="xs"> Invert <input type="checkbox" name="RM"> Open drain <input type="checkbox" name="RO"><span style="cursor: pointer;" onclick="off('RL')">&nbsp;&#x2715;</span><br>
 		<hr class="sml">
 		<h3>Defaults</h3>
 		Turn LEDs on after power up/reset: <input type="checkbox" name="BO"><br>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -243,6 +243,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       rlyPin = -1;
     }
     rlyMde = (bool)request->hasArg(F("RM"));
+    rlyOpenDrain = (bool)request->hasArg(F("RO"));
 
     disablePullUp = (bool)request->hasArg(F("IP"));
     touchThreshold = request->arg(F("TT")).toInt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -288,6 +288,12 @@ WLED_GLOBAL bool rlyMde _INIT(true);
 #else
 WLED_GLOBAL bool rlyMde _INIT(RLYMDE);
 #endif
+//Use open drain (floating pin) when relay should be off
+#ifndef RLYODRAIN
+WLED_GLOBAL bool rlyOpenDrain _INIT(false);
+#else
+WLED_GLOBAL bool rlyOpenDrain _INIT(RLYODRAIN);
+#endif
 #ifndef IRPIN
   #define IRPIN -1
 #endif

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -458,6 +458,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('i',SET_F("PB"),strip.paletteBlend);
     sappend('v',SET_F("RL"),rlyPin);
     sappend('c',SET_F("RM"),rlyMde);
+    sappend('c',SET_F("RO"),rlyOpenDrain);
     for (uint8_t i=0; i<WLED_MAX_BUTTONS; i++) {
       oappend(SET_F("addBtn("));
       oappend(itoa(i,nS,10)); oappend(",");


### PR DESCRIPTION
This PR adds a new boolean option to the relay settings: open drain.

![image](https://github.com/Aircoookie/WLED/assets/830773/017fabc3-d3a3-45c6-8090-b098d2537f35)

When select, relay pin mode is set to OUTPUT_OPEN_DRAIN instead of normal OUTPUT.

> OUTPUT_OPEN_DRAIN: an open-drain or open-collector output. HIGH (1) leaves the output in high impedance state, LOW (0) pulls the output low. Typically used with an external pull-up resistor to allow any of multiple devices to set the value low safely.

**This allow driving 5v relay modules (cheap super common Arduino ones) just powering them with 5V and adding an external pull-up resistor between the module input pin and 5V, without risking the esp32 pins (that are not 5v-tolerant) and without additional level converters.**

![image](https://github.com/Aircoookie/WLED/assets/830773/81d4e48c-ad57-4510-9ae0-a1c4d82d8948)

Fully tested