### PR TITLE
Fix typo in "Battery" usermod (Build Failed)

### DIFF
--- a/usermods/Battery/usermod_v2_Battery.h
+++ b/usermods/Battery/usermod_v2_Battery.h
@@ -5,7 +5,7 @@
 #include "UMBattery.h"
 #include "types/UnkownUMBattery.h"
 #include "types/LionUMBattery.h"
-#include "types/LiPoUMBattery.h"
+#include "types/LipoUMBattery.h"
 
 /*
  * Usermod by Maximilian Mewes


### PR DESCRIPTION
Building with the battery usermod currently fails:
![image](https://github.com/Aircoookie/WLED/assets/14938497/69db2892-e984-43e9-80c9-6a3a9e3f38ec)
