### PR TITLE
Allow 2D panel to be larger than 256px in both dimensions

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -855,8 +855,8 @@ class WS2812FX {  // 96 bytes
     typedef struct panel_t {
       uint16_t xOffset; // x offset relative to the top left of matrix in LEDs
       uint16_t yOffset; // y offset relative to the top left of matrix in LEDs
-      uint8_t  width;   // width of the panel
-      uint8_t  height;  // height of the panel
+      uint16_t width;   // width of the panel
+      uint16_t height;  // height of the panel
       union {
         uint8_t options;
         struct {

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -401,7 +401,7 @@
 #endif
 
 #ifndef MAX_LEDS_PER_BUS
-#define MAX_LEDS_PER_BUS 2048   // may not be enough for fast LEDs (i.e. APA102)
+#define MAX_LEDS_PER_BUS 4096   // may not be enough for fast LEDs (i.e. APA102)
 #endif
 
 // string temp buffer (now stored in stack locally)


### PR DESCRIPTION
Increase MAX_LEDS_PER_BUS and change width and height type in WS2812FX class to uint16_t from uint8_t, which overflowed when attempted to configure a panel larger than 255 pixels.