### PR TITLE
fix: esp32 s3 zero rev v0.2 wifi not working

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -480,6 +480,7 @@ build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_qspi
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
+  -DLOLIN_WIFI_FIX ; seems to work much better with this
   -D WLED_WATCHDOG_TIMEOUT=0
   ${esp32.AR_build_flags}
 lib_deps = ${esp32s3.lib_deps}


### PR DESCRIPTION
This PR solves problems with the newly added support for `esp32s3_4M_qspi` for some esp32-s3 chip versions, where the wifi won't work.

I have two different esp32-s3 zero dev boards.

- ESP32-S3 (QFN56) (revision v0.2) seems to need the `LOLIN_WIFI_FIX` to get the wifi working.
- ESP32-S3 (QFN56) (revision v0.1) seems to work without the fix but also works perfectly fine with it.

It's a simple fix since it already exists for some other esp32 chip types by adding the `LOLIN_WIFI_FIX` build variable.