### PR TITLE
Using brightness in analog clock overlay

### DIFF
--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -11,7 +11,6 @@ void _overlayAnalogClock()
   {
     _overlayAnalogCountdown(); return;
   }
-  uint8_t brightness = strip.getBrightness();
   float hourP = ((float)(hour(localTime)%12))/12.0f;
   float minuteP = ((float)minute(localTime))/60.0f;
   hourP = hourP + minuteP/12.0f;
@@ -26,11 +25,11 @@ void _overlayAnalogClock()
   {
     if (secondPixel < analogClock12pixel)
     {
-      strip.setRange(analogClock12pixel, overlayMax, color_fade(0xFF0000, brightness));
-      strip.setRange(overlayMin, secondPixel, color_fade(0xFF0000, brightness));
+      strip.setRange(analogClock12pixel, overlayMax, color_fade(0xFF0000, bri));
+      strip.setRange(overlayMin, secondPixel, color_fade(0xFF0000, bri));
     } else
     {
-      strip.setRange(analogClock12pixel, secondPixel, color_fade(0xFF0000, brightness));
+      strip.setRange(analogClock12pixel, secondPixel, color_fade(0xFF0000, bri));
     }
   }
   if (analogClock5MinuteMarks)
@@ -39,12 +38,12 @@ void _overlayAnalogClock()
     {
       unsigned pix = analogClock12pixel + roundf((overlaySize / 12.0f) *i);
       if (pix > overlayMax) pix -= overlaySize;
-      strip.setPixelColor(pix, color_fade(0x00FFAA, brightness));
+      strip.setPixelColor(pix, color_fade(0x00FFAA, bri));
     }
   }
-  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, color_fade(0xFF0000, brightness));
-  strip.setPixelColor(minutePixel, color_fade(0x00FF00, brightness));
-  strip.setPixelColor(hourPixel, color_fade(0x0000FF, brightness));
+  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, color_fade(0xFF0000, bri));
+  strip.setPixelColor(minutePixel, color_fade(0x00FF00, bri));
+  strip.setPixelColor(hourPixel, color_fade(0x0000FF, bri));
 }
 
 

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -26,11 +26,11 @@ void _overlayAnalogClock()
   {
     if (secondPixel < analogClock12pixel)
     {
-      strip.setRange(analogClock12pixel, overlayMax, (uint32_t)brightness<<16);
-      strip.setRange(overlayMin, secondPixel, (uint32_t)brightness<<16);
+      strip.setRange(analogClock12pixel, overlayMax, color_fade(0xFF0000, brightness));
+      strip.setRange(overlayMin, secondPixel, color_fade(0xFF0000, brightness));
     } else
     {
-      strip.setRange(analogClock12pixel, secondPixel, (uint32_t)brightness<<16);
+      strip.setRange(analogClock12pixel, secondPixel, color_fade(0xFF0000, brightness));
     }
   }
   if (analogClock5MinuteMarks)
@@ -39,12 +39,12 @@ void _overlayAnalogClock()
     {
       unsigned pix = analogClock12pixel + roundf((overlaySize / 12.0f) *i);
       if (pix > overlayMax) pix -= overlaySize;
-      strip.setPixelColor(pix, ((uint32_t)brightness<<8)|((uint32_t)brightness*2/3));
+      strip.setPixelColor(pix, color_fade(0x00FFAA, brightness));
     }
   }
-  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, (uint32_t)brightness<<16);
-  strip.setPixelColor(minutePixel, (uint32_t)brightness<<8);
-  strip.setPixelColor(hourPixel, (uint32_t)brightness);
+  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, color_fade(0xFF0000, brightness));
+  strip.setPixelColor(minutePixel, color_fade(0x00FF00, brightness));
+  strip.setPixelColor(hourPixel, color_fade(0x0000FF, brightness));
 }
 
 

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -11,6 +11,7 @@ void _overlayAnalogClock()
   {
     _overlayAnalogCountdown(); return;
   }
+  uint8_t brightness = strip.getBrightness();
   float hourP = ((float)(hour(localTime)%12))/12.0f;
   float minuteP = ((float)minute(localTime))/60.0f;
   hourP = hourP + minuteP/12.0f;
@@ -25,11 +26,11 @@ void _overlayAnalogClock()
   {
     if (secondPixel < analogClock12pixel)
     {
-      strip.setRange(analogClock12pixel, overlayMax, 0xFF0000);
-      strip.setRange(overlayMin, secondPixel, 0xFF0000);
+      strip.setRange(analogClock12pixel, overlayMax, (uint32_t)brightness<<16);
+      strip.setRange(overlayMin, secondPixel, (uint32_t)brightness<<16);
     } else
     {
-      strip.setRange(analogClock12pixel, secondPixel, 0xFF0000);
+      strip.setRange(analogClock12pixel, secondPixel, (uint32_t)brightness<<16);
     }
   }
   if (analogClock5MinuteMarks)
@@ -38,12 +39,12 @@ void _overlayAnalogClock()
     {
       unsigned pix = analogClock12pixel + roundf((overlaySize / 12.0f) *i);
       if (pix > overlayMax) pix -= overlaySize;
-      strip.setPixelColor(pix, 0x00FFAA);
+      strip.setPixelColor(pix, ((uint32_t)brightness<<8)|((uint32_t)brightness*2/3));
     }
   }
-  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, 0xFF0000);
-  strip.setPixelColor(minutePixel, 0x00FF00);
-  strip.setPixelColor(hourPixel, 0x0000FF);
+  if (!analogClockSecondsTrail) strip.setPixelColor(secondPixel, (uint32_t)brightness<<16);
+  strip.setPixelColor(minutePixel, (uint32_t)brightness<<8);
+  strip.setPixelColor(hourPixel, (uint32_t)brightness);
 }
 
 


### PR DESCRIPTION
I want to adjust the brightness of the analog clock. I used the existing brightness setting to decrease the intensity of the 3 LEDs related to the analog clock overlay.
I tested on my ESP8266 Wemos D1 mini