### PR TITLE
Restore ability to configure multi-pin bus from build flags

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -801,6 +801,7 @@ class WS2812FX {  // 96 bytes
       getFirstSelectedSegId(void),
       getLastActiveSegmentId(void),
       getActiveSegsLightCapabilities(bool selectedOnly = false),
+      getNumPins(uint8_t busType),
       setPixelSegment(uint8_t n);
 
     inline uint8_t getBrightness(void) { return _brightness; }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1109,11 +1109,16 @@ void WS2812FX::finalizeInit(void)
     DEBUG_PRINTLN(F("No busses, init default"));
     const uint8_t defDataPins[] = {DATA_PINS};
     const uint16_t defCounts[] = {PIXEL_COUNTS};
-    const uint8_t defNumBusses = ((sizeof defDataPins) / (sizeof defDataPins[0]));
+    const uint8_t pinsPerBus = getNumPins(DEFAULT_LED_TYPE);
+    const uint8_t defNumBusses = ((sizeof defDataPins) / pinsPerBus);
     const uint8_t defNumCounts = ((sizeof defCounts)   / (sizeof defCounts[0]));
     uint16_t prevLen = 0;
     for (int i = 0; i < defNumBusses && i < WLED_MAX_BUSSES+WLED_MIN_VIRTUAL_BUSSES; i++) {
-      uint8_t defPin[] = {defDataPins[i]};
+      uint8_t defPin[pinsPerBus];
+      for (int j = 0; j < pinsPerBus; j++) {
+        uint8_t pin = j + i * pinsPerBus;
+        defPin[j] = defDataPins[pin]; 
+      }
       uint16_t start = prevLen;
       uint16_t count = defCounts[(i < defNumCounts) ? i : defNumCounts -1];
       prevLen += count;
@@ -1442,6 +1447,18 @@ uint8_t WS2812FX::getFirstSelectedSegId(void)
   }
   // if none selected, use the main segment
   return getMainSegmentId();
+}
+
+uint8_t WS2812FX::getNumPins(uint8_t busType) {
+  if (IS_PWM(busType)) {
+    return NUM_PWM_PINS(busType);
+  }
+  else if (IS_2PIN(busType)) {
+    return 2;
+  }
+  else {
+    return 1;
+  }
 }
 
 void WS2812FX::setMainSegmentId(uint8_t n) {


### PR DESCRIPTION
I have tweaked finalizeInit() to support multi-pin busses (clocked strips, analog 2ch+). My understanding is that this was working at one point in the past since some default environments (e.g. env:Athom_RGBCW) have flags for led types that require multiple pins.  

My implementation uses a function to calculate the number of required pins for the given bus type and then divides the number of pins passed at compile time by this amount to figure out the amount of busses to create. 

I have tested all possible combinations I could think of. Here's what happens based on the amount of data pins provided and the bus type:
1. If the bus type requires more pins than provided, no output gets configured.
2. If the bus type requires a fraction of the pins provided, outputs get configured until you run out of pins. So if you have 4 pins and a type of LED that requires 2 pins, output 1 will use the first and second pins, output 2 will use the third and fourth. If you have 5 pins configured, the 5th pin is not used since you'd need 6 to configure 3x of an LED type that requires 2 pins.
3. If the bus type requires the same amount of pins provided, one output gets configured with all the provided pins.

All LED types are supported with the exception of network ones. The pins are used instead to build the IP, but this is unwanted behavior, especially because currently they return TRUE on IS_2PIN (since their type is > 47).