### PR TITLE
add ETH support for LILYGO-POE-Pro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ You are all set if you have enabled `Editor: Detect Indentation` in VS Code.
 
 #### Blocks
 
-Whether the opening bracket of e.g. an `if` block is in the same line as the condition or in a separate line is up to your discretion. If there is only one statement, leaving out block braches is acceptable.
+Whether the opening bracket of e.g. an `if` block is in the same line as the condition or in a separate line is up to your discretion. If there is only one statement, leaving out block brackets is acceptable.
 
 Good:  
 ```cpp
@@ -49,7 +49,7 @@ if (a == b) doStuff(a);
 ```
 
 There should always be a space between a keyword and its condition and between the condition and brace.  
-Within the condition, no space should be between the paranthesis and variables.  
+Within the condition, no space should be between the parenthesis and variables.  
 Spaces between variables and operators are up to the authors discretion.
 There should be no space between function names and their argument parenthesis.
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -328,7 +328,7 @@
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        12
+#define WLED_NUM_ETH_TYPES        13
 
 #define WLED_ETH_NONE              0
 #define WLED_ETH_WT32_ETH01        1
@@ -342,6 +342,7 @@
 #define WLED_ETH_ABCWLEDV43ETH     9
 #define WLED_ETH_SERG74           10
 #define WLED_ETH_ESP32_POE_WROVER 11
+#define WLED_ETH_LILYGO_T_POE_PRO 12
 
 //Hue error codes
 #define HUE_ERROR_INACTIVE        0

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -248,6 +248,7 @@ Static subnet mask:<br>
 				<option value="11">ESP32-POE-WROVER</option>
 				<option value="6">ESP32Deux/RGB2Go Tetra</option>
 				<option value="7">KIT-VE</option>
+				<option value="12">LILYGO T-POE Pro</option>
 				<option value="8">QuinLED-Dig-Octa & T-ETH-POE</option>
 				<option value="4">QuinLED-ESP32</option>
 				<option value="10">Serg74-ETH32</option>

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -133,6 +133,17 @@ const ethernet_settings ethernetBoards[] = {
     18,                   // eth_mdio,
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO0_OUT   // eth_clk_mode
+  },
+  
+  // LILYGO T-POE Pro
+  // https://github.com/Xinyuan-LilyGO/LilyGO-T-ETH-Series/blob/master/schematic/T-POE-PRO.pdf
+  {
+    0,			              // eth_address,
+    5,			              // eth_power,
+    23,			              // eth_mdc,
+    18,			              // eth_mdio,
+    ETH_PHY_LAN8720,      // eth_type,
+    ETH_CLOCK_GPIO0_OUT	// eth_clk_mode
   }
 };
 #endif


### PR DESCRIPTION
Also includes minor spelling corrections for `CONTRIBUTING.md`

Verified these settings using my LILYGO-POE-Pro board. I confirmed the connection is only over Ethernet, no Wifi.