### PR TITLE
Debug refactor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,7 @@ platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.2005
 # esp8266 : see https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
 # esp32   : see https://docs.platformio.org/en/latest/platforms/espressif32.html#debug-level
 # ------------------------------------------------------------------------------
-debug_flags = -D DEBUG=1 -D WLED_DEBUG
+debug_flags = -D DEBUG=1 -D WLED_DEBUG_ALL ;; or -D WLED_DEBUG -DWLED_DEBUG_FS -DWLED_DEBUG_FX -DWLED_DEBUG_BUS -DWLED_DEBUG_PINMANAGER -DWLED_DEBUG_USERMODS -DWLED_DEBUG_MATH
   -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM ;; for esp8266
   # if needed (for memleaks etc) also add; -DDEBUG_ESP_OOM -include "umm_malloc/umm_malloc_cfg.h"
   # -DDEBUG_ESP_CORE is not working right now

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -93,7 +93,14 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ;   -D WLED_WATCHDOG_TIMEOUT=10
 ;
 ; Create debug build (with remote debug)
+;   -D WLED_DEBUG_ALL ;; or
 ;   -D WLED_DEBUG
+;   -D WLED_DEBUG_FS
+;   -D WLED_DEBUG_FX
+;   -D WLED_DEBUG_BUS
+;   -D WLED_DEBUG_PINMANAGER
+;   -D WLED_DEBUG_USERMODS
+;   -D WLED_DEBUG_MATH
 ;   -D WLED_DEBUG_HOST='"192.168.0.100"'
 ;   -D WLED_DEBUG_PORT=7868
 ;

--- a/usermods/AHT10_v2/usermod_aht10.h
+++ b/usermods/AHT10_v2/usermod_aht10.h
@@ -114,8 +114,8 @@ private:
 
     String temp;
     serializeJson(doc, temp);
-    DEBUG_PRINTLN(t);
-    DEBUG_PRINTLN(temp);
+    DEBUGUM_PRINTLN(t);
+    DEBUGUM_PRINTLN(temp);
 
     mqtt->publish(t.c_str(), 0, true, temp.c_str());
   }
@@ -146,10 +146,10 @@ public:
     if (_lastStatus == AHT10_ERROR)
     {
       // Perform softReset and retry
-      DEBUG_PRINTLN(F("AHTxx returned error, doing softReset"));
+      DEBUGUM_PRINTLN(F("AHTxx returned error, doing softReset"));
       if (!_aht->softReset())
       {
-        DEBUG_PRINTLN(F("softReset failed"));
+        DEBUGUM_PRINTLN(F("softReset failed"));
         return;
       }
 
@@ -244,7 +244,7 @@ public:
     top[F("MqttHomeAssistantDiscovery")] = _mqttHomeAssistant;
 #endif
 
-    DEBUG_PRINTLN(F("AHT10 config saved."));
+    DEBUGUM_PRINTLN(F("AHT10 config saved."));
   }
 
   bool readFromConfig(JsonObject &root) override

--- a/usermods/Animated_Staircase/Animated_Staircase.h
+++ b/usermods/Animated_Staircase/Animated_Staircase.h
@@ -178,14 +178,14 @@ class Animated_Staircase : public Usermod {
           bottomSensorState = bottomSensorRead; // change previous state
           sensorChanged = true;
           publishMqtt(true, bottomSensorState ? "on" : "off");
-          DEBUG_PRINTLN(F("Bottom sensor changed."));
+          DEBUGUM_PRINTLN(F("Bottom sensor changed."));
         }
 
         if (topSensorRead != topSensorState) {
           topSensorState = topSensorRead; // change previous state
           sensorChanged = true;
           publishMqtt(false, topSensorState ? "on" : "off");
-          DEBUG_PRINTLN(F("Top sensor changed."));
+          DEBUGUM_PRINTLN(F("Top sensor changed."));
         }
 
         // Values read, reset the flags for next API call
@@ -202,8 +202,8 @@ class Animated_Staircase : public Usermod {
             // If the bottom sensor triggered, we need to swipe up, ON
             swipe = bottomSensorRead;
 
-            DEBUG_PRINT(F("ON -> Swipe "));
-            DEBUG_PRINTLN(swipe ? F("up.") : F("down."));
+            DEBUGUM_PRINT(F("ON -> Swipe "));
+            DEBUGUM_PRINTLN(swipe ? F("up.") : F("down."));
 
             if (onIndex == offIndex) {
               // Position the indices for a correct on-swipe
@@ -230,8 +230,8 @@ class Animated_Staircase : public Usermod {
         swipe = lastSensor;
         on = false;
 
-        DEBUG_PRINT(F("OFF -> Swipe "));
-        DEBUG_PRINTLN(swipe ? F("up.") : F("down."));
+        DEBUGUM_PRINT(F("OFF -> Swipe "));
+        DEBUGUM_PRINTLN(swipe ? F("up.") : F("down."));
       }
     }
 
@@ -273,12 +273,12 @@ class Animated_Staircase : public Usermod {
 
     void enable(bool enable) {
       if (enable) {
-        DEBUG_PRINTLN(F("Animated Staircase enabled."));
-        DEBUG_PRINT(F("Delay between steps: "));
-        DEBUG_PRINT(segment_delay_ms);
-        DEBUG_PRINT(F(" milliseconds.\nStairs switch off after: "));
-        DEBUG_PRINT(on_time_ms / 1000);
-        DEBUG_PRINTLN(F(" seconds."));
+        DEBUGUM_PRINTLN(F("Animated Staircase enabled."));
+        DEBUGUM_PRINT(F("Delay between steps: "));
+        DEBUGUM_PRINT(segment_delay_ms);
+        DEBUGUM_PRINT(F(" milliseconds.\nStairs switch off after: "));
+        DEBUGUM_PRINT(on_time_ms / 1000);
+        DEBUGUM_PRINTLN(F(" seconds."));
 
         if (!useUSSensorBottom)
           pinMode(bottomPIRorTriggerPin, INPUT_PULLUP);
@@ -311,7 +311,7 @@ class Animated_Staircase : public Usermod {
         strip.trigger();  // force strip update
         stateChanged = true;  // inform external devices/UI of change
         colorUpdated(CALL_MODE_DIRECT_CHANGE);
-        DEBUG_PRINTLN(F("Animated Staircase disabled."));
+        DEBUGUM_PRINTLN(F("Animated Staircase disabled."));
       }
       enabled = enable;
     }
@@ -400,7 +400,7 @@ class Animated_Staircase : public Usermod {
         staircase = root.createNestedObject(FPSTR(_name));
       }
       writeSensorsToJson(staircase);
-      DEBUG_PRINTLN(F("Staircase sensor state exposed in API."));
+      DEBUGUM_PRINTLN(F("Staircase sensor state exposed in API."));
     }
 
     /*
@@ -420,7 +420,7 @@ class Animated_Staircase : public Usermod {
         }
         if (en != enabled) enable(en);
         readSensorsFromJson(staircase);
-        DEBUG_PRINTLN(F("Staircase sensor state read from API."));
+        DEBUGUM_PRINTLN(F("Staircase sensor state read from API."));
       }
     }
 
@@ -452,7 +452,7 @@ class Animated_Staircase : public Usermod {
       staircase[FPSTR(_topEchoCm)]                 = topMaxDist;
       staircase[FPSTR(_bottomEchoCm)]              = bottomMaxDist;
       staircase[FPSTR(_togglePower)]               = togglePower;
-      DEBUG_PRINTLN(F("Staircase config saved."));
+      DEBUGUM_PRINTLN(F("Staircase config saved."));
     }
 
     /*
@@ -470,8 +470,8 @@ class Animated_Staircase : public Usermod {
 
       JsonObject top = root[FPSTR(_name)];
       if (top.isNull()) {
-        DEBUG_PRINT(FPSTR(_name));
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINT(FPSTR(_name));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 
@@ -498,13 +498,13 @@ class Animated_Staircase : public Usermod {
 
       togglePower = top[FPSTR(_togglePower)] | togglePower;  // staircase toggles power on/off
 
-      DEBUG_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(FPSTR(_name));
       if (!initDone) {
         // first run: reading from cfg.json
-        DEBUG_PRINTLN(F(" config loaded."));
+        DEBUGUM_PRINTLN(F(" config loaded."));
       } else {
         // changing parameters from settings page
-        DEBUG_PRINTLN(F(" config (re)loaded."));
+        DEBUGUM_PRINTLN(F(" config (re)loaded."));
         bool changed = false;
         if ((oldUseUSSensorTop != useUSSensorTop) ||
             (oldUseUSSensorBottom != useUSSensorBottom) ||

--- a/usermods/BH1750_v2/usermod_bh1750.h
+++ b/usermods/BH1750_v2/usermod_bh1750.h
@@ -104,8 +104,8 @@ private:
 
     String temp;
     serializeJson(doc, temp);
-    DEBUG_PRINTLN(t);
-    DEBUG_PRINTLN(temp);
+    DEBUGUM_PRINTLN(t);
+    DEBUGUM_PRINTLN(temp);
 
     mqtt->publish(t.c_str(), 0, true, temp.c_str());
   }
@@ -152,11 +152,11 @@ public:
             mqttInitialized = true;
           }
         mqtt->publish(mqttLuminanceTopic.c_str(), 0, true, String(lux).c_str());
-        DEBUG_PRINTLN(F("Brightness: ") + String(lux) + F("lx"));
+        DEBUGUM_PRINTLN(F("Brightness: ") + String(lux) + F("lx"));
       }
       else
       {
-        DEBUG_PRINTLN(F("Missing MQTT connection. Not publishing data"));
+        DEBUGUM_PRINTLN(F("Missing MQTT connection. Not publishing data"));
       }
 #endif
     }
@@ -202,7 +202,7 @@ public:
     top[FPSTR(_HomeAssistantDiscovery)] = HomeAssistantDiscovery;
     top[FPSTR(_offset)] = offset;
 
-    DEBUG_PRINTLN(F("BH1750 config saved."));
+    DEBUGUM_PRINTLN(F("BH1750 config saved."));
   }
 
   // called before setup() to populate properties from values stored in cfg.json
@@ -212,9 +212,9 @@ public:
     JsonObject top = root[FPSTR(_name)];
     if (top.isNull())
     {
-      DEBUG_PRINT(FPSTR(_name));
-      DEBUG_PRINT(F("BH1750"));
-      DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+      DEBUGUM_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(F("BH1750"));
+      DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
       return false;
     }
     bool configComplete = !top.isNull();
@@ -225,11 +225,11 @@ public:
     configComplete &= getJsonValue(top[FPSTR(_HomeAssistantDiscovery)], HomeAssistantDiscovery, false);
     configComplete &= getJsonValue(top[FPSTR(_offset)], offset, 1);
 
-    DEBUG_PRINT(FPSTR(_name));
+    DEBUGUM_PRINT(FPSTR(_name));
     if (!initDone) {
-      DEBUG_PRINTLN(F(" config loaded."));
+      DEBUGUM_PRINTLN(F(" config loaded."));
     } else {
-      DEBUG_PRINTLN(F(" config (re)loaded."));
+      DEBUGUM_PRINTLN(F(" config (re)loaded."));
     }
 
     return configComplete;

--- a/usermods/BME280_v2/usermod_bme280.h
+++ b/usermods/BME280_v2/usermod_bme280.h
@@ -154,8 +154,8 @@ private:
 
     String temp;
     serializeJson(doc, temp);
-    DEBUG_PRINTLN(t);
-    DEBUG_PRINTLN(temp);
+    DEBUGUM_PRINTLN(t);
+    DEBUGUM_PRINTLN(temp);
 
     mqtt->publish(t.c_str(), 0, true, temp.c_str());
   }
@@ -187,7 +187,7 @@ private:
       if (!bme.begin())
       {
         sensorType = 0;
-        DEBUG_PRINTLN(F("Could not find BME280 I2C sensor!"));
+        DEBUGUM_PRINTLN(F("Could not find BME280 I2C sensor!"));
       }
       else
       {
@@ -195,15 +195,15 @@ private:
         {
         case BME280::ChipModel_BME280:
           sensorType = 1;
-          DEBUG_PRINTLN(F("Found BME280 sensor! Success."));
+          DEBUGUM_PRINTLN(F("Found BME280 sensor! Success."));
           break;
         case BME280::ChipModel_BMP280:
           sensorType = 2;
-          DEBUG_PRINTLN(F("Found BMP280 sensor! No Humidity available."));
+          DEBUGUM_PRINTLN(F("Found BMP280 sensor! No Humidity available."));
           break;
         default:
           sensorType = 0;
-          DEBUG_PRINTLN(F("Found UNKNOWN sensor! Error!"));
+          DEBUGUM_PRINTLN(F("Found UNKNOWN sensor! Error!"));
         }
       }
     }
@@ -413,7 +413,7 @@ public:
     top[F("PublishAlways")] = PublishAlways;
     top[F("UseCelsius")] = UseCelsius;
     top[F("HomeAssistantDiscovery")] = HomeAssistantDiscovery;
-    DEBUG_PRINTLN(F("BME280 config saved."));
+    DEBUGUM_PRINTLN(F("BME280 config saved."));
   }
 
   // Read Usermod Config Settings
@@ -424,8 +424,8 @@ public:
 
     JsonObject top = root[FPSTR(_name)];
     if (top.isNull()) {
-      DEBUG_PRINT(F(_name));
-      DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+      DEBUGUM_PRINT(F(_name));
+      DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
       return false;
     }
     bool configComplete = !top.isNull();
@@ -445,13 +445,13 @@ public:
     configComplete &= getJsonValue(top[F("UseCelsius")], UseCelsius, true);
     configComplete &= getJsonValue(top[F("HomeAssistantDiscovery")], HomeAssistantDiscovery, false);
 
-    DEBUG_PRINT(FPSTR(_name));
+    DEBUGUM_PRINT(FPSTR(_name));
     if (!initDone) {
       // first run: reading from cfg.json
-      DEBUG_PRINTLN(F(" config loaded."));
+      DEBUGUM_PRINTLN(F(" config loaded."));
     } else {
       // changing parameters from settings page
-      DEBUG_PRINTLN(F(" config (re)loaded."));
+      DEBUGUM_PRINTLN(F(" config (re)loaded."));
 
       // Reset all known values
       sensorType = 0;

--- a/usermods/Battery/usermod_v2_Battery.h
+++ b/usermods/Battery/usermod_v2_Battery.h
@@ -136,15 +136,15 @@ class UsermodBattery : public Usermod
 
       #ifdef ARDUINO_ARCH_ESP32
         bool success = false;
-        DEBUG_PRINTLN(F("Allocating battery pin..."));
+        DEBUGUM_PRINTLN(F("Allocating battery pin..."));
         if (batteryPin >= 0 && digitalPinToAnalogChannel(batteryPin) >= 0) 
           if (pinManager.allocatePin(batteryPin, false, PinOwner::UM_Battery)) {
-            DEBUG_PRINTLN(F("Battery pin allocation succeeded."));
+            DEBUGUM_PRINTLN(F("Battery pin allocation succeeded."));
             success = true;
           }
 
         if (!success) {
-          DEBUG_PRINTLN(F("Battery pin allocation failed."));
+          DEBUGUM_PRINTLN(F("Battery pin allocation failed."));
           batteryPin = -1;  // allocation failed
         } else {
           pinMode(batteryPin, INPUT);
@@ -338,7 +338,7 @@ class UsermodBattery : public Usermod
       
       addBatteryToJsonObject(battery, true);
       
-      DEBUG_PRINTLN(F("Battery state exposed in JSON API."));
+      DEBUGUM_PRINTLN(F("Battery state exposed in JSON API."));
     }
 
 
@@ -356,7 +356,7 @@ class UsermodBattery : public Usermod
       if (!battery.isNull()) {
         getUsermodConfigFromJsonObject(battery);
       
-        DEBUG_PRINTLN(F("Battery state read from JSON API."));
+        DEBUGUM_PRINTLN(F("Battery state read from JSON API."));
       }
     }
     */
@@ -414,7 +414,7 @@ class UsermodBattery : public Usermod
       // read voltage in case calibration or voltage multiplier changed to see immediate effect
       bat->setVoltage(readVoltage());
 
-      DEBUG_PRINTLN(F("Battery config saved."));
+      DEBUGUM_PRINTLN(F("Battery config saved."));
     }
 
     void appendConfigData()
@@ -470,8 +470,8 @@ class UsermodBattery : public Usermod
       JsonObject battery = root[FPSTR(_name)];
       if (battery.isNull()) 
       {
-        DEBUG_PRINT(FPSTR(_name));
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINT(FPSTR(_name));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 
@@ -492,11 +492,11 @@ class UsermodBattery : public Usermod
         {
           // first run: reading from cfg.json
           batteryPin = newBatteryPin;
-          DEBUG_PRINTLN(F(" config loaded."));
+          DEBUGUM_PRINTLN(F(" config loaded."));
         } 
         else 
         {
-          DEBUG_PRINTLN(F(" config (re)loaded."));
+          DEBUGUM_PRINTLN(F(" config (re)loaded."));
 
           // changing parameters from settings page
           if (newBatteryPin != batteryPin) 

--- a/usermods/Cronixie/usermod_cronixie.h
+++ b/usermods/Cronixie/usermod_cronixie.h
@@ -114,8 +114,8 @@ class UsermodCronixie : public Usermod {
       //W Week of Month | WW Week of Year
       //D Day of Week | DD Day Of Month | DDD Day Of Year
 
-      DEBUG_PRINT(F("cset "));
-      DEBUG_PRINTLN(cronixieDisplay);
+      DEBUGUM_PRINT(F("cset "));
+      DEBUGUM_PRINTLN(cronixieDisplay);
       
       for (int i = 0; i < 6; i++)
       {
@@ -160,13 +160,13 @@ class UsermodCronixie : public Usermod {
           //case 'v': break; //user var1
         }
       }
-      DEBUG_PRINT(F("result "));
+      DEBUGUM_PRINT(F("result "));
       for (int i = 0; i < 5; i++)
       {
-        DEBUG_PRINT((int)dP[i]);
-        DEBUG_PRINT(" ");
+        DEBUGUM_PRINT((int)dP[i]);
+        DEBUGUM_PRINT(" ");
       }
-      DEBUG_PRINTLN((int)dP[5]);
+      DEBUGUM_PRINTLN((int)dP[5]);
 
       _overlayCronixie(); // refresh
     }

--- a/usermods/EleksTube_IPS/usermod_elekstube_ips.h
+++ b/usermods/EleksTube_IPS/usermod_elekstube_ips.h
@@ -91,7 +91,7 @@ class ElekstubeIPSUsermod : public Usermod {
       JsonObject top = root.createNestedObject(FPSTR(_name)); // usermodname
       top[FPSTR(_tubeSeg)] = tfts.tubeSegment;
       top[FPSTR(_digitOffset)] = tfts.digitOffset;
-      DEBUG_PRINTLN(F("EleksTube config saved."));
+      DEBUGUM_PRINTLN(F("EleksTube config saved."));
     }
 
     /**
@@ -101,11 +101,11 @@ class ElekstubeIPSUsermod : public Usermod {
      */
     bool readFromConfig(JsonObject &root) {
       // we look for JSON object: {"EleksTubeIPS": {"tubeSegment": 1, "digitOffset": 0}}
-      DEBUG_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(FPSTR(_name));
 
       JsonObject top = root[FPSTR(_name)];
       if (top.isNull()) {
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 

--- a/usermods/INA226_v2/usermod_ina226.h
+++ b/usermods/INA226_v2/usermod_ina226.h
@@ -120,7 +120,7 @@ private:
         _ina226 = new INA226_WE(_i2cAddress);
         if (!_ina226->init())
         {
-            DEBUG_PRINTLN(F("INA226 initialization failed!"));
+            DEBUGUM_PRINTLN(F("INA226 initialization failed!"));
             return;
         }
         _ina226->setCorrectionFactor(1.0);
@@ -287,8 +287,8 @@ private:
 
         String temp;
         serializeJson(doc, temp);
-        DEBUG_PRINTLN(t);
-        DEBUG_PRINTLN(temp);
+        DEBUGUM_PRINTLN(t);
+        DEBUGUM_PRINTLN(temp);
 
         mqtt->publish(t.c_str(), 0, true, temp.c_str());
     }
@@ -312,8 +312,8 @@ private:
 
         String temp;
         serializeJson(doc, temp);
-        DEBUG_PRINTLN(t);
-        DEBUG_PRINTLN(temp);
+        DEBUGUM_PRINTLN(t);
+        DEBUGUM_PRINTLN(temp);
 
         mqtt->publish(t.c_str(), 0, true, temp.c_str());
     }
@@ -462,7 +462,7 @@ public:
         top[F("MqttHomeAssistantDiscovery")] = _mqttHomeAssistant;
 #endif
 
-        DEBUG_PRINTLN(F("INA226 config saved."));
+        DEBUGUM_PRINTLN(F("INA226 config saved."));
     }
 
     bool readFromConfig(JsonObject &root) override

--- a/usermods/LD2410_v2/usermod_ld2410.h
+++ b/usermods/LD2410_v2/usermod_ld2410.h
@@ -82,8 +82,8 @@ class LD2410Usermod : public Usermod {
 
       String temp;
       serializeJson(doc, temp);
-      DEBUG_PRINTLN(t);
-      DEBUG_PRINTLN(temp);
+      DEBUGUM_PRINTLN(t);
+      DEBUGUM_PRINTLN(temp);
 
       mqtt->publish(t.c_str(), 0, true, temp.c_str());
     }
@@ -179,9 +179,9 @@ class LD2410Usermod : public Usermod {
       bool configComplete = !top.isNull();
       if (!configComplete)
       {
-        DEBUG_PRINT(FPSTR(_name));
-        DEBUG_PRINT(F("LD2410"));
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINT(FPSTR(_name));
+        DEBUGUM_PRINT(F("LD2410"));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 

--- a/usermods/MAX17048_v2/usermod_max17048.h
+++ b/usermods/MAX17048_v2/usermod_max17048.h
@@ -97,8 +97,8 @@ class  Usermod_MAX17048 : public Usermod {
 
         String temp;
         serializeJson(doc, temp);
-        DEBUG_PRINTLN(t);
-        DEBUG_PRINTLN(temp);
+        DEBUGUM_PRINTLN(t);
+        DEBUGUM_PRINTLN(temp);
 
         mqtt->publish(t.c_str(), 0, true, temp.c_str());
     }
@@ -151,8 +151,8 @@ class  Usermod_MAX17048 : public Usermod {
 
           publishMqtt("batteryVoltage", String(lastBattVoltage, VoltageDecimals).c_str());
           publishMqtt("batteryPercent", String(lastBattPercent, PercentDecimals).c_str());
-          DEBUG_PRINTLN(F("Battery Voltage: ") + String(lastBattVoltage, VoltageDecimals) + F("V"));
-          DEBUG_PRINTLN(F("Battery Percent: ") + String(lastBattPercent, PercentDecimals) + F("%"));
+          DEBUGUM_PRINTLN(F("Battery Voltage: ") + String(lastBattVoltage, VoltageDecimals) + F("V"));
+          DEBUGUM_PRINTLN(F("Battery Percent: ") + String(lastBattPercent, PercentDecimals) + F("%"));
         }
     }
 
@@ -232,8 +232,8 @@ class  Usermod_MAX17048 : public Usermod {
       top[FPSTR(_maxReadInterval)] = maxReadingInterval;
       top[FPSTR(_minReadInterval)] = minReadingInterval;
       top[FPSTR(_HomeAssistantDiscovery)] = HomeAssistantDiscovery;
-      DEBUG_PRINT(F(_name));
-      DEBUG_PRINTLN(F(" config saved."));
+      DEBUGUM_PRINT(F(_name));
+      DEBUGUM_PRINTLN(F(" config saved."));
     }
 
     bool readFromConfig(JsonObject& root)
@@ -241,8 +241,8 @@ class  Usermod_MAX17048 : public Usermod {
       JsonObject top = root[FPSTR(_name)];
 
       if (top.isNull()) {
-        DEBUG_PRINT(F(_name));
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINT(F(_name));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 
@@ -253,12 +253,12 @@ class  Usermod_MAX17048 : public Usermod {
       configComplete &= getJsonValue(top[FPSTR(_minReadInterval)], minReadingInterval, USERMOD_MAX17048_MIN_MONITOR_INTERVAL);
       configComplete &= getJsonValue(top[FPSTR(_HomeAssistantDiscovery)], HomeAssistantDiscovery, false);
 
-      DEBUG_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(FPSTR(_name));
       if (!initDone) {
         // first run: reading from cfg.json
-        DEBUG_PRINTLN(F(" config loaded."));
+        DEBUGUM_PRINTLN(F(" config loaded."));
       } else {
-        DEBUG_PRINTLN(F(" config (re)loaded."));
+        DEBUGUM_PRINTLN(F(" config (re)loaded."));
         // changing parameters from settings page
       }
 

--- a/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
+++ b/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
@@ -229,7 +229,7 @@ void PIRsensorSwitch::switchStrip(bool switchOn)
   if (m_offOnly && bri && (switchOn || (!PIRtriggered && !switchOn))) return; //if lights on and off only, do nothing
   if (PIRtriggered && switchOn) return; //if already on and triggered before, do nothing
   PIRtriggered = switchOn;
-  DEBUG_PRINT(F("PIR: strip=")); DEBUG_PRINTLN(switchOn?"on":"off");
+  DEBUGUM_PRINT(F("PIR: strip=")); DEBUGUM_PRINTLN(switchOn?"on":"off");
   if (switchOn) {
     if (m_onPreset) {
       if (currentPlaylist>0 && !offMode) {
@@ -321,9 +321,9 @@ void PIRsensorSwitch::publishHomeAssistantAutodiscovery()
     device[F("sw")]   = versionString;
     
     sprintf_P(buf, PSTR("homeassistant/binary_sensor/%s/config"), uid);
-    DEBUG_PRINTLN(buf);
+    DEBUGUM_PRINTLN(buf);
     size_t payload_size = serializeJson(doc, json_str);
-    DEBUG_PRINTLN(json_str);
+    DEBUGUM_PRINTLN(json_str);
 
     mqtt->publish(buf, 0, true, json_str, payload_size); // do we really need to retain?
   }
@@ -384,7 +384,7 @@ void PIRsensorSwitch::setup()
       #endif
       sensorPinState[i] = digitalRead(PIRsensorPin[i]);
     } else {
-      DEBUG_PRINT(F("PIRSensorSwitch pin ")); DEBUG_PRINTLN(i); DEBUG_PRINTLN(F(" allocation failed."));
+      DEBUGUM_PRINT(F("PIRSensorSwitch pin ")); DEBUGUM_PRINTLN(i); DEBUGUM_PRINTLN(F(" allocation failed."));
       PIRsensorPin[i] = -1;  // allocation failed
     }
   }
@@ -471,10 +471,10 @@ void PIRsensorSwitch::addToJsonInfo(JsonObject &root)
 
 void PIRsensorSwitch::onStateChange(uint8_t mode) {
   if (!initDone) return;
-  DEBUG_PRINT(F("PIR: offTimerStart=")); DEBUG_PRINTLN(offTimerStart);
+  DEBUGUM_PRINT(F("PIR: offTimerStart=")); DEBUGUM_PRINTLN(offTimerStart);
   if (m_override && PIRtriggered && offTimerStart) { // debounce
     // checking PIRtriggered and offTimerStart will prevent cancellation upon On trigger
-    DEBUG_PRINTLN(F("PIR: Canceled."));
+    DEBUGUM_PRINTLN(F("PIR: Canceled."));
     offTimerStart = 0;
     PIRtriggered = false;
   }
@@ -506,7 +506,7 @@ void PIRsensorSwitch::addToConfig(JsonObject &root)
   top[FPSTR(_override)]       = m_override;
   top[FPSTR(_haDiscovery)]    = HomeAssistantDiscovery;
   top[FPSTR(_domoticzIDX)]    = idx;
-  DEBUG_PRINTLN(F("PIR config saved."));
+  DEBUGUM_PRINTLN(F("PIR config saved."));
 }
 
 void PIRsensorSwitch::appendConfigData()
@@ -528,10 +528,10 @@ bool PIRsensorSwitch::readFromConfig(JsonObject &root)
     PIRsensorPin[i] = -1;
   }
 
-  DEBUG_PRINT(FPSTR(_name));
+  DEBUGUM_PRINT(FPSTR(_name));
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+    DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
     return false;
   }
 
@@ -561,12 +561,12 @@ bool PIRsensorSwitch::readFromConfig(JsonObject &root)
 
   if (!initDone) {
     // reading config prior to setup()
-    DEBUG_PRINTLN(F(" config loaded."));
+    DEBUGUM_PRINTLN(F(" config loaded."));
   } else {
     for (int i = 0; i < PIR_SENSOR_MAX_SENSORS; i++)
       if (oldPin[i] >= 0) pinManager.deallocatePin(oldPin[i], PinOwner::UM_PIR);
     setup();
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
   }
   // use "return !top["newestParameter"].isNull();" when updating Usermod with new features
   return !(pins.isNull() || pins.size() != PIR_SENSOR_MAX_SENSORS);

--- a/usermods/PWM_fan/usermod_PWM_fan.h
+++ b/usermods/PWM_fan/usermod_PWM_fan.h
@@ -82,7 +82,7 @@ class PWMFanUsermod : public Usermod {
       pinMode(tachoPin, INPUT);
       digitalWrite(tachoPin, HIGH);
       attachInterrupt(digitalPinToInterrupt(tachoPin), rpm_fan, FALLING);
-      DEBUG_PRINTLN(F("Tacho sucessfully initialized."));
+      DEBUGUM_PRINTLN(F("Tacho sucessfully initialized."));
     }
 
     void deinitTacho(void) {
@@ -130,7 +130,7 @@ class PWMFanUsermod : public Usermod {
       // attach the channel to the GPIO to be controlled
       ledcAttachPin(pwmPin, pwmChannel);
       #endif
-      DEBUG_PRINTLN(F("Fan PWM sucessfully initialized."));
+      DEBUGUM_PRINTLN(F("Fan PWM sucessfully initialized."));
     }
 
     void deinitPWMfan(void) {
@@ -173,7 +173,7 @@ class PWMFanUsermod : public Usermod {
 
     uint8_t calculatePwmStep(float diffTemp){
       if ((diffTemp == NAN) || (diffTemp <= -100.0)) {
-        DEBUG_PRINTLN(F("WARNING: no temperature value available. Cannot do temperature control. Will set PWM fan to 255."));
+        DEBUGUM_PRINTLN(F("WARNING: no temperature value available. Cannot do temperature control. Will set PWM fan to 255."));
         return _pwmMaxStepCount;
       }
       if(diffTemp <=0){
@@ -315,7 +315,7 @@ class PWMFanUsermod : public Usermod {
       top[FPSTR(_minPWMValuePct)] = minPWMValuePct;
       top[FPSTR(_maxPWMValuePct)] = maxPWMValuePct;
       top[FPSTR(_IRQperRotation)] = numberOfInterrupsInOneSingleRotation;
-      DEBUG_PRINTLN(F("Autosave config saved."));
+      DEBUGUM_PRINTLN(F("Autosave config saved."));
     }
 
     /*
@@ -333,9 +333,9 @@ class PWMFanUsermod : public Usermod {
       int8_t newPwmPin   = pwmPin;
 
       JsonObject top = root[FPSTR(_name)];
-      DEBUG_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(FPSTR(_name));
       if (top.isNull()) {
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 
@@ -356,12 +356,12 @@ class PWMFanUsermod : public Usermod {
         // first run: reading from cfg.json
         tachoPin = newTachoPin;
         pwmPin   = newPwmPin;
-        DEBUG_PRINTLN(F(" config loaded."));
+        DEBUGUM_PRINTLN(F(" config loaded."));
       } else {
-        DEBUG_PRINTLN(F(" config (re)loaded."));
+        DEBUGUM_PRINTLN(F(" config (re)loaded."));
         // changing paramters from settings page
         if (tachoPin != newTachoPin || pwmPin != newPwmPin) {
-          DEBUG_PRINTLN(F("Re-init pins."));
+          DEBUGUM_PRINTLN(F("Re-init pins."));
           // deallocate pin and release interrupts
           deinitTacho();
           deinitPWMfan();

--- a/usermods/RelayBlinds/usermod.cpp
+++ b/usermods/RelayBlinds/usermod.cpp
@@ -43,12 +43,12 @@ void handleRelay()
       digitalWrite(PIN_UP_RELAY, LOW);
       upActiveBefore = true;
       upStartTime = millis();
-      DEBUG_PRINTLN(F("UPA"));
+      DEBUGUM_PRINTLN(F("UPA"));
     }
     if (millis()- upStartTime > PIN_ON_TIME)
     {
       upActive = false;
-      DEBUG_PRINTLN(F("UPN"));
+      DEBUGUM_PRINTLN(F("UPN"));
     }
   } else if (upActiveBefore)
   {

--- a/usermods/SN_Photoresistor/usermod_sn_photoresistor.h
+++ b/usermods/SN_Photoresistor/usermod_sn_photoresistor.h
@@ -121,7 +121,7 @@ public:
       }
       else
       {
-        DEBUG_PRINTLN(F("Missing MQTT connection. Not publishing data"));
+        DEBUGUM_PRINTLN(F("Missing MQTT connection. Not publishing data"));
       }
     }
 #endif
@@ -172,7 +172,7 @@ public:
     top[FPSTR(_adcPrecision)] = adcPrecision;
     top[FPSTR(_offset)] = offset;
 
-    DEBUG_PRINTLN(F("Photoresistor config saved."));
+    DEBUGUM_PRINTLN(F("Photoresistor config saved."));
   }
 
   /**
@@ -183,8 +183,8 @@ public:
     // we look for JSON object.
     JsonObject top = root[FPSTR(_name)];
     if (top.isNull()) {
-      DEBUG_PRINT(FPSTR(_name));
-      DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+      DEBUGUM_PRINT(FPSTR(_name));
+      DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
       return false;
     }
 
@@ -194,8 +194,8 @@ public:
     resistorValue    = top[FPSTR(_resistorValue)] | resistorValue;
     adcPrecision     = top[FPSTR(_adcPrecision)] | adcPrecision;
     offset           = top[FPSTR(_offset)] | offset;
-    DEBUG_PRINT(FPSTR(_name));
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINT(FPSTR(_name));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
 
     // use "return !top["newestParameter"].isNull();" when updating Usermod with new features
     return true;

--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -110,12 +110,12 @@ float UsermodTemperature::readDallas() {
     oneWire->skip();                      // skip ROM
     oneWire->write(0xBE);                 // read (temperature) from EEPROM
     oneWire->read_bytes(data, 9);         // first 2 bytes contain temperature
-    #ifdef WLED_DEBUG
+    #ifdef WLED_DEBUG_USERMODS
     if (OneWire::crc8(data,8) != data[8]) {
-      DEBUG_PRINTLN(F("CRC error reading temperature."));
-      for (byte i=0; i < 9; i++) DEBUG_PRINTF_P(PSTR("0x%02X "), data[i]);
-      DEBUG_PRINT(F(" => "));
-      DEBUG_PRINTF_P(PSTR("0x%02X\n"), OneWire::crc8(data,8));
+      DEBUGUM_PRINTLN(F("CRC error reading temperature."));
+      for (byte i=0; i < 9; i++) DEBUGUM_PRINTF_P(PSTR("0x%02X "), data[i]);
+      DEBUGUM_PRINT(F(" => "));
+      DEBUGUM_PRINTF_P(PSTR("0x%02X\n"), OneWire::crc8(data,8));
     }
     #endif
     switch(sensorFound) {
@@ -138,7 +138,7 @@ float UsermodTemperature::readDallas() {
 }
 
 void UsermodTemperature::requestTemperatures() {
-  DEBUG_PRINTLN(F("Requesting temperature."));
+  DEBUGUM_PRINTLN(F("Requesting temperature."));
   oneWire->reset();
   oneWire->skip();                        // skip ROM
   oneWire->write(0x44,parasite);          // request new temperature reading
@@ -152,19 +152,19 @@ void UsermodTemperature::readTemperature() {
   temperature = readDallas();
   lastMeasurement = millis();
   waitingForConversion = false;
-  //DEBUG_PRINTF_P(PSTR("Read temperature %2.1f.\n"), temperature); // does not work properly on 8266
-  DEBUG_PRINT(F("Read temperature "));
-  DEBUG_PRINTLN(temperature);
+  //DEBUGUM_PRINTF_P(PSTR("Read temperature %2.1f.\n"), temperature); // does not work properly on 8266
+  DEBUGUM_PRINT(F("Read temperature "));
+  DEBUGUM_PRINTLN(temperature);
 }
 
 bool UsermodTemperature::findSensor() {
-  DEBUG_PRINTLN(F("Searching for sensor..."));
+  DEBUGUM_PRINTLN(F("Searching for sensor..."));
   uint8_t deviceAddress[8] = {0,0,0,0,0,0,0,0};
   // find out if we have DS18xxx sensor attached
   oneWire->reset_search();
   delay(10);
   while (oneWire->search(deviceAddress)) {
-    DEBUG_PRINTLN(F("Found something..."));
+    DEBUGUM_PRINTLN(F("Found something..."));
     if (oneWire->crc8(deviceAddress, 7) == deviceAddress[7]) {
       switch (deviceAddress[0]) {
         case 0x10:  // DS18S20
@@ -172,14 +172,14 @@ bool UsermodTemperature::findSensor() {
         case 0x28:  // DS1822
         case 0x3B:  // DS1825
         case 0x42:  // DS28EA00
-          DEBUG_PRINTLN(F("Sensor found."));
+          DEBUGUM_PRINTLN(F("Sensor found."));
           sensorFound = deviceAddress[0];
-          DEBUG_PRINTF_P(PSTR("0x%02X\n"), sensorFound);
+          DEBUGUM_PRINTF_P(PSTR("0x%02X\n"), sensorFound);
           return true;
       }
     }
   }
-  DEBUG_PRINTLN(F("Sensor NOT found."));
+  DEBUGUM_PRINTLN(F("Sensor NOT found."));
   return false;
 }
 
@@ -213,7 +213,7 @@ void UsermodTemperature::setup() {
   temperature = -127.0f; // default to -127, DS18B20 only goes down to -50C
   if (enabled) {
     // config says we are enabled
-    DEBUG_PRINTLN(F("Allocating temperature pin..."));
+    DEBUGUM_PRINTLN(F("Allocating temperature pin..."));
     // pin retrieved from cfg.json (readFromConfig()) prior to running setup()
     if (temperaturePin >= 0 && pinManager.allocatePin(temperaturePin, true, PinOwner::UM_Temperature)) {
       oneWire = new OneWire(temperaturePin);
@@ -230,7 +230,7 @@ void UsermodTemperature::setup() {
       }
     } else {
       if (temperaturePin >= 0) {
-        DEBUG_PRINTLN(F("Temperature pin allocation failed."));
+        DEBUGUM_PRINTLN(F("Temperature pin allocation failed."));
       }
       temperaturePin = -1;  // allocation failed
     }
@@ -375,7 +375,7 @@ void UsermodTemperature::addToConfig(JsonObject &root) {
   top[FPSTR(_parasite)] = parasite;
   top[FPSTR(_parasitePin)] = parasitePin;
   top[FPSTR(_domoticzIDX)] = idx;
-  DEBUG_PRINTLN(F("Temperature config saved."));
+  DEBUGUM_PRINTLN(F("Temperature config saved."));
 }
 
 /**
@@ -386,11 +386,11 @@ void UsermodTemperature::addToConfig(JsonObject &root) {
 bool UsermodTemperature::readFromConfig(JsonObject &root) {
   // we look for JSON object: {"Temperature": {"pin": 0, "degC": true}}
   int8_t newTemperaturePin = temperaturePin;
-  DEBUG_PRINT(FPSTR(_name));
+  DEBUGUM_PRINT(FPSTR(_name));
 
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+    DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
     return false;
   }
 
@@ -406,12 +406,12 @@ bool UsermodTemperature::readFromConfig(JsonObject &root) {
   if (!initDone) {
     // first run: reading from cfg.json
     temperaturePin = newTemperaturePin;
-    DEBUG_PRINTLN(F(" config loaded."));
+    DEBUGUM_PRINTLN(F(" config loaded."));
   } else {
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
     // changing paramters from settings page
     if (newTemperaturePin != temperaturePin) {
-      DEBUG_PRINTLN(F("Re-init temperature."));
+      DEBUGUM_PRINTLN(F("Re-init temperature."));
       // deallocate pin and release memory
       delete oneWire;
       pinManager.deallocatePin(temperaturePin, PinOwner::UM_Temperature);

--- a/usermods/VL53L0X_gestures/usermod_vl53l0x_gestures.h
+++ b/usermods/VL53L0X_gestures/usermod_vl53l0x_gestures.h
@@ -55,7 +55,7 @@ class UsermodVL53L0XGestures : public Usermod {
       sensor.setTimeout(150);
       if (!sensor.init())
       {
-        DEBUG_PRINTLN(F("Failed to detect and initialize VL53L0X sensor!"));
+        DEBUGUM_PRINTLN(F("Failed to detect and initialize VL53L0X sensor!"));
       } else {
         sensor.setMeasurementTimingBudget(20000); // set high speed mode
       }
@@ -69,20 +69,20 @@ class UsermodVL53L0XGestures : public Usermod {
         lastTime = millis();
 
         int range = sensor.readRangeSingleMillimeters();
-        DEBUG_PRINTF("range: %d, brightness: %d\r\n", range, bri);
+        DEBUGUM_PRINTF("range: %d, brightness: %d\r\n", range, bri);
 
         if (range < VL53L0X_MAX_RANGE_MM)
         {
           if (!wasMotionBefore)
           {
             motionStartTime = millis();
-            DEBUG_PRINTF("motionStartTime: %d\r\n", motionStartTime);
+            DEBUGUM_PRINTF("motionStartTime: %d\r\n", motionStartTime);
           }
           wasMotionBefore = true;
 
           if (millis() - motionStartTime > VL53L0X_LONG_MOTION_DELAY_MS) //long motion
           {
-            DEBUG_PRINTF("long motion: %d\r\n", motionStartTime);
+            DEBUGUM_PRINTF("long motion: %d\r\n", motionStartTime);
             if (!isLongMotion)
             {
               isLongMotion = true;
@@ -90,13 +90,13 @@ class UsermodVL53L0XGestures : public Usermod {
 
             // set brightness according to range
             bri = (VL53L0X_MAX_RANGE_MM - max(range, VL53L0X_MIN_RANGE_OFFSET)) * 255 / (VL53L0X_MAX_RANGE_MM - VL53L0X_MIN_RANGE_OFFSET);
-            DEBUG_PRINTF("new brightness: %d", bri);
+            DEBUGUM_PRINTF("new brightness: %d", bri);
             stateUpdated(1);
           }
         } else if (wasMotionBefore) { //released
           if (!isLongMotion)
           { //short press
-            DEBUG_PRINTLN(F("shortPressAction..."));
+            DEBUGUM_PRINTLN(F("shortPressAction..."));
             shortPressAction();
           }
           wasMotionBefore = false;

--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -12,7 +12,7 @@
   #error This audio reactive usermod does not support the ESP8266.
 #endif
 
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
 #include <esp_timer.h>
 #endif
 
@@ -35,17 +35,19 @@
 // #define FFT_SAMPLING_LOG             // FFT result debugging
 // #define SR_DEBUG                     // generic SR DEBUG messages
 
-#ifdef SR_DEBUG
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
   #define DEBUGSR_PRINT(x) DEBUGOUT.print(x)
   #define DEBUGSR_PRINTLN(x) DEBUGOUT.println(x)
   #define DEBUGSR_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGSR_PRINTF_P(x...) DEBUGOUT.printf_P(x)
 #else
   #define DEBUGSR_PRINT(x)
   #define DEBUGSR_PRINTLN(x)
   #define DEBUGSR_PRINTF(x...)
+  #define DEBUGSR_PRINTF_P(x...)
 #endif
 
-#if defined(MIC_LOGGER) || defined(FFT_SAMPLING_LOG)
+#if defined(WLED_DEBUG_USERMODS) && (defined(MIC_LOGGER) || defined(FFT_SAMPLING_LOG))
   #define PLOT_PRINT(x) DEBUGOUT.print(x)
   #define PLOT_PRINTLN(x) DEBUGOUT.println(x)
   #define PLOT_PRINTF(x...) DEBUGOUT.printf(x)
@@ -150,7 +152,7 @@ static float fftResultPink[NUM_GEQ_CHANNELS] = { 1.70f, 1.71f, 1.73f, 1.78f, 1.6
 static float FFT_MajorPeak = 1.0f;              // FFT: strongest (peak) frequency
 static float FFT_Magnitude = 0.0f;              // FFT: volume (magnitude) of peak frequency
 static uint8_t fftResult[NUM_GEQ_CHANNELS]= {0};// Our calculated freq. channel result table to be used by effects
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
 static uint64_t fftTime = 0;
 static uint64_t sampleTime = 0;
 #endif
@@ -158,7 +160,7 @@ static uint64_t sampleTime = 0;
 // FFT Task variables (filtering and post-processing)
 static float   fftCalc[NUM_GEQ_CHANNELS] = {0.0f};                    // Try and normalize fftBin values to a max of 4096, so that 4096/16 = 256.
 static float   fftAvg[NUM_GEQ_CHANNELS] = {0.0f};                     // Calculated frequency channel results, with smoothing (used if dynamics limiter is ON)
-#ifdef SR_DEBUG
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
 static float   fftResultMax[NUM_GEQ_CHANNELS] = {0.0f};               // A table used for testing to determine how our post-processing is working.
 #endif
 
@@ -235,7 +237,7 @@ void FFTcode(void * parameter)
       continue;
     }
 
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
     uint64_t start = esp_timer_get_time();
     bool haveDoneFFT = false; // indicates if second measurement (FFT time) is valid
 #endif
@@ -243,7 +245,7 @@ void FFTcode(void * parameter)
     // get a fresh batch of samples from I2S
     if (audioSource) audioSource->getSamples(vReal, samplesFFT);
 
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
     if (start < esp_timer_get_time()) { // filter out overflows
       uint64_t sampleTimeInMillis = (esp_timer_get_time() - start +5ULL) / 10ULL; // "+5" to ensure proper rounding
       sampleTime = (sampleTimeInMillis*3 + sampleTime*7)/10; // smooth
@@ -270,7 +272,7 @@ void FFTcode(void * parameter)
     // early release allows the filters (getSample() and agcAvg()) to work with fresh values - we will have matching gain and noise gate values when we want to process the FFT results.
     micDataReal = maxSample;
 
-#ifdef SR_DEBUG
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
     if (true) {  // this allows measure FFT runtimes, as it disables the "only when needed" optimization 
 #else
     if (sampleAvg > 0.25f) { // noise gate open means that FFT results will be used. Don't run FFT if results are not needed.
@@ -287,7 +289,7 @@ void FFTcode(void * parameter)
       FFT.majorPeak(&FFT_MajorPeak, &FFT_Magnitude);                // let the effects know which freq was most dominant
       FFT_MajorPeak = constrain(FFT_MajorPeak, 1.0f, 11025.0f);   // restrict value to range expected by effects
 
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
       haveDoneFFT = true;
 #endif
 
@@ -371,7 +373,7 @@ void FFTcode(void * parameter)
     // post-processing of frequency channels (pink noise adjustment, AGC, smoothing, scaling)
     postProcessFFTResults((fabsf(sampleAvg) > 0.25f)? true : false , NUM_GEQ_CHANNELS);
 
-#if defined(WLED_DEBUG) || defined(SR_DEBUG)
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
     if (haveDoneFFT && (start < esp_timer_get_time())) { // filter out overflows
       uint64_t fftTimeInMillis = ((esp_timer_get_time() - start) +5ULL) / 10ULL; // "+5" to ensure proper rounding
       fftTime  = (fftTimeInMillis*3 + fftTime*7)/10; // smooth
@@ -663,7 +665,7 @@ class AudioReactive : public Usermod {
     void logAudio()
     {
       if (disableSoundProcessing && (!udpSyncConnected || ((audioSyncEnabled & 0x02) == 0))) return;   // no audio availeable
-    #ifdef MIC_LOGGER
+    #if defined(WLED_DEBUG_USERMODS) && defined(MIC_LOGGER)
       // Debugging functions for audio input and sound processing. Comment out the values you want to see
       PLOT_PRINT("micReal:");     PLOT_PRINT(micDataReal); PLOT_PRINT("\t");
       PLOT_PRINT("volumeSmth:");  PLOT_PRINT(volumeSmth);  PLOT_PRINT("\t");
@@ -680,7 +682,7 @@ class AudioReactive : public Usermod {
       PLOT_PRINTLN();
     #endif
 
-    #ifdef FFT_SAMPLING_LOG
+    #if defined(WLED_DEBUG_USERMODS) && defined(FFT_SAMPLING_LOG)
       #if 0
         for(int i=0; i<NUM_GEQ_CHANNELS; i++) {
           PLOT_PRINT(fftResult[i]);
@@ -1195,11 +1197,7 @@ class AudioReactive : public Usermod {
       if (enabled) disableSoundProcessing = false;       // all good - enable audio processing
 
       if((!audioSource) || (!audioSource->isInitialized())) {  // audio source failed to initialize. Still stay "enabled", as there might be input arriving via UDP Sound Sync 
-      #ifdef WLED_DEBUG
-        DEBUG_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-      #else
         DEBUGSR_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-      #endif
         disableSoundProcessing = true;
       }
 
@@ -1260,18 +1258,18 @@ class AudioReactive : public Usermod {
             ||(realtimeMode == REALTIME_MODE_ADALIGHT)
             ||(realtimeMode == REALTIME_MODE_ARTNET) ) )  // please add other modes here if needed
       {
-        #ifdef WLED_DEBUG
+        #if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
         if ((disableSoundProcessing == false) && (audioSyncEnabled == 0)) {  // we just switched to "disabled"
-          DEBUG_PRINTLN(F("[AR userLoop]  realtime mode active - audio processing suspended."));
-          DEBUG_PRINTF_P(PSTR("               RealtimeMode = %d; RealtimeOverride = %d\n"), int(realtimeMode), int(realtimeOverride));
+          DEBUGSR_PRINTLN(F("[AR userLoop]  realtime mode active - audio processing suspended."));
+          DEBUGSR_PRINTF_P(PSTR("               RealtimeMode = %d; RealtimeOverride = %d\n"), int(realtimeMode), int(realtimeOverride));
         }
         #endif
         disableSoundProcessing = true;
       } else {
-        #ifdef WLED_DEBUG
+        #if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
         if ((disableSoundProcessing == true) && (audioSyncEnabled == 0) && audioSource->isInitialized()) {    // we just switched to "enabled"
-          DEBUG_PRINTLN(F("[AR userLoop]  realtime mode ended - audio processing resumed."));
-          DEBUG_PRINTF_P(PSTR("               RealtimeMode = %d; RealtimeOverride = %d\n"), int(realtimeMode), int(realtimeOverride));
+          DEBUGSR_PRINTLN(F("[AR userLoop]  realtime mode ended - audio processing resumed."));
+          DEBUGSR_PRINTF_P(PSTR("               RealtimeMode = %d; RealtimeOverride = %d\n"), int(realtimeMode), int(realtimeOverride));
         }
         #endif
         if ((disableSoundProcessing == true) && (audioSyncEnabled == 0)) lastUMRun = millis();  // just left "realtime mode" - update timekeeping
@@ -1291,11 +1289,11 @@ class AudioReactive : public Usermod {
         int userloopDelay = int(t_now - lastUMRun);
         if (lastUMRun == 0) userloopDelay=0; // startup - don't have valid data from last run.
 
-        #ifdef WLED_DEBUG
+        #if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
           // complain when audio userloop has been delayed for long time. Currently we need userloop running between 500 and 1500 times per second. 
           // softhack007 disabled temporarily - avoid serial console spam with MANY leds and low FPS
           //if ((userloopDelay > 65) && !disableSoundProcessing && (audioSyncEnabled == 0)) {
-          //  DEBUG_PRINTF_P(PSTR("[AR userLoop] hiccup detected -> was inactive for last %d millis!\n"), userloopDelay);
+          //  DEBUGSR_PRINTF_P(PSTR("[AR userLoop] hiccup detected -> was inactive for last %d millis!\n"), userloopDelay);
           //}
         #endif
 
@@ -1343,7 +1341,7 @@ class AudioReactive : public Usermod {
           limitSampleDynamics();                              // run dynamics limiter on received volumeSmth, to hide jumps and hickups
       }
 
-      #if defined(MIC_LOGGER) || defined(MIC_SAMPLING_LOG) || defined(FFT_SAMPLING_LOG)
+      #if defined(WLED_DEBUG_USERMODS) && (defined(MIC_LOGGER) || defined(FFT_SAMPLING_LOG))
       static unsigned long lastMicLoggerTime = 0;
       if (millis()-lastMicLoggerTime > 20) {
         lastMicLoggerTime = millis();
@@ -1381,7 +1379,7 @@ class AudioReactive : public Usermod {
 
     void onUpdateBegin(bool init) override
     {
-#ifdef WLED_DEBUG
+#if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
       fftTime = sampleTime = 0;
 #endif
       // gracefully suspend FFT task (if running)
@@ -1494,7 +1492,7 @@ class AudioReactive : public Usermod {
           infoArr.add(uiDomString);
         } 
 
-        // The following can be used for troubleshooting user errors and is so not enclosed in #ifdef WLED_DEBUG
+        // The following can be used for troubleshooting user errors and is so not enclosed in #ifdef WLED_DEBUG_USERMODS
 
         // current Audio input
         infoArr = user.createNestedArray(F("Audio Source"));
@@ -1571,7 +1569,7 @@ class AudioReactive : public Usermod {
             if (receivedFormat == 2) infoArr.add(F(" v2"));
         }
 
-        #if defined(WLED_DEBUG) || defined(SR_DEBUG)
+        #if defined(WLED_DEBUG_USERMODS) && defined(SR_DEBUG)
         infoArr = user.createNestedArray(F("Sampling time"));
         infoArr.add(float(sampleTime)/100.0f);
         infoArr.add(" ms");
@@ -1854,24 +1852,24 @@ class AudioReactive : public Usermod {
 };
 
 void AudioReactive::removeAudioPalettes(void) {
-  DEBUG_PRINTLN(F("Removing audio palettes."));
+  DEBUGSR_PRINTLN(F("Removing audio palettes."));
   while (palettes>0) {
     strip.customPalettes.pop_back();
-    DEBUG_PRINTLN(palettes);
+    DEBUGSR_PRINTLN(palettes);
     palettes--;
   }
-  DEBUG_PRINT(F("Total # of palettes: ")); DEBUG_PRINTLN(strip.customPalettes.size());
+  DEBUGSR_PRINT(F("Total # of palettes: ")); DEBUGSR_PRINTLN(strip.customPalettes.size());
 }
 
 void AudioReactive::createAudioPalettes(void) {
-  DEBUG_PRINT(F("Total # of palettes: ")); DEBUG_PRINTLN(strip.customPalettes.size());
+  DEBUGSR_PRINT(F("Total # of palettes: ")); DEBUGSR_PRINTLN(strip.customPalettes.size());
   if (palettes) return;
-  DEBUG_PRINTLN(F("Adding audio palettes."));
+  DEBUGSR_PRINTLN(F("Adding audio palettes."));
   for (int i=0; i<MAX_PALETTES; i++)
     if (strip.customPalettes.size() < 10) {
       strip.customPalettes.push_back(CRGBPalette16(CRGB(BLACK)));
       palettes++;
-      DEBUG_PRINTLN(palettes);
+      DEBUGSR_PRINTLN(palettes);
     } else break;
 }
 

--- a/usermods/boblight/boblight.h
+++ b/usermods/boblight/boblight.h
@@ -64,7 +64,7 @@ class BobLightUsermod : public Usermod {
       int bcount;
 
       if (total > strip.getLengthTotal()) {
-        DEBUG_PRINTLN(F("BobLight: Too many lights."));
+        DEBUGUM_PRINTLN(F("BobLight: Too many lights."));
         return;
       }
 
@@ -172,11 +172,11 @@ class BobLightUsermod : public Usermod {
 
       numLights = lightcount;
 
-      #if WLED_DEBUG
-      DEBUG_PRINTLN(F("Fill light data: "));
-      DEBUG_PRINTF_P(PSTR(" lights %d\n"), numLights);
+      #if WLED_DEBUG_USERMODS
+      DEBUGUM_PRINTLN(F("Fill light data: "));
+      DEBUGUM_PRINTF_P(PSTR(" lights %d\n"), numLights);
       for (int i=0; i<numLights; i++) {
-        DEBUG_PRINTF_P(PSTR(" light %s scan %2.1f %2.1f %2.1f %2.1f\n"), lights[i].lightname, lights[i].vscan[0], lights[i].vscan[1], lights[i].hscan[0], lights[i].hscan[1]);
+        DEBUGUM_PRINTF_P(PSTR(" light %s scan %2.1f %2.1f %2.1f %2.1f\n"), lights[i].lightname, lights[i].vscan[0], lights[i].vscan[1], lights[i].hscan[0], lights[i].hscan[1]);
       }
       #endif
     }
@@ -190,8 +190,8 @@ class BobLightUsermod : public Usermod {
     void setup() override {
       uint16_t totalLights = bottom + left + top + right;
       if ( totalLights > strip.getLengthTotal() ) {
-        DEBUG_PRINTLN(F("BobLight: Too many lights."));
-        DEBUG_PRINTF_P(PSTR("%d+%d+%d+%d>%d\n"), bottom, left, top, right, strip.getLengthTotal());
+        DEBUGUM_PRINTLN(F("BobLight: Too many lights."));
+        DEBUGUM_PRINTF_P(PSTR("%d+%d+%d+%d>%d\n"), bottom, left, top, right, strip.getLengthTotal());
         totalLights = strip.getLengthTotal();
         top = bottom = (uint16_t) roundf((float)totalLights * 16.0f / 50.0f);
         left = right = (uint16_t) roundf((float)totalLights *  9.0f / 50.0f);
@@ -376,7 +376,7 @@ void BobLightUsermod::pollBob() {
     if (!bobClient || !bobClient.connected()) {
       if (bobClient) bobClient.stop();
       bobClient = bob->available();
-      DEBUG_PRINTLN(F("Boblight: Client connected."));
+      DEBUGUM_PRINTLN(F("Boblight: Client connected."));
     }
     //no free/disconnected spot so reject
     WiFiClient bobClientTmp = bob->available();
@@ -392,30 +392,30 @@ void BobLightUsermod::pollBob() {
     //get data from the client
     while (bobClient.available()) {
       String input = bobClient.readStringUntil('\n');
-      // DEBUG_PRINT(F("Client: ")); DEBUG_PRINTLN(input); // may be to stressful on Serial
+      // DEBUGUM_PRINT(F("Client: ")); DEBUGUM_PRINTLN(input); // may be to stressful on Serial
       if (input.startsWith(F("hello"))) {
-        DEBUG_PRINTLN(F("hello"));
+        DEBUGUM_PRINTLN(F("hello"));
         bobClient.print(F("hello\n"));
       } else if (input.startsWith(F("ping"))) {
-        DEBUG_PRINTLN(F("ping 1"));
+        DEBUGUM_PRINTLN(F("ping 1"));
         bobClient.print(F("ping 1\n"));
       } else if (input.startsWith(F("get version"))) {
-        DEBUG_PRINTLN(F("version 5"));
+        DEBUGUM_PRINTLN(F("version 5"));
         bobClient.print(F("version 5\n"));
       } else if (input.startsWith(F("get lights"))) {
         char tmp[64];
         String answer = "";
         sprintf_P(tmp, PSTR("lights %d\n"), numLights);
-        DEBUG_PRINT(tmp);
+        DEBUGUM_PRINT(tmp);
         answer.concat(tmp);
         for (int i=0; i<numLights; i++) {
           sprintf_P(tmp, PSTR("light %s scan %2.1f %2.1f %2.1f %2.1f\n"), lights[i].lightname, lights[i].vscan[0], lights[i].vscan[1], lights[i].hscan[0], lights[i].hscan[1]);
-          DEBUG_PRINT(tmp);
+          DEBUGUM_PRINT(tmp);
           answer.concat(tmp);
         }
         bobClient.print(answer);
       } else if (input.startsWith(F("set priority"))) {
-        DEBUG_PRINTLN(F("set priority not implemented"));
+        DEBUGUM_PRINTLN(F("set priority not implemented"));
         // not implemented
       } else if (input.startsWith(F("set light "))) { // <id> <cmd in rgb, speed, interpolation> <value> ...
         input.remove(0,10);
@@ -449,7 +449,7 @@ void BobLightUsermod::pollBob() {
         BobSync();
       } else {
         // Client sent gibberish
-        DEBUG_PRINTLN(F("Client sent gibberish."));
+        DEBUGUM_PRINTLN(F("Client sent gibberish."));
         bobClient.stop();
         bobClient = bob->available();
         BobClear();

--- a/usermods/mpu6050_imu/usermod_mpu6050_imu.h
+++ b/usermods/mpu6050_imu/usermod_mpu6050_imu.h
@@ -33,9 +33,7 @@
 
 #include "I2Cdev.h"
 
-#undef DEBUG_PRINT
-#undef DEBUG_PRINTLN
-#undef DEBUG_PRINTF
+// MPU6050 unfortunately uses the same DEBUG macro names as WLED :(
 #include "MPU6050_6Axis_MotionApps20.h"
 //#include "MPU6050.h" // not necessary if using MotionApps include file
 
@@ -45,20 +43,6 @@
     #include "Wire.h"
 #endif
 
-// Restore debug macros
-// MPU6050 unfortunately uses the same macro names as WLED :(
-#undef DEBUG_PRINT
-#undef DEBUG_PRINTLN
-#undef DEBUG_PRINTF
-#ifdef WLED_DEBUG
-  #define DEBUG_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUG_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUG_PRINTF(x...) DEBUGOUT.printf(x)
-#else
-  #define DEBUG_PRINT(x)
-  #define DEBUG_PRINTLN(x)
-  #define DEBUG_PRINTF(x...)
-#endif
 
 
 
@@ -158,11 +142,11 @@ class MPU6050Driver : public Usermod {
       }
 
       if (!config.enabled) return;
-      if (i2c_scl<0 || i2c_sda<0) { DEBUG_PRINTLN(F("MPU6050: I2C is no good."));  return; }
+      if (i2c_scl<0 || i2c_sda<0) { DEBUGUM_PRINTLN(F("MPU6050: I2C is no good."));  return; }
       // Check the interrupt pin
       if (config.interruptPin >= 0) {
         irqBound = pinManager.allocatePin(config.interruptPin, false, PinOwner::UM_IMU);
-        if (!irqBound) { DEBUG_PRINTLN(F("MPU6050: IRQ pin already in use.")); return; }
+        if (!irqBound) { DEBUGUM_PRINTLN(F("MPU6050: IRQ pin already in use.")); return; }
         pinMode(config.interruptPin, INPUT);
       };
 
@@ -173,15 +157,15 @@ class MPU6050Driver : public Usermod {
       #endif
 
       // initialize device
-      DEBUG_PRINTLN(F("Initializing I2C devices..."));
+      DEBUGUM_PRINTLN(F("Initializing I2C devices..."));
       mpu.initialize();
 
       // verify connection
-      DEBUG_PRINTLN(F("Testing device connections..."));
-      DEBUG_PRINTLN(mpu.testConnection() ? F("MPU6050 connection successful") : F("MPU6050 connection failed"));
+      DEBUGUM_PRINTLN(F("Testing device connections..."));
+      DEBUGUM_PRINTLN(mpu.testConnection() ? F("MPU6050 connection successful") : F("MPU6050 connection failed"));
 
       // load and configure the DMP
-      DEBUG_PRINTLN(F("Initializing DMP..."));
+      DEBUGUM_PRINTLN(F("Initializing DMP..."));
       devStatus = mpu.dmpInitialize();
 
       // set offsets (from config)
@@ -198,13 +182,13 @@ class MPU6050Driver : public Usermod {
       // make sure it worked (returns 0 if so)
       if (devStatus == 0) {
         // turn on the DMP, now that it's ready
-        DEBUG_PRINTLN(F("Enabling DMP..."));
+        DEBUGUM_PRINTLN(F("Enabling DMP..."));
         mpu.setDMPEnabled(true);
 
         mpuInterrupt = true;
         if (irqBound) {
           // enable Arduino interrupt detection
-          DEBUG_PRINTLN(F("Enabling interrupt detection (Arduino external interrupt 0)..."));          
+          DEBUGUM_PRINTLN(F("Enabling interrupt detection (Arduino external interrupt 0)..."));          
           attachInterrupt(digitalPinToInterrupt(config.interruptPin), dmpDataReady, RISING);
         }
 
@@ -212,16 +196,16 @@ class MPU6050Driver : public Usermod {
         packetSize = mpu.dmpGetFIFOPacketSize();
 
         // set our DMP Ready flag so the main loop() function knows it's okay to use it
-        DEBUG_PRINTLN(F("DMP ready!"));
+        DEBUGUM_PRINTLN(F("DMP ready!"));
         dmpReady = true;
       } else {
         // ERROR!
         // 1 = initial memory load failed
         // 2 = DMP configuration updates failed
         // (if it's going to break, usually the code will be 1)
-        DEBUG_PRINT(F("DMP Initialization failed (code "));
-        DEBUG_PRINT(devStatus);
-        DEBUG_PRINTLN(")");
+        DEBUGUM_PRINT(F("DMP Initialization failed (code "));
+        DEBUGUM_PRINT(devStatus);
+        DEBUGUM_PRINTLN(")");
       }
 
       fifoCount = 0;
@@ -233,7 +217,7 @@ class MPU6050Driver : public Usermod {
      * Use it to initialize network interfaces
      */
     void connected() {
-      //DEBUG_PRINTLN(F("Connected to WiFi!"));
+      //DEBUGUM_PRINTLN(F("Connected to WiFi!"));
     }
 
 
@@ -257,16 +241,16 @@ class MPU6050Driver : public Usermod {
       if ((mpuIntStatus & 0x10) || fifoCount == 1024) {
         // reset so we can continue cleanly
         mpu.resetFIFO();
-        DEBUG_PRINTLN(F("MPU6050: FIFO overflow!"));
+        DEBUGUM_PRINTLN(F("MPU6050: FIFO overflow!"));
 
         // otherwise, check for data ready
       } else if (fifoCount >= packetSize) {
         // clear local interrupt pending status, if not polling
         mpuInterrupt = !irqBound;
 
-        // DEBUG_PRINT(F("MPU6050: Processing packet: "));
-        // DEBUG_PRINT(fifoCount);
-        // DEBUG_PRINTLN(F(" bytes in FIFO"));
+        // DEBUGUM_PRINT(F("MPU6050: Processing packet: "));
+        // DEBUGUM_PRINT(fifoCount);
+        // DEBUGUM_PRINTLN(F(" bytes in FIFO"));
 
         // read a packet from FIFO
         mpu.getFIFOBytes(fifoBuffer, packetSize);
@@ -391,15 +375,15 @@ class MPU6050Driver : public Usermod {
       configComplete &= getJsonValue(top[FPSTR(_y_gyro_bias)], config.gyro_offset[1], 0);
       configComplete &= getJsonValue(top[FPSTR(_z_gyro_bias)], config.gyro_offset[2], 0);
 
-      DEBUG_PRINT(FPSTR(_name));
+      DEBUGUM_PRINT(FPSTR(_name));
       if (top.isNull()) {
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
       } else if (!initDone()) {
-        DEBUG_PRINTLN(F(": config loaded."));
+        DEBUGUM_PRINTLN(F(": config loaded."));
       } else if (memcmp(&config, &old_cfg, sizeof(config)) == 0) {
-        DEBUG_PRINTLN(F(": config unchanged."));
+        DEBUGUM_PRINTLN(F(": config unchanged."));
       } else {
-        DEBUG_PRINTLN(F(": config updated."));
+        DEBUGUM_PRINTLN(F(": config updated."));
         // Previously loaded and config changed
         if (irqBound && ((old_cfg.interruptPin != config.interruptPin) || !config.enabled)) {
           detachInterrupt(old_cfg.interruptPin);

--- a/usermods/multi_relay/usermod_multi_relay.h
+++ b/usermods/multi_relay/usermod_multi_relay.h
@@ -262,10 +262,10 @@ void MultiRelay::handleOffTimer() {
  */
 #define GEOGABVERSION "0.1.3"
 void MultiRelay::InitHtmlAPIHandle() {  // https://github.com/me-no-dev/ESPAsyncWebServer
-  DEBUG_PRINTLN(F("Relays: Initialize HTML API"));
+  DEBUGUM_PRINTLN(F("Relays: Initialize HTML API"));
 
   server.on(SET_F("/relays"), HTTP_GET, [this](AsyncWebServerRequest *request) {
-    DEBUG_PRINTLN(F("Relays: HTML API"));
+    DEBUGUM_PRINTLN(F("Relays: HTML API"));
     String janswer;
     String error = "";
     //int params = request->params();
@@ -399,7 +399,7 @@ void MultiRelay::switchRelay(uint8_t relay, bool mode) {
       state |= (_relay[i].invert ? !_relay[i].state : _relay[i].state) << pin; // fill relay states for all pins
     }
     IOexpanderWrite(addrPcf8574, state);
-    DEBUG_PRINT(F("Writing to PCF8574: ")); DEBUG_PRINTLN(state);
+    DEBUGUM_PRINT(F("Writing to PCF8574: ")); DEBUGUM_PRINTLN(state);
   } else if (_relay[relay].pin < 100) {
     pinMode(_relay[relay].pin, OUTPUT);
     digitalWrite(_relay[relay].pin, _relay[relay].invert ? !_relay[relay].state : _relay[relay].state);
@@ -527,7 +527,7 @@ void MultiRelay::setup() {
   }
   if (usePcf8574) {
     IOexpanderWrite(addrPcf8574, state);  // init expander (set all outputs)
-    DEBUG_PRINTLN(F("PCF8574(s) inited."));
+    DEBUGUM_PRINTLN(F("PCF8574(s) inited."));
   }
   _oldMode = offMode;
   initDone = true;
@@ -761,7 +761,7 @@ void MultiRelay::addToConfig(JsonObject &root) {
     relay[FPSTR(_external)]   = _relay[i].external;
     relay[FPSTR(_button)]     = _relay[i].button;
   }
-  DEBUG_PRINTLN(F("MultiRelay config saved."));
+  DEBUGUM_PRINTLN(F("MultiRelay config saved."));
 }
 
 void MultiRelay::appendConfigData() {
@@ -782,8 +782,8 @@ bool MultiRelay::readFromConfig(JsonObject &root) {
 
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINT(FPSTR(_name));
-    DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+    DEBUGUM_PRINT(FPSTR(_name));
+    DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
     return false;
   }
 
@@ -809,10 +809,10 @@ bool MultiRelay::readFromConfig(JsonObject &root) {
     _relay[i].delay    = min(600,max(0,abs((int)_relay[i].delay))); // bounds checking max 10min
   }
 
-  DEBUG_PRINT(FPSTR(_name));
+  DEBUGUM_PRINT(FPSTR(_name));
   if (!initDone) {
     // reading config prior to setup()
-    DEBUG_PRINTLN(F(" config loaded."));
+    DEBUGUM_PRINTLN(F(" config loaded."));
   } else {
     // deallocate all pins 1st
     for (int i=0; i<MULTI_RELAY_MAX_RELAYS; i++)
@@ -821,7 +821,7 @@ bool MultiRelay::readFromConfig(JsonObject &root) {
       }
     // allocate new pins
     setup();
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
   }
   // use "return !top["newestParameter"].isNull();" when updating Usermod with new features
   return !top[FPSTR(_pcf8574)].isNull();

--- a/usermods/pwm_outputs/usermod_pwm_outputs.h
+++ b/usermods/pwm_outputs/usermod_pwm_outputs.h
@@ -28,25 +28,25 @@ class PwmOutput {
       if (pin_ < 0)
         return;
 
-      DEBUG_PRINTF("pwm_output[%d]: setup to freq %d\n", pin_, freq_);
+      DEBUGUM_PRINTF("pwm_output[%d]: setup to freq %d\n", pin_, freq_);
       if (!pinManager.allocatePin(pin_, true, PinOwner::UM_PWM_OUTPUTS))
         return;
       
       channel_ = pinManager.allocateLedc(1);
       if (channel_ == 255) {
-        DEBUG_PRINTF("pwm_output[%d]: failed to quire ledc\n", pin_);
+        DEBUGUM_PRINTF("pwm_output[%d]: failed to quire ledc\n", pin_);
         pinManager.deallocatePin(pin_, PinOwner::UM_PWM_OUTPUTS);
         return;
       }
 
       ledcSetup(channel_, freq_, bit_depth_);
       ledcAttachPin(pin_, channel_);
-      DEBUG_PRINTF("pwm_output[%d]: init successful\n", pin_);
+      DEBUGUM_PRINTF("pwm_output[%d]: init successful\n", pin_);
       enabled_ = true;
     }
 
     void close() {
-      DEBUG_PRINTF("pwm_output[%d]: close\n", pin_);
+      DEBUGUM_PRINTF("pwm_output[%d]: close\n", pin_);
       if (!enabled_)
         return;
       pinManager.deallocatePin(pin_, PinOwner::UM_PWM_OUTPUTS);
@@ -58,7 +58,7 @@ class PwmOutput {
     }
 
     void setDuty(const float duty) {
-      DEBUG_PRINTF("pwm_output[%d]: set duty %f\n", pin_, duty);
+      DEBUGUM_PRINTF("pwm_output[%d]: set duty %f\n", pin_, duty);
       if (!enabled_)
         return;
       duty_ = min(1.0f, max(0.0f, duty));

--- a/usermods/quinled-an-penta/quinled-an-penta.h
+++ b/usermods/quinled-an-penta/quinled-an-penta.h
@@ -130,14 +130,14 @@ class QuinLEDAnPentaUsermod : public Usermod
     {
       PinManagerPinType pins[5] = { { oledSpiClk, true }, { oledSpiData, true }, { oledSpiCs, true }, { oledSpiDc, true }, { oledSpiRst, true } };
       if (!pinManager.allocateMultiplePins(pins, 5, PinOwner::UM_QuinLEDAnPenta)) {
-        DEBUG_PRINTF("[%s] OLED pin allocation failed!\n", _name);
+        DEBUGUM_PRINTF("[%s] OLED pin allocation failed!\n", _name);
         oledEnabled = oledInitDone = false;
         return;
       }
 
       oledDisplay = (U8G2 *) new U8G2_SSD1306_128X64_NONAME_2_4W_SW_SPI(U8G2_R0, oledSpiClk, oledSpiData, oledSpiCs, oledSpiDc, oledSpiRst);
       if (oledDisplay == nullptr) {
-        DEBUG_PRINTF("[%s] OLED init failed!\n", _name);
+        DEBUGUM_PRINTF("[%s] OLED init failed!\n", _name);
         oledEnabled = oledInitDone = false;
         return;
       }
@@ -185,7 +185,7 @@ class QuinLEDAnPentaUsermod : public Usermod
     {
       PinManagerPinType pins[2] = { { shtSda, true }, { shtScl, true } };
       if (!pinManager.allocateMultiplePins(pins, 2, PinOwner::UM_QuinLEDAnPenta)) {
-        DEBUG_PRINTF("[%s] SHT30 pin allocation failed!\n", _name);
+        DEBUGUM_PRINTF("[%s] SHT30 pin allocation failed!\n", _name);
         shtEnabled = shtInitDone = false;
         return;
       }
@@ -198,7 +198,7 @@ class QuinLEDAnPentaUsermod : public Usermod
       // The SHT lib calls wire.begin() again without the SDA and SCL pins... So call it again here...
       wire->begin(shtSda, shtScl);
       if (sht30TempHumidSensor->readStatus() == 0xFFFF) {
-        DEBUG_PRINTF("[%s] SHT30 init failed!\n", _name);
+        DEBUGUM_PRINTF("[%s] SHT30 init failed!\n", _name);
         shtEnabled = shtInitDone = false;
         return;
       }
@@ -600,7 +600,7 @@ class QuinLEDAnPentaUsermod : public Usermod
     {
       JsonObject top = root[FPSTR(_name)];
       if (top.isNull()) {
-        DEBUG_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
+        DEBUGUM_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
         return false;
       }
 
@@ -619,12 +619,12 @@ class QuinLEDAnPentaUsermod : public Usermod
 
       // First run: reading from cfg.json, nothing to do here, will be all done in setup()
       if (!firstRunDone) {
-        DEBUG_PRINTF("[%s] First run, nothing to do\n", _name);
+        DEBUGUM_PRINTF("[%s] First run, nothing to do\n", _name);
       }
       // Check if mod has been en-/disabled
       else if (enabled != oldEnabled) {
         enabled ? setup() : cleanup();
-        DEBUG_PRINTF("[%s] Usermod has been en-/disabled\n", _name);
+        DEBUGUM_PRINTF("[%s] Usermod has been en-/disabled\n", _name);
       }
       // Config has been changed, so adopt to changes
       else if (enabled) {
@@ -641,7 +641,7 @@ class QuinLEDAnPentaUsermod : public Usermod
           shtEnabled ? initSht30TempHumiditySensor() : cleanupSht30TempHumiditySensor();
         }
 
-        DEBUG_PRINTF("[%s] Config (re)loaded\n", _name);
+        DEBUGUM_PRINTF("[%s] Config (re)loaded\n", _name);
       }
 
       return true;

--- a/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
+++ b/usermods/rgb-rotary-encoder/rgb-rotary-encoder.h
@@ -249,7 +249,7 @@ class RgbRotaryEncoderUsermod : public Usermod
     {
       JsonObject top = root[FPSTR(_name)];
       if (top.isNull()) {
-        DEBUG_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
+        DEBUGUM_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
         return false;
       }
 
@@ -277,17 +277,17 @@ class RgbRotaryEncoderUsermod : public Usermod
       }
       // Mod was disabled, so run setup()
       else if (enabled && enabled != oldEnabled) {
-        DEBUG_PRINTF("[%s] Usermod has been re-enabled\n", _name);
+        DEBUGUM_PRINTF("[%s] Usermod has been re-enabled\n", _name);
         setup();
       }
       // Config has been changed, so adopt to changes
       else {
         if (!enabled) {
-          DEBUG_PRINTF("[%s] Usermod has been disabled\n", _name);
+          DEBUGUM_PRINTF("[%s] Usermod has been disabled\n", _name);
           cleanup();
         }
         else {
-          DEBUG_PRINTF("[%s] Usermod is enabled\n", _name);
+          DEBUGUM_PRINTF("[%s] Usermod is enabled\n", _name);
           if (ledIo != oldLedIo) {
             delete ledBus;
             initLedBus();
@@ -311,7 +311,7 @@ class RgbRotaryEncoderUsermod : public Usermod
           }
         }
 
-        DEBUG_PRINTF("[%s] Config (re)loaded\n", _name);
+        DEBUGUM_PRINTF("[%s] Config (re)loaded\n", _name);
       }
       
       return true;

--- a/usermods/sd_card/readme.md
+++ b/usermods/sd_card/readme.md
@@ -7,7 +7,7 @@
   2. via `-D WLED_USE_SD_SPI` when connected via SPI (use usermod page to setup SPI pins)
 
 ### Test
-- enable `-D SD_PRINT_HOME_DIR` and `-D WLED_DEBUG`
+- enable `-D SD_PRINT_HOME_DIR` and `-D WLED_DEBUG_USERMODS`
 - this will print all files in `/` on boot via serial
 
 ## Configuration

--- a/usermods/sd_card/usermod_sd_card.h
+++ b/usermods/sd_card/usermod_sd_card.h
@@ -46,7 +46,7 @@ class UsermodSdCard : public Usermod {
         };
 
         if (!pinManager.allocateMultiplePins(pins, 4, PinOwner::UM_SdCard)) {
-            DEBUG_PRINTF("[%s] SD (SPI) pin allocation failed!\n", _name);
+            DEBUGUM_PRINTF("[%s] SD (SPI) pin allocation failed!\n", _name);
             sdInitDone = false;
             return;
         }
@@ -59,7 +59,7 @@ class UsermodSdCard : public Usermod {
         #endif
 
         if(!returnOfInitSD) {
-          DEBUG_PRINTF("[%s] SPI begin failed!\n", _name);
+          DEBUGUM_PRINTF("[%s] SPI begin failed!\n", _name);
           sdInitDone = false;
           return;
         }
@@ -74,7 +74,7 @@ class UsermodSdCard : public Usermod {
 
         SD_ADAPTER.end();
 
-        DEBUG_PRINTF("[%s] deallocate pins!\n", _name);
+        DEBUGUM_PRINTF("[%s] deallocate pins!\n", _name);
         pinManager.deallocatePin(configPinSourceSelect, PinOwner::UM_SdCard);
         pinManager.deallocatePin(configPinSourceClock,  PinOwner::UM_SdCard);
         pinManager.deallocatePin(configPinPoci,         PinOwner::UM_SdCard);
@@ -96,10 +96,10 @@ class UsermodSdCard : public Usermod {
         if(sdInitDone) return;
         bool returnOfInitSD = false;
         returnOfInitSD = SD_ADAPTER.begin();
-        DEBUG_PRINTF("[%s] MMC begin\n", _name);
+        DEBUGUM_PRINTF("[%s] MMC begin\n", _name);
 
         if(!returnOfInitSD) {
-          DEBUG_PRINTF("[%s] MMC begin failed!\n", _name);
+          DEBUGUM_PRINTF("[%s] MMC begin failed!\n", _name);
           sdInitDone = false;
           return;
         }
@@ -113,7 +113,7 @@ class UsermodSdCard : public Usermod {
     static const char _name[];
 
     void setup() {
-      DEBUG_PRINTF("[%s] usermod loaded \n", _name);
+      DEBUGUM_PRINTF("[%s] usermod loaded \n", _name);
       #if defined(WLED_USE_SD_SPI)
         init_SD_SPI();
       #elif defined(WLED_USE_SD_MMC)
@@ -151,7 +151,7 @@ class UsermodSdCard : public Usermod {
       #ifdef WLED_USE_SD_SPI
         JsonObject top = root[FPSTR(_name)];
         if (top.isNull()) {
-          DEBUG_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
+          DEBUGUM_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
           return false;
         }
 
@@ -169,7 +169,7 @@ class UsermodSdCard : public Usermod {
 
         if(configSdEnabled != oldSdEnabled) {
           configSdEnabled ? init_SD_SPI() : deinit_SD_SPI();
-          DEBUG_PRINTF("[%s] SD card %s\n", _name, configSdEnabled ? "enabled" : "disabled");
+          DEBUGUM_PRINTF("[%s] SD card %s\n", _name, configSdEnabled ? "enabled" : "disabled");
         }
 
         if( configSdEnabled && (
@@ -179,8 +179,8 @@ class UsermodSdCard : public Usermod {
             oldPinPico          != configPinPico)
           )
         {
-          DEBUG_PRINTF("[%s] Init SD card based of config\n", _name);
-          DEBUG_PRINTF("[%s] Config changes \n - SS: %d -> %d\n - MI: %d -> %d\n - MO: %d -> %d\n - En: %d -> %d\n", _name, oldPinSourceSelect, configPinSourceSelect, oldPinSourceClock, configPinSourceClock, oldPinPoci, configPinPoci, oldPinPico, configPinPico);
+          DEBUGUM_PRINTF("[%s] Init SD card based of config\n", _name);
+          DEBUGUM_PRINTF("[%s] Config changes \n - SS: %d -> %d\n - MI: %d -> %d\n - MO: %d -> %d\n - En: %d -> %d\n", _name, oldPinSourceSelect, configPinSourceSelect, oldPinSourceClock, configPinSourceClock, oldPinPoci, configPinPoci, oldPinPico, configPinPico);
           reinit_SD_SPI();
         }
       #endif
@@ -202,7 +202,7 @@ bool file_onSD(const char *filepath)
 
   uint8_t cardType = SD_ADAPTER.cardType();
   if(cardType == CARD_NONE) {
-    DEBUG_PRINTF("[%s] not attached / cardType none\n", UsermodSdCard::_name);
+    DEBUGUM_PRINTF("[%s] not attached / cardType none\n", UsermodSdCard::_name);
     return false; // no SD card attached
   }
   if(cardType == CARD_MMC || cardType == CARD_SD || cardType == CARD_SDHC)
@@ -214,27 +214,27 @@ bool file_onSD(const char *filepath)
 }
 
 void listDir( const char * dirname, uint8_t levels){
-    DEBUG_PRINTF("Listing directory: %s\n", dirname);
+    DEBUGUM_PRINTF("Listing directory: %s\n", dirname);
 
     File root = SD_ADAPTER.open(dirname);
     if(!root){
-        DEBUG_PRINTF("Failed to open directory\n");
+        DEBUGUM_PRINTF("Failed to open directory\n");
         return;
     }
     if(!root.isDirectory()){
-        DEBUG_PRINTF("Not a directory\n");
+        DEBUGUM_PRINTF("Not a directory\n");
         return;
     }
 
     File file = root.openNextFile();
     while(file){
         if(file.isDirectory()){
-            DEBUG_PRINTF("  DIR : %s\n",file.name());
+            DEBUGUM_PRINTF("  DIR : %s\n",file.name());
             if(levels){
                 listDir(file.name(), levels -1);
             }
         } else {
-            DEBUG_PRINTF("  FILE: %s  SIZE: %d\n",file.name(), file.size());
+            DEBUGUM_PRINTF("  FILE: %s  SIZE: %d\n",file.name(), file.size());
         }
         file = root.openNextFile();
     }

--- a/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
+++ b/usermods/seven_segment_display_reloaded/usermod_seven_segment_reloaded.h
@@ -385,7 +385,7 @@ public:
     #ifdef USERMOD_SN_PHOTORESISTOR
       ptr = (Usermod_SN_Photoresistor*) usermods.lookup(USERMOD_ID_SN_PHOTORESISTOR);
     #endif
-    DEBUG_PRINTLN(F("Setup done"));
+    DEBUGUM_PRINTLN(F("Setup done"));
   }
 
   /*
@@ -517,8 +517,8 @@ public:
     JsonObject top = root[FPSTR(_str_name)];
 
     if (top.isNull()) {
-      DEBUG_PRINT(FPSTR(_str_name));
-      DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+      DEBUGUM_PRINT(FPSTR(_str_name));
+      DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
       return false;
     }
 
@@ -539,8 +539,8 @@ public:
     umSSDRBrightnessMin    = top[FPSTR(_str_minBrightness)] | umSSDRBrightnessMin;
     umSSDRBrightnessMax    = top[FPSTR(_str_maxBrightness)] | umSSDRBrightnessMax;
 
-    DEBUG_PRINT(FPSTR(_str_name));
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINT(FPSTR(_str_name));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
 
     return true;
   }

--- a/usermods/sht/usermod_sht.h
+++ b/usermods/sht/usermod_sht.h
@@ -95,7 +95,7 @@ void ShtUsermod::initShtTempHumiditySensor()
 
   shtTempHumidSensor->begin(shtI2cAddress); // uses &Wire
   if (shtTempHumidSensor->readStatus() == 0xFFFF) {
-    DEBUG_PRINTF("[%s] SHT init failed!\n", _name);
+    DEBUGUM_PRINTF("[%s] SHT init failed!\n", _name);
     cleanup();
     return;
   }
@@ -231,7 +231,7 @@ void ShtUsermod::setup()
   if (enabled) {
     // GPIOs can be set to -1 , so check they're gt zero
     if (i2c_sda < 0 || i2c_scl < 0) {
-      DEBUG_PRINTF("[%s] I2C bus not initialised!\n", _name);
+      DEBUGUM_PRINTF("[%s] I2C bus not initialised!\n", _name);
       cleanup();
       return;
     }
@@ -362,7 +362,7 @@ bool ShtUsermod::readFromConfig(JsonObject &root)
 {
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
+    DEBUGUM_PRINTF("[%s] No config found. (Using defaults.)\n", _name);
     return false;
   }
 
@@ -378,12 +378,12 @@ bool ShtUsermod::readFromConfig(JsonObject &root)
 
   // First run: reading from cfg.json, nothing to do here, will be all done in setup()
   if (!firstRunDone) {
-    DEBUG_PRINTF("[%s] First run, nothing to do\n", _name);
+    DEBUGUM_PRINTF("[%s] First run, nothing to do\n", _name);
   }
   // Check if mod has been en-/disabled
   else if (enabled != oldEnabled) {
     enabled ? setup() : cleanup();
-    DEBUG_PRINTF("[%s] Usermod has been en-/disabled\n", _name);
+    DEBUGUM_PRINTF("[%s] Usermod has been en-/disabled\n", _name);
   }
   // Config has been changed, so adopt to changes
   else if (enabled) {
@@ -401,7 +401,7 @@ bool ShtUsermod::readFromConfig(JsonObject &root)
       publishHomeAssistantAutodiscovery();
     }
 
-    DEBUG_PRINTF("[%s] Config (re)loaded\n", _name);
+    DEBUGUM_PRINTF("[%s] Config (re)loaded\n", _name);
   }
 
   return true;

--- a/usermods/smartnest/usermod_smartnest.h
+++ b/usermods/smartnest/usermod_smartnest.h
@@ -177,7 +177,7 @@ public:
    * setup() is called once at startup to initialize the usermod.
    */
   void setup() {
-      DEBUG_PRINTF("Smartnest usermod setup initializing...");
+      DEBUGUM_PRINTF("Smartnest usermod setup initializing...");
       
       // Publish initial status
       sendToBroker("report/status", "Smartnest usermod initialized");

--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.h
@@ -225,7 +225,7 @@ class AutoSaveUsermod : public Usermod {
       top[FPSTR(_autoSaveAfterSec)]    = autoSaveAfterSec;  // usermodparam
       top[FPSTR(_autoSavePreset)]      = autoSavePreset;    // usermodparam
       top[FPSTR(_autoSaveApplyOnBoot)] = applyAutoSaveOnBoot;
-      DEBUG_PRINTLN(F("Autosave config saved."));
+      DEBUGUM_PRINTLN(F("Autosave config saved."));
     }
 
     /*
@@ -242,8 +242,8 @@ class AutoSaveUsermod : public Usermod {
       // we look for JSON object: {"Autosave": {"enabled": true, "autoSaveAfterSec": 10, "autoSavePreset": 250, ...}}
       JsonObject top = root[FPSTR(_name)];
       if (top.isNull()) {
-        DEBUG_PRINT(FPSTR(_name));
-        DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+        DEBUGUM_PRINT(FPSTR(_name));
+        DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
         return false;
       }
 
@@ -253,8 +253,8 @@ class AutoSaveUsermod : public Usermod {
       autoSavePreset      = top[FPSTR(_autoSavePreset)] | autoSavePreset;
       autoSavePreset      = (uint8_t) min(250,max(100,(int)autoSavePreset)); // bounds checking
       applyAutoSaveOnBoot = top[FPSTR(_autoSaveApplyOnBoot)] | applyAutoSaveOnBoot;
-      DEBUG_PRINT(FPSTR(_name));
-      DEBUG_PRINTLN(F(" config (re)loaded."));
+      DEBUGUM_PRINT(FPSTR(_name));
+      DEBUGUM_PRINTLN(F(" config (re)loaded."));
 
       // use "return !top["newestParameter"].isNull();" when updating Usermod with new features
       return true;

--- a/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
+++ b/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
@@ -376,7 +376,7 @@ void FourLineDisplayUsermod::setVcomh(bool highContrast) {
 void FourLineDisplayUsermod::startDisplay() {
   if (type == NONE || !enabled) return;
   lineHeight = u8x8->getRows() > 4 ? 2 : 1;
-  DEBUG_PRINTLN(F("Starting display."));
+  DEBUGUM_PRINTLN(F("Starting display."));
   u8x8->setBusClock(ioFrequency);  // can be used for SPI too
   u8x8->begin();
   setFlipMode(flip);
@@ -549,7 +549,7 @@ void FourLineDisplayUsermod::setup() {
     if (i2c_scl<0 || i2c_sda<0) { type=NONE; }
   }
 
-  DEBUG_PRINTLN(F("Allocating display."));
+  DEBUGUM_PRINTLN(F("Allocating display."));
   switch (type) {
     // U8X8 uses Wire (or Wire1 with 2ND constructor) and will use existing Wire properties (calls Wire.begin() though)
     case SSD1306:       u8x8 = (U8X8 *) new U8X8_SSD1306_128X32_UNIVISION_HW_I2C(); break;
@@ -567,7 +567,7 @@ void FourLineDisplayUsermod::setup() {
   }
 
   if (nullptr == u8x8) {
-    DEBUG_PRINTLN(F("Display init failed."));
+    DEBUGUM_PRINTLN(F("Display init failed."));
     if (isSPI) {
       pinManager.deallocateMultiplePins((const uint8_t*)ioPin, 3, PinOwner::UM_FourLineDisplay);
     }
@@ -1094,7 +1094,7 @@ bool FourLineDisplayUsermod::handleButton(uint8_t b) {
     if (now - buttonPressedTime > 600) { //long press
       //TODO: handleButton() handles button 0 without preset in a different way for double click
       //so we need to override with same behaviour
-      //DEBUG_PRINTLN(F("4LD action."));
+      //DEBUGUM_PRINTLN(F("4LD action."));
       //if (!buttonLongPressed) longPressAction(0);
       buttonLongPressed = true;
       return false;
@@ -1251,7 +1251,7 @@ void FourLineDisplayUsermod::addToConfig(JsonObject& root) {
   top[FPSTR(_clockMode)]     = (bool) clockMode;
   top[FPSTR(_showSeconds)]   = (bool) showSeconds;
   top[FPSTR(_busClkFrequency)] = ioFrequency/1000;
-  DEBUG_PRINTLN(F("4 Line Display config saved."));
+  DEBUGUM_PRINTLN(F("4 Line Display config saved."));
 }
 
 /*
@@ -1269,8 +1269,8 @@ bool FourLineDisplayUsermod::readFromConfig(JsonObject& root) {
 
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINT(FPSTR(_name));
-    DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+    DEBUGUM_PRINT(FPSTR(_name));
+    DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
     return false;
   }
 
@@ -1293,13 +1293,13 @@ bool FourLineDisplayUsermod::readFromConfig(JsonObject& root) {
   else
     ioFrequency = min(3400, max(100, (int)(top[FPSTR(_busClkFrequency)] | ioFrequency/1000))) * 1000;  // limit frequency
 
-  DEBUG_PRINT(FPSTR(_name));
+  DEBUGUM_PRINT(FPSTR(_name));
   if (!initDone) {
     // first run: reading from cfg.json
     type = newType;
-    DEBUG_PRINTLN(F(" config loaded."));
+    DEBUGUM_PRINTLN(F(" config loaded."));
   } else {
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
     // changing parameters from settings page
     bool pinsChanged = false;
     for (byte i=0; i<3; i++) if (ioPin[i] != oldPin[i]) { pinsChanged = true; break; }

--- a/usermods/usermod_v2_klipper_percentage/usermod_v2_klipper_percentage.h
+++ b/usermods/usermod_v2_klipper_percentage/usermod_v2_klipper_percentage.h
@@ -88,15 +88,15 @@ public:
             }
             printPercent = (int)(klipperDoc[F("result")][F("status")][F("virtual_sdcard")][F("progress")].as<float>() * 100);
 
-            DEBUG_PRINT(F("Percent: "));
-            DEBUG_PRINTLN((int)(klipperDoc[F("result")][F("status")][F("virtual_sdcard")][F("progress")].as<float>() * 100));
-            DEBUG_PRINT(F("LEDs: "));
-            DEBUG_PRINTLN(direction == 2 ? (strip.getLengthTotal() / 2) * printPercent / 100 : strip.getLengthTotal() * printPercent / 100);
+            DEBUGUM_PRINT(F("Percent: "));
+            DEBUGUM_PRINTLN((int)(klipperDoc[F("result")][F("status")][F("virtual_sdcard")][F("progress")].as<float>() * 100));
+            DEBUGUM_PRINT(F("LEDs: "));
+            DEBUGUM_PRINTLN(direction == 2 ? (strip.getLengthTotal() / 2) * printPercent / 100 : strip.getLengthTotal() * printPercent / 100);
           }
           else
           {
-            DEBUG_PRINTLN(errorMessage);
-            DEBUG_PRINTLN(ip);
+            DEBUGUM_PRINTLN(errorMessage);
+            DEBUGUM_PRINTLN(ip);
           }
           lastTime = millis();
         }

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
@@ -392,13 +392,13 @@ byte RotaryEncoderUIUsermod::readPin(uint8_t pin) {
  * modes_alpha_indexes and palettes_alpha_indexes.
  */
 void RotaryEncoderUIUsermod::sortModesAndPalettes() {
-  DEBUG_PRINT(F("Sorting modes: ")); DEBUG_PRINTLN(strip.getModeCount());
+  DEBUGUM_PRINT(F("Sorting modes: ")); DEBUGUM_PRINTLN(strip.getModeCount());
   //modes_qstrings = re_findModeStrings(JSON_mode_names, strip.getModeCount());
   modes_qstrings = strip.getModeDataSrc();
   modes_alpha_indexes = re_initIndexArray(strip.getModeCount());
   re_sortModes(modes_qstrings, modes_alpha_indexes, strip.getModeCount(), MODE_SORT_SKIP_COUNT);
 
-  DEBUG_PRINT(F("Sorting palettes: ")); DEBUG_PRINT(strip.getPaletteCount()); DEBUG_PRINT('/'); DEBUG_PRINTLN(strip.customPalettes.size());
+  DEBUGUM_PRINT(F("Sorting palettes: ")); DEBUGUM_PRINT(strip.getPaletteCount()); DEBUGUM_PRINT('/'); DEBUGUM_PRINTLN(strip.customPalettes.size());
   palettes_qstrings = re_findModeStrings(JSON_palette_names, strip.getPaletteCount());
   palettes_alpha_indexes = re_initIndexArray(strip.getPaletteCount());
   if (strip.customPalettes.size()) {
@@ -481,20 +481,20 @@ void RotaryEncoderUIUsermod::re_sortModes(const char **modeNames, byte *indexes,
   */
 void RotaryEncoderUIUsermod::setup()
 {
-  DEBUG_PRINTLN(F("Usermod Rotary Encoder init."));
+  DEBUGUM_PRINTLN(F("Usermod Rotary Encoder init."));
 
   if (usePcf8574) {
     if (i2c_sda < 0 || i2c_scl < 0 || pinA < 0 || pinB < 0 || pinC < 0) {
-      DEBUG_PRINTLN(F("I2C and/or PCF8574 pins unused, disabling."));
+      DEBUGUM_PRINTLN(F("I2C and/or PCF8574 pins unused, disabling."));
       enabled = false;
       return;
     } else {
       if (pinIRQ >= 0 && pinManager.allocatePin(pinIRQ, false, PinOwner::UM_RotaryEncoderUI)) {
         pinMode(pinIRQ, INPUT_PULLUP);
         attachInterrupt(pinIRQ, i2cReadingISR, FALLING); // RISING, FALLING, CHANGE, ONLOW, ONHIGH
-        DEBUG_PRINTLN(F("Interrupt attached."));
+        DEBUGUM_PRINTLN(F("Interrupt attached."));
       } else {
-        DEBUG_PRINTLN(F("Unable to allocate interrupt pin, disabling."));
+        DEBUGUM_PRINTLN(F("Unable to allocate interrupt pin, disabling."));
         pinIRQ = -1;
         enabled = false;
         return;
@@ -562,7 +562,7 @@ void RotaryEncoderUIUsermod::loop()
   }
 
   if (modes_alpha_indexes[effectCurrentIndex] != effectCurrent || palettes_alpha_indexes[effectPaletteIndex] != effectPalette) {
-    DEBUG_PRINTLN(F("Current mode or palette changed."));
+    DEBUGUM_PRINTLN(F("Current mode or palette changed."));
     currentEffectAndPaletteInitialized = false;
   }
 
@@ -686,24 +686,24 @@ void RotaryEncoderUIUsermod::displayNetworkInfo() {
 }
 
 void RotaryEncoderUIUsermod::findCurrentEffectAndPalette() {
-  DEBUG_PRINTLN(F("Finding current mode and palette."));
+  DEBUGUM_PRINTLN(F("Finding current mode and palette."));
   currentEffectAndPaletteInitialized = true;
 
   effectCurrentIndex = 0;
   for (int i = 0; i < strip.getModeCount(); i++) {
     if (modes_alpha_indexes[i] == effectCurrent) {
       effectCurrentIndex = i;
-      DEBUG_PRINTLN(F("Found current mode."));
+      DEBUGUM_PRINTLN(F("Found current mode."));
       break;
     }
   }
 
   effectPaletteIndex = 0;
-  DEBUG_PRINTLN(effectPalette);
+  DEBUGUM_PRINTLN(effectPalette);
   for (uint8_t i = 0; i < strip.getPaletteCount()+strip.customPalettes.size(); i++) {
     if (palettes_alpha_indexes[i] == effectPalette) {
       effectPaletteIndex = i;
-      DEBUG_PRINTLN(F("Found palette."));
+      DEBUGUM_PRINTLN(F("Found palette."));
       break;
     }
   }
@@ -1086,7 +1086,7 @@ void RotaryEncoderUIUsermod::addToConfig(JsonObject &root) {
   top[FPSTR(_pcf8574)]    = usePcf8574;
   top[FPSTR(_pcfAddress)] = addrPcf8574;
   top[FPSTR(_pcfINTpin)]  = pinIRQ;
-  DEBUG_PRINTLN(F("Rotary Encoder config saved."));
+  DEBUGUM_PRINTLN(F("Rotary Encoder config saved."));
 }
 
 void RotaryEncoderUIUsermod::appendConfigData() {
@@ -1103,8 +1103,8 @@ bool RotaryEncoderUIUsermod::readFromConfig(JsonObject &root) {
   // we look for JSON object: {"Rotary-Encoder":{"DT-pin":12,"CLK-pin":14,"SW-pin":13}}
   JsonObject top = root[FPSTR(_name)];
   if (top.isNull()) {
-    DEBUG_PRINT(FPSTR(_name));
-    DEBUG_PRINTLN(F(": No config found. (Using defaults.)"));
+    DEBUGUM_PRINT(FPSTR(_name));
+    DEBUGUM_PRINTLN(F(": No config found. (Using defaults.)"));
     return false;
   }
   int8_t newDTpin  = top[FPSTR(_DT_pin)]  | pinA;
@@ -1124,29 +1124,29 @@ bool RotaryEncoderUIUsermod::readFromConfig(JsonObject &root) {
   usePcf8574 = top[FPSTR(_pcf8574)] | usePcf8574;
   addrPcf8574 = top[FPSTR(_pcfAddress)] | addrPcf8574;
 
-  DEBUG_PRINT(FPSTR(_name));
+  DEBUGUM_PRINT(FPSTR(_name));
   if (!initDone) {
     // first run: reading from cfg.json
     pinA = newDTpin;
     pinB = newCLKpin;
     pinC = newSWpin;
-    DEBUG_PRINTLN(F(" config loaded."));
+    DEBUGUM_PRINTLN(F(" config loaded."));
   } else {
-    DEBUG_PRINTLN(F(" config (re)loaded."));
+    DEBUGUM_PRINTLN(F(" config (re)loaded."));
     // changing parameters from settings page
     if (pinA!=newDTpin || pinB!=newCLKpin || pinC!=newSWpin || pinIRQ!=newIRQpin) {
       if (oldPcf8574) {
         if (pinIRQ >= 0) {
           detachInterrupt(pinIRQ);
           pinManager.deallocatePin(pinIRQ, PinOwner::UM_RotaryEncoderUI);
-          DEBUG_PRINTLN(F("Deallocated old IRQ pin."));
+          DEBUGUM_PRINTLN(F("Deallocated old IRQ pin."));
         }
         pinIRQ = newIRQpin<100 ? newIRQpin : -1; // ignore PCF8574 pins
       } else {
         pinManager.deallocatePin(pinA, PinOwner::UM_RotaryEncoderUI);
         pinManager.deallocatePin(pinB, PinOwner::UM_RotaryEncoderUI);
         pinManager.deallocatePin(pinC, PinOwner::UM_RotaryEncoderUI);
-        DEBUG_PRINTLN(F("Deallocated old pins."));
+        DEBUGUM_PRINTLN(F("Deallocated old pins."));
       }
       pinA = newDTpin;
       pinB = newCLKpin;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -31,6 +31,25 @@
 
 #include "const.h"
 
+#ifdef WLED_DEBUG_FX
+  // enable additional debug output
+  #if defined(WLED_DEBUG_HOST)
+    #include "net_debug.h"
+    #define DEBUGOUT NetDebug
+  #else
+    #define DEBUGOUT Serial
+  #endif
+  #define DEBUGFX_PRINT(x) DEBUGOUT.print(x)
+  #define DEBUGFX_PRINTLN(x) DEBUGOUT.println(x)
+  #define DEBUGFX_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGFX_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+#else
+  #define DEBUGFX_PRINT(x)
+  #define DEBUGFX_PRINTLN(x)
+  #define DEBUGFX_PRINTF(x...)
+  #define DEBUGFX_PRINTF_P(x...)
+#endif
+
 #define FASTLED_INTERNAL //remove annoying pragma messages
 #define USE_GET_MILLISECOND_TIMER
 #include "FastLED.h"
@@ -484,7 +503,7 @@ typedef struct Segment {
       _dataLen(0),
       _t(nullptr)
     {
-      #ifdef WLED_DEBUG
+      #ifdef WLED_DEBUG_FX
       //Serial.printf("-- Creating segment: %p\n", this);
       #endif
     }
@@ -498,7 +517,7 @@ typedef struct Segment {
     Segment(Segment &&orig) noexcept; // move constructor
 
     ~Segment() {
-      #ifdef WLED_DEBUG
+      #ifdef WLED_DEBUG_FX
       //Serial.printf("-- Destroying segment: %p", this);
       //if (name) Serial.printf(" %s (%p)", name, name);
       //if (data) Serial.printf(" %d->(%p)", (int)_dataLen, data);
@@ -512,7 +531,7 @@ typedef struct Segment {
     Segment& operator= (const Segment &orig); // copy assignment
     Segment& operator= (Segment &&orig) noexcept; // move assignment
 
-#ifdef WLED_DEBUG
+#ifdef WLED_DEBUG_FX
     size_t getSize() const { return sizeof(Segment) + (data?_dataLen:0) + (name?strlen(name):0) + (_t?sizeof(Transition):0); }
 #endif
 
@@ -760,7 +779,7 @@ class WS2812FX {  // 96 bytes
     static WS2812FX* getInstance(void) { return instance; }
 
     void
-#ifdef WLED_DEBUG
+#ifdef WLED_DEBUG_FX
       printSize(),                                // prints memory usage for strip components
 #endif
       finalizeInit(),                             // initialises strip components

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -53,7 +53,7 @@ void WS2812FX::setUpMatrix() {
 
     // safety check
     if (Segment::maxWidth * Segment::maxHeight > MAX_LEDS || Segment::maxWidth <= 1 || Segment::maxHeight <= 1) {
-      DEBUG_PRINTLN(F("2D Bounds error."));
+      DEBUGFX_PRINTLN(F("2D Bounds error."));
       isMatrix = false;
       Segment::maxWidth = _length;
       Segment::maxHeight = 1;
@@ -89,8 +89,8 @@ void WS2812FX::setUpMatrix() {
       int8_t *gapTable = nullptr;
 
       if (isFile && requestJSONBufferLock(20)) {
-        DEBUG_PRINT(F("Reading LED gap from "));
-        DEBUG_PRINTLN(fileName);
+        DEBUGFX_PRINT(F("Reading LED gap from "));
+        DEBUGFX_PRINTLN(fileName);
         // read the array into global JSON buffer
         if (readObjectFromFile(fileName, nullptr, pDoc)) {
           // the array is similar to ledmap, except it has only 3 values:
@@ -106,7 +106,7 @@ void WS2812FX::setUpMatrix() {
             }
           }
         }
-        DEBUG_PRINTLN(F("Gaps loaded."));
+        DEBUGFX_PRINTLN(F("Gaps loaded."));
         releaseJSONBufferLock();
       }
 
@@ -130,16 +130,16 @@ void WS2812FX::setUpMatrix() {
       // delete gap array as we no longer need it
       if (gapTable) delete[] gapTable;
 
-      #ifdef WLED_DEBUG
-      DEBUG_PRINT(F("Matrix ledmap:"));
+      #ifdef WLED_DEBUG_FX
+      DEBUGFX_PRINT(F("Matrix ledmap:"));
       for (unsigned i=0; i<customMappingSize; i++) {
-        if (!(i%Segment::maxWidth)) DEBUG_PRINTLN();
-        DEBUG_PRINTF_P(PSTR("%4d,"), customMappingTable[i]);
+        if (!(i%Segment::maxWidth)) DEBUGFX_PRINTLN();
+        DEBUGFX_PRINTF_P(PSTR("%4d,"), customMappingTable[i]);
       }
-      DEBUG_PRINTLN();
+      DEBUGFX_PRINTLN();
       #endif
     } else { // memory allocation error
-      DEBUG_PRINTLN(F("ERROR 2D LED map allocation error."));
+      DEBUGFX_PRINTLN(F("ERROR 2D LED map allocation error."));
       isMatrix = false;
       panels = 0;
       panel.clear();

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -17,29 +17,6 @@ uint32_t colorBalanceFromKelvin(uint16_t kelvin, uint32_t rgb);
 //udp.cpp
 uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, byte *buffer, uint8_t bri=255, bool isRGBW=false);
 
-// enable additional debug output
-#if defined(WLED_DEBUG_HOST)
-  #include "net_debug.h"
-  #define DEBUGOUT NetDebug
-#else
-  #define DEBUGOUT Serial
-#endif
-
-#ifdef WLED_DEBUG
-  #ifndef ESP8266
-  #include <rom/rtc.h>
-  #endif
-  #define DEBUG_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUG_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUG_PRINTF(x...) DEBUGOUT.printf(x)
-  #define DEBUG_PRINTF_P(x...) DEBUGOUT.printf_P(x)
-#else
-  #define DEBUG_PRINT(x)
-  #define DEBUG_PRINTLN(x)
-  #define DEBUG_PRINTF(x...)
-  #define DEBUG_PRINTF_P(x...)
-#endif
-
 //color mangling macros
 #define RGBW32(r,g,b,w) (uint32_t((byte(w) << 24) | (byte(r) << 16) | (byte(g) << 8) | (byte(b))))
 #define R(c) (byte((c) >> 16))
@@ -129,7 +106,7 @@ BusDigital::BusDigital(BusConfig &bc, uint8_t nr, const ColorOrderMap &com)
   if (bc.type == TYPE_WS2812_1CH_X3) lenToCreate = NUM_ICS_WS2812_1CH_3X(bc.count); // only needs a third of "RGB" LEDs for NeoPixelBus
   _busPtr = PolyBus::create(_iType, _pins, lenToCreate + _skip, nr, _frequencykHz);
   _valid = (_busPtr != nullptr);
-  DEBUG_PRINTF_P(PSTR("%successfully inited strip %u (len %u) with type %u and pins %u,%u (itype %u). mA=%d/%d\n"), _valid?"S":"Uns", nr, bc.count, bc.type, _pins[0], IS_2PIN(bc.type)?_pins[1]:255, _iType, _milliAmpsPerLed, _milliAmpsMax);
+  DEBUGBUS_PRINTF_P(PSTR("%successfully inited strip %u (len %u) with type %u and pins %u,%u (itype %u). mA=%d/%d\n"), _valid?"S":"Uns", nr, bc.count, bc.type, _pins[0], IS_2PIN(bc.type)?_pins[1]:255, _iType, _milliAmpsPerLed, _milliAmpsMax);
 }
 
 //fine tune power estimation constants for your setup
@@ -367,7 +344,7 @@ void BusDigital::reinit() {
 }
 
 void BusDigital::cleanup() {
-  DEBUG_PRINTLN(F("Digital Cleanup."));
+  DEBUGBUS_PRINTLN(F("Digital Cleanup."));
   PolyBus::cleanup(_busPtr, _iType);
   _iType = I_NONE;
   _valid = false;
@@ -419,7 +396,7 @@ BusPwm::BusPwm(BusConfig &bc)
   }
   _data = _pwmdata; // avoid malloc() and use stack
   _valid = true;
-  DEBUG_PRINTF_P(PSTR("%successfully inited PWM strip with type %u and pins %u,%u,%u,%u,%u\n"), _valid?"S":"Uns", bc.type, _pins[0], _pins[1], _pins[2], _pins[3], _pins[4]);
+  DEBUGBUS_PRINTF_P(PSTR("%successfully inited PWM strip with type %u and pins %u,%u,%u,%u,%u\n"), _valid?"S":"Uns", bc.type, _pins[0], _pins[1], _pins[2], _pins[3], _pins[4]);
 }
 
 void BusPwm::setPixelColor(uint16_t pix, uint32_t c) {
@@ -570,7 +547,7 @@ BusOnOff::BusOnOff(BusConfig &bc)
   pinMode(_pin, OUTPUT);
   _data = &_onoffdata; // avoid malloc() and use stack
   _valid = true;
-  DEBUG_PRINTF_P(PSTR("%successfully inited On/Off strip with pin %u\n"), _valid?"S":"Uns", _pin);
+  DEBUGBUS_PRINTF_P(PSTR("%successfully inited On/Off strip with pin %u\n"), _valid?"S":"Uns", _pin);
 }
 
 void BusOnOff::setPixelColor(uint16_t pix, uint32_t c) {
@@ -625,7 +602,7 @@ BusNetwork::BusNetwork(BusConfig &bc)
   _UDPchannels = _rgbw ? 4 : 3;
   _client = IPAddress(bc.pins[0],bc.pins[1],bc.pins[2],bc.pins[3]);
   _valid = (allocData(_len * _UDPchannels) != nullptr);
-  DEBUG_PRINTF_P(PSTR("%successfully inited virtual strip with type %u and IP %u.%u.%u.%u\n"), _valid?"S":"Uns", bc.type, bc.pins[0], bc.pins[1], bc.pins[2], bc.pins[3]);
+  DEBUGBUS_PRINTF_P(PSTR("%successfully inited virtual strip with type %u and IP %u.%u.%u.%u\n"), _valid?"S":"Uns", bc.type, bc.pins[0], bc.pins[1], bc.pins[2], bc.pins[3]);
 }
 
 void BusNetwork::setPixelColor(uint16_t pix, uint32_t c) {
@@ -713,7 +690,7 @@ void BusManager::useParallelOutput(void) {
 
 //do not call this method from system context (network callback)
 void BusManager::removeAll() {
-  DEBUG_PRINTLN(F("Removing all."));
+  DEBUGBUS_PRINTLN(F("Removing all."));
   //prevents crashes due to deleting busses while in use.
   while (!canAllShow()) yield();
   for (unsigned i = 0; i < numBusses; i++) delete busses[i];

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -7,6 +7,29 @@
 
 #include "const.h"
 
+// enable additional debug output
+#if defined(WLED_DEBUG_HOST)
+  #include "net_debug.h"
+  #define DEBUGOUT NetDebug
+#else
+  #define DEBUGOUT Serial
+#endif
+
+#ifdef WLED_DEBUG_BUS
+  #ifndef ESP8266
+  #include <rom/rtc.h>
+  #endif
+  #define DEBUGBUS_PRINT(x) DEBUGOUT.print(x)
+  #define DEBUGBUS_PRINTLN(x) DEBUGOUT.println(x)
+  #define DEBUGBUS_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGBUS_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+#else
+  #define DEBUGBUS_PRINT(x)
+  #define DEBUGBUS_PRINTLN(x)
+  #define DEBUGBUS_PRINTF(x...)
+  #define DEBUGBUS_PRINTF_P(x...)
+#endif
+
 //colors.cpp
 uint16_t approximateKelvinFromRGB(uint32_t rgb);
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -625,4 +625,14 @@
   #define HW_PIN_MISOSPI MISO
 #endif
 
+#ifdef WLED_DEBUG_ALL
+  #define WLED_DEBUG 1
+  #define WLED_DEBUG_FX 1
+  #define WLED_DEBUG_FS 1
+  #define WLED_DEBUG_BUS 1
+  #define WLED_DEBUG_PINMANAGER 1
+  #define WLED_DEBUG_USERMODS 1
+  #define WLED_DEBUG_MATH 1
+#endif
+
 #endif

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -39,7 +39,7 @@ void closeFile() {
     uint32_t s = millis();
   #endif
   f.close();
-  DEBUGFS_PRINTF("took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("took %lu ms\n", millis() - s);
   doCloseFile = false;
 }
 
@@ -69,14 +69,14 @@ static bool bufferedFind(const char *target, bool fromStart = true) {
       if(buf[count] == target[index]) {
         if(++index >= targetLen) { // return true if all chars in the target match
           f.seek((f.position() - bufsize) + count +1);
-          DEBUGFS_PRINTF("Found at pos %d, took %d ms", f.position(), millis() - s);
+          DEBUGFS_PRINTF("Found at pos %d, took %lu ms", f.position(), millis() - s);
           return true;
         }
       }
       count++;
     }
   }
-  DEBUGFS_PRINTF("No match, took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("No match, took %lu ms\n", millis() - s);
   return false;
 }
 
@@ -111,7 +111,7 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
             f.seek((f.position() - bufsize) + count +1 - targetLen);
             knownLargestSpace = MAX_SPACE; //there may be larger spaces after, so we don't know
           }
-          DEBUGFS_PRINTF("Found at pos %d, took %d ms", f.position(), millis() - s);
+          DEBUGFS_PRINTF("Found at pos %d, took %lu ms", f.position(), millis() - s);
           return true;
         }
       } else {
@@ -125,7 +125,7 @@ static bool bufferedFindSpace(size_t targetLen, bool fromStart = true) {
       count++;
     }
   }
-  DEBUGFS_PRINTF("No match, took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("No match, took %lu ms\n", millis() - s);
   return false;
 }
 
@@ -151,13 +151,13 @@ static bool bufferedFindObjectEnd() {
       if (buf[count] == '}') objDepth--;
       if (objDepth == 0) {
         f.seek((f.position() - bufsize) + count +1);
-        DEBUGFS_PRINTF("} at pos %d, took %d ms", f.position(), millis() - s);
+        DEBUGFS_PRINTF("} at pos %d, took %lu ms", f.position(), millis() - s);
         return true;
       }
       count++;
     }
   }
-  DEBUGFS_PRINTF("No match, took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("No match, took %lu ms\n", millis() - s);
   return false;
 }
 
@@ -203,7 +203,7 @@ bool appendObjectToFile(const char* key, JsonDocument* content, uint32_t s, uint
     if (f.position() > 2) f.write(','); //add comma if not first object
     f.print(key);
     serializeJson(*content, f);
-    DEBUGFS_PRINTF("Inserted, took %d ms (total %d)", millis() - s1, millis() - s);
+    DEBUGFS_PRINTF("Inserted, took %lu ms (total %lu)", millis() - s1, millis() - s);
     doCloseFile = true;
     return true;
   }
@@ -251,7 +251,7 @@ bool appendObjectToFile(const char* key, JsonDocument* content, uint32_t s, uint
   f.write('}');
 
   doCloseFile = true;
-  DEBUGFS_PRINTF("Appended, took %d ms (total %d)", millis() - s1, millis() - s);
+  DEBUGFS_PRINTF("Appended, took %lu ms (total %lu)", millis() - s1, millis() - s);
   return true;
 }
 
@@ -321,7 +321,7 @@ bool writeObjectToFile(const char* file, const char* key, JsonDocument* content)
   }
 
   doCloseFile = true;
-  DEBUGFS_PRINTF("Replaced/deleted, took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("Replaced/deleted, took %lu ms\n", millis() - s);
   return true;
 }
 
@@ -355,7 +355,7 @@ bool readObjectFromFile(const char* file, const char* key, JsonDocument* dest)
   deserializeJson(*dest, f);
 
   f.close();
-  DEBUGFS_PRINTF("Read, took %d ms\n", millis() - s);
+  DEBUGFS_PRINTF("Read, took %lu ms\n", millis() - s);
   return true;
 }
 
@@ -418,7 +418,7 @@ static const uint8_t *getPresetCache(size_t &size) {
 #endif
 
 bool handleFileRead(AsyncWebServerRequest* request, String path){
-  DEBUG_PRINT(F("WS FileRead: ")); DEBUG_PRINTLN(path);
+  DEBUGFS_PRINT(F("WS FileRead: ")); DEBUGFS_PRINTLN(path);
   if(path.endsWith("/")) path += "index.htm";
   if(path.indexOf(F("sec")) > -1) return false;
   #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1144,10 +1144,7 @@ void serveJson(AsyncWebServerRequest* request)
 
   DEBUG_PRINTF_P(PSTR("JSON buffer size: %u for request: %d\n"), lDoc.memoryUsage(), subJson);
 
-  #ifdef WLED_DEBUG
-  size_t len =
-  #endif
-  response->setLength();
+  [[maybe_unused]] size_t len = response->setLength();
   DEBUG_PRINT(F("JSON content length: ")); DEBUG_PRINTLN(len);
 
   request->send(response);

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -1,14 +1,13 @@
 #include "pin_manager.h"
-#include "wled.h"
 
-#ifdef WLED_DEBUG
+#ifdef WLED_DEBUG_PINMANAGER
 static void DebugPrintOwnerTag(PinOwner tag)
 {
   uint32_t q = static_cast<uint8_t>(tag);
   if (q) {
-    DEBUG_PRINTF_P(PSTR("0x%02x (%d)"), q, q);
+    DEBUGPM_PRINTF_P(PSTR("0x%02x (%d)"), q, q);
   } else {
-    DEBUG_PRINT(F("(no owner)"));
+    DEBUGPM_PRINT(F("(no owner)"));
   }
 }
 #endif
@@ -21,12 +20,12 @@ bool PinManagerClass::deallocatePin(byte gpio, PinOwner tag)
 
   // if a non-zero ownerTag, only allow de-allocation if the owner's tag is provided
   if ((ownerTag[gpio] != PinOwner::None) && (ownerTag[gpio] != tag)) {
-    #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN DEALLOC: IO "));
-    DEBUG_PRINT(gpio);
-    DEBUG_PRINT(F(" allocated by "));
+    #ifdef WLED_DEBUG_PINMANAGER
+    DEBUGPM_PRINT(F("PIN DEALLOC: IO "));
+    DEBUGPM_PRINT(gpio);
+    DEBUGPM_PRINT(F(" allocated by "));
     DebugPrintOwnerTag(ownerTag[gpio]);
-    DEBUG_PRINT(F(", but attempted de-allocation by "));
+    DEBUGPM_PRINT(F(", but attempted de-allocation by "));
     DebugPrintOwnerTag(tag);
     #endif
     return false;
@@ -43,7 +42,7 @@ bool PinManagerClass::deallocatePin(byte gpio, PinOwner tag)
 bool PinManagerClass::deallocateMultiplePins(const uint8_t *pinArray, byte arrayElementCount, PinOwner tag)
 {
   bool shouldFail = false;
-  DEBUG_PRINTLN(F("MULTIPIN DEALLOC"));
+  DEBUGPM_PRINTLN(F("MULTIPIN DEALLOC"));
   // first verify the pins are OK and allocated by selected owner
   for (int i = 0; i < arrayElementCount; i++) {
     byte gpio = pinArray[i];
@@ -56,12 +55,12 @@ bool PinManagerClass::deallocateMultiplePins(const uint8_t *pinArray, byte array
       // if the current pin is allocated by selected owner it is possible to release it
       continue;
     }
-    #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN DEALLOC: IO "));
-    DEBUG_PRINT(gpio);
-    DEBUG_PRINT(F(" allocated by "));
+    #ifdef WLED_DEBUG_PINMANAGER
+    DEBUGPM_PRINT(F("PIN DEALLOC: IO "));
+    DEBUGPM_PRINT(gpio);
+    DEBUGPM_PRINT(F(" allocated by "));
     DebugPrintOwnerTag(ownerTag[gpio]);
-    DEBUG_PRINT(F(", but attempted de-allocation by "));
+    DEBUGPM_PRINT(F(", but attempted de-allocation by "));
     DebugPrintOwnerTag(tag);
     #endif
     shouldFail = true;
@@ -106,11 +105,11 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
       continue;
     }
     if (!isPinOk(gpio, mptArray[i].isOutput)) {
-      #ifdef WLED_DEBUG
-      DEBUG_PRINT(F("PIN ALLOC: Invalid pin attempted to be allocated: GPIO "));
-      DEBUG_PRINT(gpio);
-      DEBUG_PRINT(F(" as ")); DEBUG_PRINT(mptArray[i].isOutput ? F("output"): F("input"));
-      DEBUG_PRINTLN(F(""));
+      #ifdef WLED_DEBUG_PINMANAGER
+      DEBUGPM_PRINT(F("PIN ALLOC: Invalid pin attempted to be allocated: GPIO "));
+      DEBUGPM_PRINT(gpio);
+      DEBUGPM_PRINT(F(" as ")); DEBUGPM_PRINT(mptArray[i].isOutput ? F("output"): F("input"));
+      DEBUGPM_PRINTLN(F(""));
       #endif
       shouldFail = true;
     }
@@ -118,12 +117,12 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
       // allow multiple "allocations" of HW I2C & SPI bus pins
       continue;
     } else if (isPinAllocated(gpio)) {
-      #ifdef WLED_DEBUG
-      DEBUG_PRINT(F("PIN ALLOC: FAIL: IO "));
-      DEBUG_PRINT(gpio);
-      DEBUG_PRINT(F(" already allocated by "));
+      #ifdef WLED_DEBUG_PINMANAGER
+      DEBUGPM_PRINT(F("PIN ALLOC: FAIL: IO "));
+      DEBUGPM_PRINT(gpio);
+      DEBUGPM_PRINT(F(" already allocated by "));
       DebugPrintOwnerTag(ownerTag[gpio]);
-      DEBUG_PRINTLN(F(""));
+      DEBUGPM_PRINTLN(F(""));
       #endif
       shouldFail = true;
     }
@@ -150,12 +149,12 @@ bool PinManagerClass::allocateMultiplePins(const managed_pin_type * mptArray, by
     byte bi = gpio - 8*by;
     bitWrite(pinAlloc[by], bi, true);
     ownerTag[gpio] = tag;
-    #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin "));
-    DEBUG_PRINT(gpio);
-    DEBUG_PRINT(F(" allocated by "));
+    #ifdef WLED_DEBUG_PINMANAGER
+    DEBUGPM_PRINT(F("PIN ALLOC: Pin "));
+    DEBUGPM_PRINT(gpio);
+    DEBUGPM_PRINT(F(" allocated by "));
     DebugPrintOwnerTag(tag);
-    DEBUG_PRINTLN(F(""));
+    DEBUGPM_PRINTLN(F(""));
     #endif
   }
   return true;
@@ -165,29 +164,29 @@ bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
 {
   // HW I2C & SPI pins have to be allocated using allocateMultiplePins variant since there is always SCL/SDA pair
   if (!isPinOk(gpio, output) || (gpio >= WLED_NUM_PINS) || tag==PinOwner::HW_I2C || tag==PinOwner::HW_SPI) {
-    #ifdef WLED_DEBUG
+    #ifdef WLED_DEBUG_PINMANAGER
     if (gpio < 255) {  // 255 (-1) is the "not defined GPIO"
       if (!isPinOk(gpio, output)) {
-        DEBUG_PRINT(F("PIN ALLOC: FAIL for owner "));
+        DEBUGPM_PRINT(F("PIN ALLOC: FAIL for owner "));
         DebugPrintOwnerTag(tag);
-        DEBUG_PRINT(F(": GPIO ")); DEBUG_PRINT(gpio);
-        if (output) DEBUG_PRINTLN(F(" cannot be used for i/o on this MCU."));
-        else DEBUG_PRINTLN(F(" cannot be used as input on this MCU."));
+        DEBUGPM_PRINT(F(": GPIO ")); DEBUGPM_PRINT(gpio);
+        if (output) DEBUGPM_PRINTLN(F(" cannot be used for i/o on this MCU."));
+        else DEBUGPM_PRINTLN(F(" cannot be used as input on this MCU."));
       } else {
-        DEBUG_PRINT(F("PIN ALLOC: FAIL: GPIO ")); DEBUG_PRINT(gpio);
-        DEBUG_PRINTLN(F(" - HW I2C & SPI pins have to be allocated using allocateMultiplePins()"));
+        DEBUGPM_PRINT(F("PIN ALLOC: FAIL: GPIO ")); DEBUGPM_PRINT(gpio);
+        DEBUGPM_PRINTLN(F(" - HW I2C & SPI pins have to be allocated using allocateMultiplePins()"));
       }
     }
     #endif
     return false;
   }
   if (isPinAllocated(gpio)) {
-    #ifdef WLED_DEBUG
-    DEBUG_PRINT(F("PIN ALLOC: Pin "));
-    DEBUG_PRINT(gpio);
-    DEBUG_PRINT(F(" already allocated by "));
+    #ifdef WLED_DEBUG_PINMANAGER
+    DEBUGPM_PRINT(F("PIN ALLOC: Pin "));
+    DEBUGPM_PRINT(gpio);
+    DEBUGPM_PRINT(F(" already allocated by "));
     DebugPrintOwnerTag(ownerTag[gpio]);
-    DEBUG_PRINTLN(F(""));
+    DEBUGPM_PRINTLN(F(""));
     #endif
     return false;
   }
@@ -196,12 +195,12 @@ bool PinManagerClass::allocatePin(byte gpio, bool output, PinOwner tag)
   byte bi = gpio - 8*by;
   bitWrite(pinAlloc[by], bi, true);
   ownerTag[gpio] = tag;
-  #ifdef WLED_DEBUG
-  DEBUG_PRINT(F("PIN ALLOC: Pin "));
-  DEBUG_PRINT(gpio);
-  DEBUG_PRINT(F(" successfully allocated by "));
+  #ifdef WLED_DEBUG_PINMANAGER
+  DEBUGPM_PRINT(F("PIN ALLOC: Pin "));
+  DEBUGPM_PRINT(gpio);
+  DEBUGPM_PRINT(F(" successfully allocated by "));
   DebugPrintOwnerTag(tag);
-  DEBUG_PRINTLN(F(""));
+  DEBUGPM_PRINTLN(F(""));
   #endif
 
   return true;

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -6,6 +6,25 @@
 #include <Arduino.h>
 #include "const.h" // for USERMOD_* values
 
+#ifdef WLED_DEBUG_PINMANAGER
+  // enable additional debug output
+  #if defined(WLED_DEBUG_HOST)
+    #include "net_debug.h"
+    #define DEBUGOUT NetDebug
+  #else
+    #define DEBUGOUT Serial
+  #endif
+  #define DEBUGPM_PRINT(x) DEBUGOUT.print(x)
+  #define DEBUGPM_PRINTLN(x) DEBUGOUT.println(x)
+  #define DEBUGPM_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGPM_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+#else
+  #define DEBUGPM_PRINT(x)
+  #define DEBUGPM_PRINTLN(x)
+  #define DEBUGPM_PRINTF(x...)
+  #define DEBUGPM_PRINTF_P(x...)
+#endif
+
 typedef struct PinManagerPinType {
   int8_t pin;
   bool   isOutput;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -290,7 +290,9 @@ void WLED::loop()
       DEBUG_PRINT(F("UM time[ms]: "));     DEBUG_PRINT(avgUsermodMillis/loops); DEBUG_PRINT("/");DEBUG_PRINTLN(maxUsermodMillis);
       DEBUG_PRINT(F("Strip time[ms]: "));  DEBUG_PRINT(avgStripMillis/loops); DEBUG_PRINT("/"); DEBUG_PRINTLN(maxStripMillis);
     }
+    #ifdef WLED_DEBUG_FX
     strip.printSize();
+    #endif
     loops = 0;
     maxLoopMillis = 0;
     maxUsermodMillis = 0;
@@ -334,24 +336,23 @@ void WLED::disableWatchdog() {
 
 void WLED::setup()
 {
-  #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
+#if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detection
-  #endif
+#endif
 
-  #ifdef ARDUINO_ARCH_ESP32
+#ifdef ARDUINO_ARCH_ESP32
   pinMode(hardwareRX, INPUT_PULLDOWN); delay(1);        // suppress noise in case RX pin is floating (at low noise energy) - see issue #3128
-  #endif
+#endif
   Serial.begin(115200);
-  #if !ARDUINO_USB_CDC_ON_BOOT
+#if !ARDUINO_USB_CDC_ON_BOOT
   Serial.setTimeout(50);  // this causes troubles on new MCUs that have a "virtual" USB Serial (HWCDC)
-  #else
-  #endif
-  #if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && (defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || ARDUINO_USB_CDC_ON_BOOT)
+#endif
+#if (defined(WLED_DEBUG) || defined(WLED_DEBUG_FX) || defined(WLED_DEBUG_FS) || defined(WLED_DEBUG_BUS) || defined(WLED_DEBUG_PINMANAGER) || defined(WLED_DEBUG_USERMODS)) && defined(ARDUINO_ARCH_ESP32) && (defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || ARDUINO_USB_CDC_ON_BOOT)
   delay(2500);  // allow CDC USB serial to initialise
-  #endif
-  #if !defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && !defined(WLED_DEBUG_HOST) && ARDUINO_USB_CDC_ON_BOOT
+#endif
+#if !(defined(WLED_DEBUG) || defined(WLED_DEBUG_FX) || defined(WLED_DEBUG_FS) || defined(WLED_DEBUG_BUS) || defined(WLED_DEBUG_PINMANAGER) || defined(WLED_DEBUG_USERMODS)) && defined(ARDUINO_ARCH_ESP32) && !defined(WLED_DEBUG_HOST) && ARDUINO_USB_CDC_ON_BOOT
   Serial.setDebugOutput(false); // switch off kernel messages when using USBCDC
-  #endif
+#endif
   DEBUG_PRINTLN();
   DEBUG_PRINT(F("---WLED "));
   DEBUG_PRINT(versionString);
@@ -408,7 +409,7 @@ void WLED::setup()
   DEBUG_PRINTF_P(PSTR("TX power: %d/%d\n"), WiFi.getTxPower(), txPower);
 #endif
 
-#if defined(WLED_DEBUG) && !defined(WLED_DEBUG_HOST)
+#if (defined(WLED_DEBUG) || defined(WLED_DEBUG_FX) || defined(WLED_DEBUG_FS) || defined(WLED_DEBUG_BUS) || defined(WLED_DEBUG_PINMANAGER) || defined(WLED_DEBUG_USERMODS)) && !defined(WLED_DEBUG_HOST)
   pinManager.allocatePin(hardwareTX, true, PinOwner::DebugOut); // TX (GPIO1 on ESP32) reserved for debug output
 #endif
 #ifdef WLED_ENABLE_DMX //reserve GPIO2 as hardcoded DMX pin

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -220,6 +220,7 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
 #endif
 
 #ifndef WLED_DISABLE_INFRARED
+  #define _IR_ENABLE_DEFAULT_ false
   #include <IRremoteESP8266.h>
   #include <IRrecv.h>
   #include <IRutils.h>
@@ -845,6 +846,18 @@ WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
   #define DEBUG_PRINTLN(x)
   #define DEBUG_PRINTF(x...)
   #define DEBUG_PRINTF_P(x...)
+#endif
+
+#ifdef WLED_DEBUG_USERMODS
+  #define DEBUGUM_PRINT(x) DEBUGOUT.print(x)
+  #define DEBUGUM_PRINTLN(x) DEBUGOUT.println(x)
+  #define DEBUGUM_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGUM_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+#else
+  #define DEBUGUM_PRINT(x)
+  #define DEBUGUM_PRINTLN(x)
+  #define DEBUGUM_PRINTF(x...)
+  #define DEBUGUM_PRINTF_P(x...)
 #endif
 
 #ifdef WLED_DEBUG_FS

--- a/wled00/wled_math.cpp
+++ b/wled00/wled_math.cpp
@@ -9,6 +9,25 @@
 #include <Arduino.h> //PI constant
 
 //#define WLED_DEBUG_MATH
+#ifdef WLED_DEBUG_MATH
+  // enable additional debug output
+  #if defined(WLED_DEBUG_HOST)
+    #include "net_debug.h"
+    #define DEBUGOUT NetDebug
+  #else
+    #define DEBUGOUT Serial
+  #endif
+  #define DEBUGM_PRINT(x) DEBUGOUT.print(x)
+  #define DEBUGM_PRINTLN(x) DEBUGOUT.println(x)
+  #define DEBUGM_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGM_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+#else
+  #define DEBUGM_PRINT(x)
+  #define DEBUGM_PRINTLN(x)
+  #define DEBUGM_PRINTF(x...)
+  #define DEBUGM_PRINTF_P(x...)
+#endif
+
 
 #define modd(x, y) ((x) - (int)((x) / (y)) * (y))
 
@@ -25,17 +44,13 @@ float cos_t(float phi)
   float xx = x * x;
 
   float res = sign * (1 - ((xx) / (2)) + ((xx * xx) / (24)) - ((xx * xx * xx) / (720)) + ((xx * xx * xx * xx) / (40320)) - ((xx * xx * xx * xx * xx) / (3628800)) + ((xx * xx * xx * xx * xx * xx) / (479001600)));
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("cos: %f,%f,%f,(%f)\n",phi,res,cos(x),res-cos(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("cos: %f,%f,%f,(%f)\n"),phi,res,cos(x),res-cos(x));
   return res;
 }
 
 float sin_t(float x) {
   float res =  cos_t(HALF_PI - x);
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("sin: %f,%f,%f,(%f)\n",x,res,sin(x),res-sin(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("sin: %f,%f,%f,(%f)\n"),x,res,sin(x),res-sin(x));
   return res;
 }
 
@@ -43,9 +58,7 @@ float tan_t(float x) {
   float c = cos_t(x);
   if (c==0.0f) return 0;
   float res = sin_t(x) / c;
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("tan: %f,%f,%f,(%f)\n",x,res,tan(x),res-tan(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("tan: %f,%f,%f,(%f)\n"),x,res,tan(x),res-tan(x));
   return res;
 }
 
@@ -64,17 +77,13 @@ float acos_t(float x) {
   ret = ret * sqrt(1.0f-xabs);
   ret = ret - 2 * negate * ret;
   float res = negate * PI + ret;
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("acos: %f,%f,%f,(%f)\n",x,res,acos(x),res-acos(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("acos: %f,%f,%f,(%f)\n"),x,res,acos(x),res-acos(x));
   return res;
 }
 
 float asin_t(float x) {
   float res = HALF_PI - acos_t(x);
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("asin: %f,%f,%f,(%f)\n",x,res,asin(x),res-asin(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("asin: %f,%f,%f,(%f)\n"),x,res,asin(x),res-asin(x));
   return res;
 }
 
@@ -95,9 +104,7 @@ float atan_t(float x) {
   static const float C3 {  0.05375f  };
   static const float C4 { -0.003445f };
 
-  #ifdef WLED_DEBUG_MATH
-  float xinput = x;
-  #endif
+  [[maybe_unused]] float xinput = x;
   bool neg = (x < 0);
   x = std::abs(x);
   float res;
@@ -113,9 +120,7 @@ float atan_t(float x) {
   if (neg) {
     res = -res;
   }
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("atan: %f,%f,%f,(%f)\n",xinput,res,atan(xinput),res-atan(xinput));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("atan: %f,%f,%f,(%f)\n"),xinput,res,atan(xinput),res-atan(xinput));
   return res;
 }
 
@@ -123,17 +128,13 @@ float floor_t(float x) {
   bool neg = x < 0;
   int val = x;
   if (neg) val--;
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("floor: %f,%f,%f\n",x,(float)val,floor(x));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("floor: %f,%f,%f\n"),x,(float)val,floor(x));
   return val;
 }
 
 float fmod_t(float num, float denom) {
   int tquot = num / denom;
   float res = num - tquot * denom;
-  #ifdef WLED_DEBUG_MATH
-  Serial.printf("fmod: %f,%f,(%f)\n",res,fmod(num,denom),res-fmod(num,denom));
-  #endif
+  DEBUGM_PRINTF_P(PSTR("fmod: %f,%f,(%f)\n"),res,fmod(num,denom),res-fmod(num,denom));
   return res;
 }

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -160,7 +160,7 @@ void appendGPIOinfo() {
   oappend(SET_F(",2")); // DMX hardcoded pin
   #endif
 
-  #if defined(WLED_DEBUG) && !defined(WLED_DEBUG_HOST)
+  #if (defined(WLED_DEBUG) || defined(WLED_DEBUG_FX) || defined(WLED_DEBUG_FS) || defined(WLED_DEBUG_BUS) || defined(WLED_DEBUG_PINMANAGER) || defined(WLED_DEBUG_USERMODS)) && !defined(WLED_DEBUG_HOST)
   oappend(SET_F(",")); oappend(itoa(hardwareTX,nS,10)); // debug output (TX) pin
   #endif
 


### PR DESCRIPTION
Separate different debug components]

- generic (WLED_DEBUG)
- FX (WLED_DEBUG_FX)
- bus manager (WLED_DEBUG_BUS)
- pin manager (WLED_DEBUG_PINMANAGER)
- usermods (WLED_DEBUG_USERMODS)
- math (WLED_DEBUG_MATH)
- all (WLED_DEBUG_ALL)

In an attempt to reduce flash usage while still getting a few debug messages.

It would still be preferable to implement #3396 instead or alongside.