### PR TITLE
Correct mA/LED value for WS2815

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -713,7 +713,7 @@ Length: <input type="number" name="XC${i}" id="xc${i}" class="l" min="1" max="65
 				<option value="55" selected>5V default (55mA)</option>
 				<option value="35">5V efficient (35mA)</option>
 				<option value="30">12V (30mA)</option>
-				<option value="255">WS2815 (12mA)</option>
+				<option value="12">WS2815 (12mA)</option>
 				<option value="50">Custom</option>
 			</select><br>
 			<span id="LAdis" style="display: none;">Custom max. current per LED: <input name="LA" type="number" min="0" max="255" id="la" oninput="UI()" required> mA<br></span>


### PR DESCRIPTION
Currently it's not possible to save an LED strip set as WS2815 because the mA/LED value falls outside the allowed range.  The form validation throws an error because the input element isn't focusable because it's hidden by default and only shown when a custom mA/LED value is entered

This PR fixes that by setting the correct value for mA/LED for WS2815 strips