### PR TITLE
Reserve "FOSS" product name for official builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,11 @@
 # CI/release binaries
 default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, esp32dev, esp32_eth, esp32dev_audioreactive, lolin_s2_mini, esp32c3dev, esp32s3dev_8MB, esp32s3dev_8MB_PSRAM_opi, esp32s3_4M_PSRAM_qspi, esp32_wrover
 
+# Note that WLED_BRAND_NAME='"WLED"' identifies the source code as coming from the Aircoookie repository. Forks should use a different value.
+# Official builds from this repository have WLED_PRODUCT_NAME='"FOSS"'. Unofficial builds can have other values.
+# Note that third-party components may use these values in order to OTA update your device's firmware using these builds,
+# overwriting any custom firmware that you have loaded.
+
 src_dir  = ./wled00
 data_dir = ./wled00/data
 build_cache_dir = ~/.buildcache
@@ -311,14 +316,14 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266 #-DWLED_DISABLE_2D
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266 -D WLED_PRODUCT_NAME='"FOSS"' #-DWLED_DISABLE_2D
 lib_deps = ${esp8266.lib_deps}
 monitor_filters = esp8266_exception_decoder
 
 [env:nodemcuv2_160]
 extends = env:nodemcuv2
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266_160 #-DWLED_DISABLE_2D
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP8266_160 -D WLED_PRODUCT_NAME='"FOSS"' #-DWLED_DISABLE_2D
 
 [env:esp8266_2m]
 board = esp_wroom_02
@@ -326,13 +331,13 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02 -D WLED_PRODUCT_NAME='"FOSS"'
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp8266_2m_160]
 extends = env:esp8266_2m
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02_160
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP02_160 -D WLED_PRODUCT_NAME='"FOSS"'
 
 [env:esp01_1m_full]
 board = esp01_1m
@@ -340,14 +345,14 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01 -D WLED_DISABLE_OTA
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01 -D WLED_PRODUCT_NAME='"FOSS"' -D WLED_DISABLE_OTA
   ; -D WLED_USE_UNREAL_MATH ;; may cause wrong sunset/sunrise times, but saves 7064 bytes FLASH and 975 bytes RAM
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp01_1m_full_160]
 extends = env:esp01_1m_full
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01_160 -D WLED_DISABLE_OTA
+build_flags = ${common.build_flags_esp8266} -D WLED_RELEASE_NAME=ESP01_160 -D WLED_PRODUCT_NAME='"FOSS"' -D WLED_DISABLE_OTA
   ; -D WLED_USE_UNREAL_MATH ;; may cause wrong sunset/sunrise times, but saves 7064 bytes FLASH and 975 bytes RAM
 
 [env:esp32dev]
@@ -355,7 +360,7 @@ board = esp32dev
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 #-D WLED_DISABLE_BROWNOUT_DET
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32 -D WLED_PRODUCT_NAME='"FOSS"' #-D WLED_DISABLE_BROWNOUT_DET
 lib_deps = ${esp32.lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
@@ -365,7 +370,7 @@ board = esp32dev
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_audioreactive #-D WLED_DISABLE_BROWNOUT_DET
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_audioreactive -D WLED_PRODUCT_NAME='"FOSS"' #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
 lib_deps = ${esp32.lib_deps}
   ${esp32.AR_lib_deps}
@@ -380,7 +385,7 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_Ethernet -D WLED_PRODUCT_NAME='"FOSS"' -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
   -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
 lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
@@ -392,7 +397,7 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = tools/WLED_ESP32-wrover_4MB.csv
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER
+build_flags = ${common.build_flags_esp32} -D WLED_RELEASE_NAME=ESP32_WROVER -D WLED_PRODUCT_NAME='"FOSS"'
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
   -D LEDPIN=25
 lib_deps = ${esp32.lib_deps}
@@ -404,7 +409,7 @@ platform_packages = ${esp32c3.platform_packages}
 framework = arduino
 board = esp32-c3-devkitm-1
 board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
-build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3
+build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3 -D WLED_PRODUCT_NAME='"FOSS"'
   -D WLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
@@ -420,7 +425,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600 ; or  460800
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB -D WLED_PRODUCT_NAME='"FOSS"'
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   ;-D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1 ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -441,7 +446,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB_PSRAM_opi
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB_PSRAM_opi -D WLED_PRODUCT_NAME='"FOSS"'
   -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
   ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -462,7 +467,7 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_PSRAM_qspi
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_PSRAM_qspi -D WLED_PRODUCT_NAME='"FOSS"'
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -482,7 +487,7 @@ board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 ;board_build.flash_mode = qio
 ;board_build.f_flash = 80000000L
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2
+build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2 -D WLED_PRODUCT_NAME='"FOSS"'
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DARDUINO_USB_MSC_ON_BOOT=0
   -DARDUINO_USB_DFU_ON_BOOT=0

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -61,6 +61,10 @@ build_flags = ${common.build_flags_esp8266}
 ; Limit max buses
 ;   -D WLED_MAX_BUSSES=2
 ;
+; Customise brand and product name
+;   -D WLED_BRAND_NAME='"MyBrand"'
+;   -D WLED_PRODUCT_NAME='"MyProduct"'
+;
 ; Configure default WiFi
 ;   -D CLIENT_SSID='"MyNetwork"'
 ;   -D CLIENT_PASS='"Netw0rkPassw0rd"'

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -21,7 +21,7 @@
   #define WLED_BRAND "WLED"
 #endif
 #ifndef WLED_PRODUCT_NAME
-  #define WLED_PRODUCT_NAME "FOSS"
+  #define WLED_PRODUCT_NAME "DIY"
 #endif
 
 //Defaults


### PR DESCRIPTION
If the "FOSS" product name is reserved for official builds, then it becomes much easier to identify devices that have official builds from the Aircoookie repository.

* WLED_BRAND_NAME = "WLED"  --> Implies it uses the Aircoookie version of the source code. Forks should use a different value.
* WLED_PRODUCT_NAME = "FOSS" --> Implies it's an official build. Unofficial ones should use a different one. The default for custom builds is now "DIY".
