### PR TITLE
Update Usermod: Battery

### DIFF
--- a/usermods/Battery/battery_defaults.h
+++ b/usermods/Battery/battery_defaults.h
@@ -14,6 +14,12 @@
   #endif
 #endif
 
+// The initial delay before the first battery voltage reading after power-on.
+// This allows the voltage to stabilize before readings are taken, improving accuracy of initial reading.
+#ifndef USERMOD_BATTERY_INITIAL_DELAY
+  #define USERMOD_BATTERY_INITIAL_DELAY 10000 // (milliseconds)
+#endif
+
 // the frequency to check the battery, 30 sec
 #ifndef USERMOD_BATTERY_MEASUREMENT_INTERVAL
   #define USERMOD_BATTERY_MEASUREMENT_INTERVAL 30000

--- a/usermods/Battery/readme.md
+++ b/usermods/Battery/readme.md
@@ -37,6 +37,7 @@ define `USERMOD_BATTERY` in `wled00/my_config.h`
 | ----------------------------------------------- | ----------- |-------------------------------------------------------------------------------------- |
 | `USERMOD_BATTERY`                               |             | define this (in `my_config.h`) to have this usermod included wled00\usermods_list.cpp |
 | `USERMOD_BATTERY_MEASUREMENT_PIN`               |             | defaults to A0 on ESP8266 and GPIO35 on ESP32                                         |
+| `USERMOD_BATTERY_INITIAL_DELAY`                 | ms          | delay before initial reading. defaults to 10 seconds to allow voltage stabilization
 | `USERMOD_BATTERY_MEASUREMENT_INTERVAL`          | ms          | battery check interval. defaults to 30 seconds                                        |
 | `USERMOD_BATTERY_{TYPE}_MIN_VOLTAGE`            | v           | minimum battery voltage. default is 2.6 (18650 battery standard)                      |
 | `USERMOD_BATTERY_{TYPE}_MAX_VOLTAGE`            | v           | maximum battery voltage. default is 4.2 (18650 battery standard)                      |
@@ -85,6 +86,10 @@ Specification from:  [Molicel INR18650-M35A, 3500mAh 10A Lithium-ion battery, 3.
 - https://arduinodiy.wordpress.com/2016/12/25/monitoring-lipo-battery-voltage-with-wemos-d1-minibattery-shield-and-thingspeak/
 
 ## 📝 Change Log
+
+2024-04-30
+
+- improved initial reading accuracy by delaying initial measurement to allow voltage to stabilize at power-on
 
 2024-04-30
 


### PR DESCRIPTION
When taking the initial voltage reading after first powering on, voltage hasn't had chance to stabilize so the reading can be inaccurate, which in turn may incorrectly trigger the low-power preset. (Manifests when the user has selected a low read interval and/or is using a capacitor).

Resolution: A non-blocking, fixed 10 second delay has been added to the initial voltage reading to give the voltage time to stabilize.

Thankyou!