### PR TITLE
platform.ini cleanup + version bumps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,107 +19,37 @@ extra_configs =
   platformio_override.ini
 
 [common]
-# ------------------------------------------------------------------------------
-# PLATFORM:
-#   !! DO NOT confuse platformio's ESP8266 development platform with Arduino core for ESP8266
-#
-#   arduino core 2.6.3 = platformIO 2.3.2
-#   arduino core 2.7.0 = platformIO 2.5.0
-# ------------------------------------------------------------------------------
-arduino_core_2_6_3 = espressif8266@2.3.3
-arduino_core_2_7_4 = espressif8266@2.6.2
-arduino_core_3_0_0 = espressif8266@3.0.0
-arduino_core_3_0_2 = espressif8266@3.2.0
-arduino_core_3_1_0 = espressif8266@4.1.0
-arduino_core_3_1_2 = espressif8266@4.2.1
-
-# Development platforms
-arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
-arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
-
-# Platform to use for ESP8266
-platform_wled_default = ${common.arduino_core_3_1_2}
-# We use 2.7.4.7 for all, includes PWM flicker fix and Wstring optimization
-#platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.200502
-                    platformio/tool-esptool #@ ~1.413.0
-                    platformio/tool-esptoolpy #@ ~1.30000.0
-
-## previous platform for 8266, in case of problems with the new one
-## you'll need  makuna/NeoPixelBus@ 2.6.9 for arduino_core_3_0_2, which does not support Ucs890x
-;; platform_wled_default = ${common.arduino_core_3_0_2}
-;; platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-;;                    platformio/toolchain-xtensa @ ~2.40802.200502
-;;                    platformio/tool-esptool @ ~1.413.0
-;;                    platformio/tool-esptoolpy @ ~1.30000.0
+# ldscript (available ldscripts at https://github.com/esp8266/Arduino/tree/master/tools/sdk/ld)
+#    ldscript_2m1m (2048 KB) = 1019 KB sketch, 4 KB eeprom, 1004 KB spiffs, 16 KB reserved
+#    ldscript_4m1m (4096 KB) = 1019 KB sketch, 4 KB eeprom, 1002 KB spiffs, 16 KB reserved, 2048 KB empty/ota?
+ldscript_1m128k = eagle.flash.1m128.ld
+ldscript_2m512k = eagle.flash.2m512.ld
+ldscript_2m1m = eagle.flash.2m1m.ld
+ldscript_4m1m = eagle.flash.4m1m.ld
 
 # ------------------------------------------------------------------------------
 # FLAGS: DEBUG
 # esp8266 : see https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
 # esp32   : see https://docs.platformio.org/en/latest/platforms/espressif32.html#debug-level
 # ------------------------------------------------------------------------------
-debug_flags = -D DEBUG=1 -D WLED_DEBUG
-  -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM ;; for esp8266
+debug_flags =
+  -g
+  -DDEBUG=1
+  -DWLED_DEBUG
+  -DDEBUG_ESP_WIFI
+  -DDEBUG_ESP_HTTP_CLIENT
+  -DDEBUG_ESP_HTTP_UPDATE
+  -DDEBUG_ESP_HTTP_SERVER
+  -DDEBUG_ESP_UPDATER
+  -DDEBUG_ESP_OTA
+  -DDEBUG_TLS_MEM
   # if needed (for memleaks etc) also add; -DDEBUG_ESP_OOM -include "umm_malloc/umm_malloc_cfg.h"
   # -DDEBUG_ESP_CORE is not working right now
 
 # ------------------------------------------------------------------------------
-# FLAGS: ldscript (available ldscripts at https://github.com/esp8266/Arduino/tree/master/tools/sdk/ld)
-#    ldscript_2m1m (2048 KB) = 1019 KB sketch, 4 KB eeprom, 1004 KB spiffs, 16 KB reserved
-#    ldscript_4m1m (4096 KB) = 1019 KB sketch, 4 KB eeprom, 1002 KB spiffs, 16 KB reserved, 2048 KB empty/ota?
-#
-# Available lwIP variants (macros):
-#    -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH  = v1.4 Higher Bandwidth (default)
-#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY       = v2 Lower Memory
-#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH = v2 Higher Bandwidth
-#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
-#
-# BearSSL performance:
-#  When building with -DSECURE_CLIENT=SECURE_CLIENT_BEARSSL, please add `board_build.f_cpu = 160000000` to the environment configuration
-#
-# BearSSL ciphers:
-#   When building on core >= 2.5, you can add the build flag -DBEARSSL_SSL_BASIC in order to build BearSSL with a limited set of ciphers:
-#     TLS_RSA_WITH_AES_128_CBC_SHA256 / AES128-SHA256
-#     TLS_RSA_WITH_AES_256_CBC_SHA256 / AES256-SHA256
-#     TLS_RSA_WITH_AES_128_CBC_SHA / AES128-SHA
-#     TLS_RSA_WITH_AES_256_CBC_SHA / AES256-SHA
-#  This reduces the OTA size with ~45KB, so it's especially useful on low memory boards (512k/1m).
-# ------------------------------------------------------------------------------
-build_flags =
-  -DMQTT_MAX_PACKET_SIZE=1024
-  -DSECURE_CLIENT=SECURE_CLIENT_BEARSSL
-  -DBEARSSL_SSL_BASIC
-  -D CORE_DEBUG_LEVEL=0
-  -D NDEBUG
-  -Wno-attributes ;; silence warnings about unknown attribute 'maybe_unused' in NeoPixelBus
-  #build_flags for the IRremoteESP8266 library (enabled decoders have to appear here)
-  -D _IR_ENABLE_DEFAULT_=false
-  -D DECODE_HASH=true
-  -D DECODE_NEC=true
-  -D DECODE_SONY=true
-  -D DECODE_SAMSUNG=true
-  -D DECODE_LG=true
-  -DWLED_USE_MY_CONFIG
-
-build_unflags =
-
-ldscript_1m128k = eagle.flash.1m128.ld
-ldscript_2m512k = eagle.flash.2m512.ld
-ldscript_2m1m = eagle.flash.2m1m.ld
-ldscript_4m1m = eagle.flash.4m1m.ld
-
-[scripts_defaults]
-extra_scripts =
-  pre:pio-scripts/set_version.py
-  post:pio-scripts/output_bins.py
-  post:pio-scripts/strip-floats.py
-  pre:pio-scripts/user_config_copy.py
-  pre:pio-scripts/build_ui.py
-  ; post:pio-scripts/obj-dump.py  ;; convenience script to create a disassembly dump of the firmware (hardcore debugging)
-
-# ------------------------------------------------------------------------------
 # COMMON SETTINGS:
 # ------------------------------------------------------------------------------
+
 [env]
 framework = arduino
 board_build.flash_mode = dout
@@ -136,7 +66,7 @@ upload_speed = 115200
 # ------------------------------------------------------------------------------
 lib_compat_mode = strict
 lib_deps =
-    fastled/FastLED @ 3.6.0
+    fastled/FastLED @ 3.7.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.8.0
     #https://github.com/makuna/NeoPixelBus.git#CoreShaderBeta
@@ -165,7 +95,7 @@ lib_deps =
     ; https://github.com/adafruit/Adafruit_MAX1704X @ 1.0.2
   #For MPU6050 IMU uncomment follwoing
     ;electroniccats/MPU6050 @1.0.1
-  # For -D USERMOD_ANIMARTRIX
+  # For -DUSERMOD_ANIMARTRIX
   # CC BY-NC 3.0 licensed effects by Stefan Petrick, include this usermod only if you accept the terms!
     ;https://github.com/netmindz/animartrix.git#18bf17389e57c69f11bc8d04ebe1d215422c7fb7
   # SHT85
@@ -173,10 +103,58 @@ lib_deps =
   # Audioreactive usermod
     ;kosme/arduinoFFT @ 2.0.1
 
-extra_scripts = ${scripts_defaults.extra_scripts}
+extra_scripts =
+  pre:pio-scripts/set_version.py
+  post:pio-scripts/output_bins.py
+  post:pio-scripts/strip-floats.py
+  pre:pio-scripts/user_config_copy.py
+  pre:pio-scripts/build_ui.py
+  ; post:pio-scripts/obj-dump.py  ;; convenience script to create a disassembly dump of the firmware (hardcore debugging)
+
+# ------------------------------------------------------------------------------
+# Available lwIP variants (macros):
+#    -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH  = v1.4 Higher Bandwidth (default)
+#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY       = v2 Lower Memory
+#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH = v2 Higher Bandwidth
+#    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH
+#
+# BearSSL performance:
+#  When building with -DSECURE_CLIENT=SECURE_CLIENT_BEARSSL, please add `board_build.f_cpu = 160000000` to the environment configuration
+#
+# BearSSL ciphers:
+#   When building on core >= 2.5, you can add the build flag -DBEARSSL_SSL_BASIC in order to build BearSSL with a limited set of ciphers:
+#     TLS_RSA_WITH_AES_128_CBC_SHA256 / AES128-SHA256
+#     TLS_RSA_WITH_AES_256_CBC_SHA256 / AES256-SHA256
+#     TLS_RSA_WITH_AES_128_CBC_SHA / AES128-SHA
+#     TLS_RSA_WITH_AES_256_CBC_SHA / AES256-SHA
+#  This reduces the OTA size with ~45KB, so it's especially useful on low memory boards (512k/1m).
+# ------------------------------------------------------------------------------
+build_flags =
+  -std=gnu++17
+  -DMQTT_MAX_PACKET_SIZE=1024
+  -DSECURE_CLIENT=SECURE_CLIENT_BEARSSL
+  -DBEARSSL_SSL_BASIC
+  -DCORE_DEBUG_LEVEL=0
+  -DNDEBUG
+  -Wno-attributes ; silence warnings about unknown attribute 'maybe_unused' in NeoPixelBus
+  #build_flags for the IRremoteESP8266 library (enabled decoders have to appear here)
+  -D_IR_ENABLE_DEFAULT_=false
+  -DDECODE_HASH=true
+  -DDECODE_NEC=true
+  -DDECODE_SONY=true
+  -DDECODE_SAMSUNG=true
+  -DDECODE_LG=true
+  -DWLED_USE_MY_CONFIG
+  ; ${common.debug_flags}
+
+build_unflags =
+  -std=gnu++11
 
 [esp8266]
+platform = espressif8266@4.2.1
+monitor_filters = esp8266_exception_decoder
 build_flags =
+  ${env.build_flags}
   -DESP8266
   -DFP_IN_IROM
   ;-Wno-deprecated-declarations
@@ -195,25 +173,22 @@ build_flags =
   -DMIMETYPE_MINIMAL
   ; other special-purpose framework flags (see https://docs.platformio.org/en/latest/platforms/espressif8266.html)
   ; decrease code cache size and increase IRAM to fit all pixel functions
-  -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48 ;; in case of linker errors like "section `.text1' will not fit in region `iram1_0_seg'"
-  ; -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED ;; (experimental) adds some extra heap, but may cause slowdown
+  -DPIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48 ;; in case of linker errors like "section `.text1' will not fit in region `iram1_0_seg'"
+  ; -DPIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED ;; (experimental) adds some extra heap, but may cause slowdown
 
 lib_deps =
-  #https://github.com/lorol/LITTLEFS.git
+  ${env.lib_deps}
   ESPAsyncTCP @ 1.2.2
   ESPAsyncUDP
-  ${env.lib_deps}
 
 [esp32]
-#platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
-platform = espressif32@3.5.0
-platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
-build_flags = -g
+platform = espressif32@6.7.0
+; platform_packages = toolchain-xtensa-esp32@~12.2
+monitor_filters = esp32_exception_decoder
+build_flags =
+  ${env.build_flags}
   -DARDUINO_ARCH_ESP32
-  #-DCONFIG_LITTLEFS_FOR_IDF_3_2
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
-  -D LOROL_LITTLEFS
+  -DCONFIG_ASYNC_TCP_USE_WDT=0
   ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
 tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
@@ -221,83 +196,67 @@ extended_partitions = tools/WLED_ESP32_4MB_700k_FS.csv
 big_partitions = tools/WLED_ESP32_4MB_256KB_FS.csv     ;; 1.8MB firmware, 256KB filesystem, coredump support
 large_partitions = tools/WLED_ESP32_8MB.csv
 extreme_partitions = tools/WLED_ESP32_16MB_9MB_FS.csv
+board_build.partitions = ${esp32.default_partitions}
 lib_deps =
-  https://github.com/lorol/LITTLEFS.git
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
+  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
 # additional build flags for audioreactive
-AR_build_flags = -D USERMOD_AUDIOREACTIVE
+AR_build_flags = -DUSERMOD_AUDIOREACTIVE
 AR_lib_deps = kosme/arduinoFFT @ 2.0.1
 
 [esp32_idf_V4]
 ;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
-;; very similar to the normal ESP32 flags, but omitting Lorol LittleFS, as littlefs is included in the new framework already.
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
-platform = espressif32@ ~6.3.2
-platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-build_flags = -g
+extends = esp32
+build_flags =
+  ${esp32.build_flags}
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
-  -DARDUINO_ARCH_ESP32 -DESP32
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -DESP32
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-lib_deps =
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
-  ${env.lib_deps}
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
-platform = espressif32@ ~6.3.2
-platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-build_flags = -g
-  -DARDUINO_ARCH_ESP32
+extends = esp32
+build_flags =
+  ${esp32.build_flags}
   -DARDUINO_ARCH_ESP32S2
   -DCONFIG_IDF_TARGET_ESP32S2=1
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0
+  -DCONFIG_ASYNC_TCP_USE_WDT=0
+  -DARDUINO_USB_MSC_ON_BOOT=0
+  -DARDUINO_USB_DFU_ON_BOOT=0
   -DCO
   -DARDUINO_USB_MODE=0 ;; this flag is mandatory for ESP32-S2 !
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_CDC_ON_BOOT
-lib_deps =
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
-  ${env.lib_deps}
-
-[esp32c3]
-;; generic definitions for all ESP32-C3 boards
-platform = espressif32@ ~6.3.2
-platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-build_flags = -g
-  -DARDUINO_ARCH_ESP32
-  -DARDUINO_ARCH_ESP32C3
-  -DCONFIG_IDF_TARGET_ESP32C3=1
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -DCO
-  -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
-  ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
-  ;; ARDUINO_USB_CDC_ON_BOOT
-lib_deps =
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
-  ${env.lib_deps}
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
-platform = espressif32@ ~6.3.2
-platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-build_flags = -g
+extends = esp32
+build_flags =
+  ${esp32.build_flags}
   -DESP32
-  -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32S3
   -DCONFIG_IDF_TARGET_ESP32S3=1
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -DCONFIG_ASYNC_TCP_USE_WDT=0
   -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_DFU_ON_BOOT=0
   -DCO
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
   ;; ARDUINO_USB_MODE, ARDUINO_USB_CDC_ON_BOOT
-lib_deps =
-  https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
-  ${env.lib_deps}
+
+[esp32c3]
+;; generic definitions for all ESP32-C3 boards
+extends = esp32
+build_flags =
+  ${esp32.build_flags}
+  -DARDUINO_ARCH_ESP32C3
+  -DCONFIG_IDF_TARGET_ESP32C3=1
+  -DCONFIG_ASYNC_TCP_USE_WDT=0
+  -DCO
+  -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
+  ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
+  ;; ARDUINO_USB_CDC_ON_BOOT
 
 
 # ------------------------------------------------------------------------------
@@ -305,215 +264,204 @@ lib_deps =
 # ------------------------------------------------------------------------------
 
 [env:nodemcuv2]
+extends = esp8266
 board = nodemcuv2
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP8266 #-DWLED_DISABLE_2D
-lib_deps = ${esp8266.lib_deps}
-monitor_filters = esp8266_exception_decoder
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP8266
+  #-DWLED_DISABLE_2D
 
 [env:nodemcuv2_160]
 extends = env:nodemcuv2
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP8266_160 #-DWLED_DISABLE_2D
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP8266_160
+  #-DWLED_DISABLE_2D
 
 [env:esp8266_2m]
+extends = esp8266
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP02
-lib_deps = ${esp8266.lib_deps}
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP02
 
 [env:esp8266_2m_160]
 extends = env:esp8266_2m
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP02_160
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP02_160
 
 [env:esp01_1m_full]
+extends = esp8266
 board = esp01_1m
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP01 -D WLED_DISABLE_OTA
-  ; -D WLED_USE_REAL_MATH ;; may fix wrong sunset/sunrise times, at the cost of 7064 bytes FLASH and 975 bytes RAM
-lib_deps = ${esp8266.lib_deps}
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP01
+  -DWLED_DISABLE_OTA
+  ; -DWLED_USE_REAL_MATH ;; may fix wrong sunset/sunrise times, at the cost of 7064 bytes FLASH and 975 bytes RAM
 
 [env:esp01_1m_full_160]
 extends = env:esp01_1m_full
 board_build.f_cpu = 160000000L
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=ESP01_160 -D WLED_DISABLE_OTA
-  ; -D WLED_USE_REAL_MATH ;; may fix wrong sunset/sunrise times, at the cost of 7064 bytes FLASH and 975 bytes RAM
+build_flags =
+  ${esp8266.build_flags}
+  -DWLED_RELEASE_NAME=ESP01_160
+  -DWLED_DISABLE_OTA
+  ; -DWLED_USE_REAL_MATH ;; may fix wrong sunset/sunrise times, at the cost of 7064 bytes FLASH and 975 bytes RAM
 
 [env:esp32dev]
+extends = esp32
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=ESP32 #-D WLED_DISABLE_BROWNOUT_DET
-lib_deps = ${esp32.lib_deps}
-monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32.default_partitions}
+build_flags =
+  ${esp32.build_flags}
+  -DWLED_RELEASE_NAME=ESP32
+  #-DWLED_DISABLE_BROWNOUT_DET
 
 [env:esp32dev_8M]
+extends = esp32_idf_V4
 board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=ESP32_8M #-D WLED_DISABLE_BROWNOUT_DET
+build_flags =
+  ${esp32_idf_V4.build_flags}
+  -DWLED_RELEASE_NAME=ESP32_8M
+  #-DWLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
-lib_deps = ${esp32_idf_V4.lib_deps}
+lib_deps =
+  ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps}
-monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.large_partitions}
 ; board_build.f_flash = 80000000L
 
 [env:esp32dev_audioreactive]
+extends = esp32
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=ESP32_audioreactive #-D WLED_DISABLE_BROWNOUT_DET
+build_flags =
+  ${esp32.build_flags}
+  -DWLED_RELEASE_NAME=ESP32_audioreactive
+  #-DWLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
-lib_deps = ${esp32.lib_deps}
+lib_deps =
+  ${esp32.lib_deps}
   ${esp32.AR_lib_deps}
-monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32.default_partitions}
 ; board_build.f_flash = 80000000L
 ; board_build.flash_mode = dio
 
 [env:esp32_eth]
+extends = esp32
 board = esp32-poe
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
 upload_speed = 921600
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=ESP32_Ethernet -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
-  -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
-lib_deps = ${esp32.lib_deps}
-board_build.partitions = ${esp32.default_partitions}
+build_flags =
+  ${esp32.build_flags}
+  -DWLED_RELEASE_NAME=ESP32_Ethernet
+  -DRLYPIN=-1
+  -DWLED_USE_ETHERNET
+  -DBTNPIN=-1
+  -DWLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only
 
 [env:esp32_wrover]
 extends = esp32_idf_V4
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-board_build.partitions = ${esp32.default_partitions}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=ESP32_WROVER
-  -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
-  -D LEDPIN=25
+build_flags =
+  ${esp32_idf_V4.build_flags}
+  -DWLED_RELEASE_NAME=ESP32_WROVER
+  -DBOARD_HAS_PSRAM
+  -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
+  -DLEDPIN=25
   ; ${esp32.AR_build_flags}
-lib_deps = ${esp32_idf_V4.lib_deps}
-  ; ${esp32.AR_lib_deps}
 
 [env:esp32c3dev]
 extends = esp32c3
-platform = ${esp32c3.platform}
-platform_packages = ${esp32c3.platform_packages}
-framework = arduino
 board = esp32-c3-devkitm-1
-board_build.partitions = ${esp32.default_partitions}
-build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=ESP32-C3
-  -D WLED_WATCHDOG_TIMEOUT=0
+build_flags =
+  ${esp32c3.build_flags}
+  -DWLED_RELEASE_NAME=ESP32-C3
+  -DWLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
   ;-DARDUINO_USB_CDC_ON_BOOT=0   ;; for serial-to-USB chip
 upload_speed = 460800
-build_unflags = ${common.build_unflags}
-lib_deps = ${esp32c3.lib_deps}
 
 [env:esp32s3dev_16MB_opi]
 ;; ESP32-S3 development board, with 16MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)
+extends = esp32s3
 board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
 board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_16MB_opi
-  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
-  ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
-  -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
+build_flags =
+  ${esp32s3.build_flags}
+  -DWLED_RELEASE_NAME=ESP32-S3_16MB_opi
+  -DCONFIG_LITTLEFS_FOR_IDF_3_2
+  -DWLED_WATCHDOG_TIMEOUT=0
+  ;-DARDUINO_USB_CDC_ON_BOOT=0  ;; -DARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
+  -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   ${esp32.AR_build_flags}
-lib_deps = ${esp32s3.lib_deps}
+lib_deps =
+  ${esp32s3.lib_deps}
   ${esp32.AR_lib_deps}
 board_build.partitions = ${esp32.extreme_partitions}
-board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
+board_build.f_flash = 80000000L
 
 [env:esp32s3dev_8MB_opi]
 ;; ESP32-S3 development board, with 8MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)
-board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
-board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
-upload_speed = 921600
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_8MB_opi
-  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
-  ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
-  -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
+extends = env:esp32s3dev_16MB_opi
+build_flags =
+  ${esp32s3.build_flags}
+  -DWLED_RELEASE_NAME=ESP32-S3_8MB_opi
+  -DCONFIG_LITTLEFS_FOR_IDF_3_2
+  -DWLED_WATCHDOG_TIMEOUT=0
+  ;-DARDUINO_USB_CDC_ON_BOOT=0  ;; -DARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
+  -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   ${esp32.AR_build_flags}
-lib_deps = ${esp32s3.lib_deps}
-  ${esp32.AR_lib_deps}
 board_build.partitions = ${esp32.large_partitions}
-board_build.f_flash = 80000000L
-board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
 
 [env:esp32s3_4M_qspi]
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
-board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM 
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
+extends = esp32s3
+board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM
 upload_speed = 921600
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_qspi
+build_flags =
+  ${esp32s3.build_flags}
+  -DWLED_RELEASE_NAME=ESP32-S3_4M_qspi
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   -DLOLIN_WIFI_FIX ; seems to work much better with this
-  -D WLED_WATCHDOG_TIMEOUT=0
+  -DWLED_WATCHDOG_TIMEOUT=0
   ${esp32.AR_build_flags}
-lib_deps = ${esp32s3.lib_deps}
+lib_deps =
+  ${esp32s3.lib_deps}
   ${esp32.AR_lib_deps}
-board_build.partitions = ${esp32.default_partitions}
-board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
+board_build.f_flash = 80000000L
 
 [env:lolin_s2_mini]
-platform = ${esp32s2.platform}
-platform_packages = ${esp32s2.platform_packages}
+extends = esp32s2
 board = lolin_s2_mini
-board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = qio
 board_build.f_flash = 80000000L
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2
+build_flags =
+  ${esp32s2.build_flags}
+  -DWLED_RELEASE_NAME=ESP32-S2
   -DARDUINO_USB_CDC_ON_BOOT=1
-  -DARDUINO_USB_MSC_ON_BOOT=0
-  -DARDUINO_USB_DFU_ON_BOOT=0
   -DBOARD_HAS_PSRAM
   -DLOLIN_WIFI_FIX ; seems to work much better with this
-  -D WLED_WATCHDOG_TIMEOUT=0
-  -D CONFIG_ASYNC_TCP_USE_WDT=0
-  -D LEDPIN=16
-  -D HW_PIN_SCL=35
-  -D HW_PIN_SDA=33
-  -D HW_PIN_CLOCKSPI=7
-  -D HW_PIN_DATASPI=11
-  -D HW_PIN_MISOSPI=9
-;  -D STATUSLED=15
+  -DWLED_WATCHDOG_TIMEOUT=0
+  -DLEDPIN=16
+  -DHW_PIN_SCL=35
+  -DHW_PIN_SDA=33
+  -DHW_PIN_CLOCKSPI=7
+  -DHW_PIN_DATASPI=11
+  -DHW_PIN_MISOSPI=9
+;  -DSTATUSLED=15
   ${esp32.AR_build_flags}
-lib_deps = ${esp32s2.lib_deps}
+lib_deps =
+  ${esp32s2.lib_deps}
   ${esp32.AR_lib_deps}


### PR DESCRIPTION
## Goals

1. Make the platform.ini file easier to understand and read.
2. Being able to use more recent compiler and c++ versions (in all environments, instead of most environments). This will enable future improvements, that I am working on.

## Changes

- make formatting more uniform
- organize environments hierarchically
- remove duplications
- upgrade platform versions
- remove some obsolete dependencies
- upgrade some dependencies while at it
- upgrade c++ version from gnu++11 to gnu++17 (fastled doesn't compile without gnu extensions)
- remove debug symbols from the esp32 release builds

## Discussion
### Platform Version Upgrade
Most environments were using relatively recent platform versions, but the base esp32 configuration was not. Upgrading it does increase image size. But that is a problem we have anyway, because we do have envs that use more recent platform versions. This change just results in fewer differences between environments. It also increases the minimum gcc version the code has to compile with, therefore enabling better features and more recent c++ versions.

### Dependencies:
The original LittleFS dependency was removed, because all platforms are now recent enough to include it anyway.

The other removed dependency is `framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4` that was used by the base esp32 configuration, but not all environments. I removed it because it is incompatible with the more recent platform version. 
I could however not figure out what it was good for originally, so hopefully this doesn't break anything? 
As far as I can tell, WLED runs fine without it on the ESP-WROOM-32 board. (Most other boards didn't use it.)

## Further Upgrade Options:
This PR brings the minimum GCC version from 5.2 to 8.4. It is possible to get it up to 12.2 by adding a line such as:
```
platform_packages = toolchain-xtensa-esp32@~12.2
```
That works, I tried it. It would however require specifying different toolchains for each architecture (I think).