### PR TITLE
Add changeable i2c address to BME280 usermod

### DIFF
--- a/usermods/BME280_v2/README.md
+++ b/usermods/BME280_v2/README.md
@@ -7,6 +7,7 @@ This Usermod is designed to read a `BME280` or `BMP280` sensor and output the fo
 - Dew Point (`BME280` only)
 
 Configuration is performed via the Usermod menu.  There are no parameters to set in code!  The following settings can be configured in the Usermod Menu:
+- The i2c address in decimal. Set it to either 118 (0x76, the default) or 119 (0x77). **Requires reboot**.
 - Temperature Decimals (number of decimal places to output)
 - Humidity Decimals
 - Pressure Decimals

--- a/usermods/BME280_v2/README.md
+++ b/usermods/BME280_v2/README.md
@@ -7,7 +7,7 @@ This Usermod is designed to read a `BME280` or `BMP280` sensor and output the fo
 - Dew Point (`BME280` only)
 
 Configuration is performed via the Usermod menu.  There are no parameters to set in code!  The following settings can be configured in the Usermod Menu:
-- The i2c address in decimal. Set it to either 118 (0x76, the default) or 119 (0x77). **Requires reboot**.
+- The i2c address in decimal. Set it to either 118 (0x76, the default) or 119 (0x77).
 - Temperature Decimals (number of decimal places to output)
 - Humidity Decimals
 - Pressure Decimals

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -24,6 +24,7 @@ private:
   uint8_t  PressureDecimals = 0;    // Number of decimal places in published pressure values
   uint16_t TemperatureInterval = 5; // Interval to measure temperature (and humidity, dew point if available) in seconds
   uint16_t PressureInterval = 300;  // Interval to measure pressure in seconds
+  BME280I2C::I2CAddr I2CAddress = BME280I2C::I2CAddr_0x76;  // i2c address, defaults to 0x76
   bool PublishAlways = false;             // Publish values even when they have not changed
   bool UseCelsius = true;                 // Use Celsius for Reporting
   bool HomeAssistantDiscovery = false;    // Publish Home Assistant Device Information
@@ -35,20 +36,7 @@ private:
   #endif
   bool initDone = false;
 
-  // BME280 sensor settings
-  BME280I2C::Settings settings{
-      BME280::OSR_X16, // Temperature oversampling x16
-      BME280::OSR_X16, // Humidity oversampling x16
-      BME280::OSR_X16, // Pressure oversampling x16
-      // Defaults
-      BME280::Mode_Forced,
-      BME280::StandbyTime_1000ms,
-      BME280::Filter_Off,
-      BME280::SpiEnable_False,
-      BME280I2C::I2CAddr_0x76 // I2C address. I2C specific. Default 0x76
-  };
-
-  BME280I2C bme{settings};
+  BME280I2C bme;
 
   uint8_t sensorType;
 
@@ -183,6 +171,19 @@ private:
 
     void initializeBmeComms()
     {
+      BME280I2C::Settings settings{
+            BME280::OSR_X16,    // Temperature oversampling x16
+            BME280::OSR_X16,    // Humidity oversampling x16
+            BME280::OSR_X16,    // Pressure oversampling x16
+            BME280::Mode_Forced,
+            BME280::StandbyTime_1000ms,
+            BME280::Filter_Off,
+            BME280::SpiEnable_False,
+            I2CAddress
+        };
+
+      bme.setSettings(settings);
+      
       if (!bme.begin())
       {
         sensorType = 0;
@@ -213,7 +214,7 @@ public:
     if (i2c_scl<0 || i2c_sda<0) { enabled = false; sensorType = 0; return; }
     
     initializeBmeComms();
-    initDone=true;
+    initDone = true;
   }
 
   void loop()
@@ -403,7 +404,7 @@ public:
   {
     JsonObject top = root.createNestedObject(FPSTR(_name));
     top[FPSTR(_enabled)] = enabled;
-    top[F("I2CAddress")] = static_cast<uint8_t>(settings.bme280Addr);
+    top[F("I2CAddress")] = static_cast<uint8_t>(I2CAddress);
     top[F("TemperatureDecimals")] = TemperatureDecimals;
     top[F("HumidityDecimals")] = HumidityDecimals;
     top[F("PressureDecimals")] = PressureDecimals;
@@ -433,6 +434,8 @@ public:
     // A 3-argument getJsonValue() assigns the 3rd argument as a default value if the Json value is missing
     uint8_t tmpI2cAddress;
     configComplete &= getJsonValue(top[F("I2CAddress")], tmpI2cAddress, 0x76);
+    I2CAddress = static_cast<BME280I2C::I2CAddr>(tmpI2cAddress);
+
     configComplete &= getJsonValue(top[F("TemperatureDecimals")], TemperatureDecimals, 1);
     configComplete &= getJsonValue(top[F("HumidityDecimals")], HumidityDecimals, 0);
     configComplete &= getJsonValue(top[F("PressureDecimals")], PressureDecimals, 0);
@@ -441,9 +444,6 @@ public:
     configComplete &= getJsonValue(top[F("PublishAlways")], PublishAlways, false);
     configComplete &= getJsonValue(top[F("UseCelsius")], UseCelsius, true);
     configComplete &= getJsonValue(top[F("HomeAssistantDiscovery")], HomeAssistantDiscovery, false);
-
-    settings.bme280Addr = static_cast<BME280I2C::I2CAddr>(tmpI2cAddress);
-    bme.setSettings(settings);
 
     DEBUG_PRINT(FPSTR(_name));
     if (!initDone) {


### PR DESCRIPTION
The BME280 usermod assumes an address of 0x76 which is incorrect for the BMP280 chip, which defaults to 0x77. This change puts the i2c address into the config and defaults to 0x76. 

Notes:
* ~~This builds on #3965. I'll rebase when that's merged.~~
* ~~As of right now, WLED must be rebooted for the address change to take effect. I'm not much of a C++ developer to know the ins and outs of reinitializing the `BME280I2C` instance .. do I stop it? delete it? .. If that was fixed, rebooting wasn't necessary.~~
* The config shows up as a text field with integers. It's my understanding that I can't manipulate with how the configs are shown, f.ex. to make a dropdown. Should it instead be a textual field which is then parsed in the code as a hex string -- or is decimals fine? ..

New config view. The `I2CAddress` is new - here set to 0x77.

![image](https://github.com/Aircoookie/WLED/assets/1027111/6154838f-7aff-465f-aeac-21dc38d46fd5)
