### PR TITLE
Fetch supported LED types from Bus

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -719,7 +719,7 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
 std::vector<LEDType> BusOnOff::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
-  ledType.id = 40;
+  ledType.id = TYPE_ONOFF;
   ledType.name = F("On/Off");
   ledType.type = "";
   result.push_back(ledType);
@@ -793,7 +793,7 @@ std::vector<LEDType> BusNetwork::getLEDTypes() {
 
   ledType.type = F("V");
 
-  ledType.id = 80;
+  ledType.id = TYPE_NET_DDP_RGB;
   ledType.name = F("DDP RGB (network)");
   result.push_back(ledType);
 
@@ -801,15 +801,15 @@ std::vector<LEDType> BusNetwork::getLEDTypes() {
   // ledType.name = F("E1.31 RGB (network)");
   // result.push_back(ledType);
 
-  ledType.id = 82;
+  ledType.id = TYPE_NET_ARTNET_RGB;
   ledType.name = F("Art-Net RGB (network)");
   result.push_back(ledType);
 
-  ledType.id = 88;
+  ledType.id = TYPE_NET_DDP_RGBW;
   ledType.name = F("DDP RGBW (network)");
   result.push_back(ledType);
 
-  ledType.id = 89;
+  ledType.id = TYPE_NET_ARTNET_RGBW;
   ledType.name = F("Art-Net RGBW (network)");
   result.push_back(ledType);
 

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -555,6 +555,43 @@ void BusPwm::deallocatePins() {
   #endif
 }
 
+std::vector<LEDType> BusPwm::getLEDTypes() {
+  std::vector<LEDType> result;
+  LEDType ledType;
+
+  ledType.id = "41";
+  ledType.name = "PWM White";
+  ledType.type = "A";
+  result.push_back(ledType);
+
+  ledType.id = "42";
+  ledType.name = "PWM CCT";
+  ledType.type = "AA";
+  result.push_back(ledType);
+
+  ledType.id = "43";
+  ledType.name = "PWM RGB";
+  ledType.type = "AAA";
+  result.push_back(ledType);
+
+  ledType.id = "44";
+  ledType.name = "PWM RGBW";
+  ledType.type = "AAAA";
+  result.push_back(ledType);
+
+  ledType.id = "45";
+  ledType.name = "PWM RGB+CCT";
+  ledType.type = "AAAAA";
+  result.push_back(ledType);
+
+  // ledType.id = "46";
+  // ledType.name = "PWM RGB+DCCT";
+  // ledType.type = "AAAAAA";
+  // result.push_back(ledType);
+
+  return result;
+}
+
 
 BusOnOff::BusOnOff(BusConfig &bc)
 : Bus(bc.type, bc.start, bc.autoWhite, 1, bc.reversed)
@@ -907,6 +944,9 @@ String BusManager::getLEDTypes() {
   String json = "[";
 
   std::vector<LEDType> busTypes;
+
+  busTypes = BusPwm::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
 
   busTypes = BusNetwork::getLEDTypes();
   types.insert(types.end(), busTypes.begin(), busTypes.end());

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -599,6 +599,17 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
   return 1;
 }
 
+std::vector<LEDType> BusOnOff::getLEDTypes() {
+  std::vector<LEDType> result;
+  LEDType ledType;
+  ledType.id = "40";
+  ledType.name = "On/Off";
+  ledType.type = "";
+  result.push_back(ledType);
+  return result;
+
+}
+
 
 BusNetwork::BusNetwork(BusConfig &bc)
 : Bus(bc.type, bc.start, bc.autoWhite, bc.count)
@@ -657,6 +668,38 @@ uint8_t BusNetwork::getPins(uint8_t* pinArray) {
     pinArray[i] = _client[i];
   }
   return 4;
+}
+
+std::vector<LEDType> BusNetwork::getLEDTypes() {
+  std::vector<LEDType> result;
+  LEDType ledType;
+
+  ledType.id = "80";
+  ledType.name = "DDP RGB (network)";
+  ledType.type = "V";
+  result.push_back(ledType);
+
+  // ledType.id = "81";
+  // ledType.name = "E1.31 RGB (network)";
+  // ledType.type = "V";
+  // result.push_back(ledType);
+
+  ledType.id = "82";
+  ledType.name = "Art-Net RGB (network)";
+  ledType.type = "V";
+  result.push_back(ledType);
+
+  ledType.id = "88";
+  ledType.name = "DDP RGBW (network)";
+  ledType.type = "V";
+  result.push_back(ledType);
+
+  ledType.id = "89";
+  ledType.name = "Art-Net RGBW (network)";
+  ledType.type = "V";
+  result.push_back(ledType);
+
+  return result;
 }
 
 void BusNetwork::cleanup() {
@@ -857,6 +900,27 @@ uint16_t BusManager::getTotalLength() {
   unsigned len = 0;
   for (unsigned i=0; i<numBusses; i++) len += busses[i]->getLength();
   return len;
+}
+
+String BusManager::getLEDTypes() {
+  std::vector<LEDType> types;
+  String json = "[";
+
+  std::vector<LEDType> busTypes;
+
+  busTypes = BusNetwork::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  busTypes = BusOnOff::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  for(int t = 0; t < types.size(); t++) {
+    LEDType type = types.at(t);
+    json += "{\"id\":"+type.id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
+  }
+
+  json += "]";
+  return json;
 }
 
 bool PolyBus::useParallelI2S = false;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -383,74 +383,74 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
 
   ledType.type = "D";
 
-  ledType.id = "22";
+  ledType.id = 22;
   ledType.name = "WS281x";
   result.push_back(ledType);
 
-  ledType.id = "30";
+  ledType.id = 30;
   ledType.name = "SK6812/WS2814 RGBW";
   result.push_back(ledType);
 
-  ledType.id = "31";
+  ledType.id = 31;
   ledType.name = "TM1814";
   result.push_back(ledType);
 
-  ledType.id = "24";
+  ledType.id = 24;
   ledType.name = "400kHz";
   result.push_back(ledType);
 
-  ledType.id = "25";
+  ledType.id = 25;
   ledType.name = "TM1829";
   result.push_back(ledType);
 
-  ledType.id = "26";
+  ledType.id = 26;
   ledType.name = "UCS8903";
   result.push_back(ledType);
 
-  ledType.id = "27";
+  ledType.id = 27;
   ledType.name = "APA106/PL9823";
   result.push_back(ledType);
 
-  ledType.id = "33";
+  ledType.id = 33;
   ledType.name = "TM1914";
   result.push_back(ledType);
 
-  ledType.id = "28";
+  ledType.id = 28;
   ledType.name = "FW1906 GRBCW";
   result.push_back(ledType);
 
-  ledType.id = "29";
+  ledType.id = 29;
   ledType.name = "UCS8904 RGBW";
   result.push_back(ledType);
 
-  ledType.id = "32";
+  ledType.id = 32;
   ledType.name = "WS2805 RGBCW";
   result.push_back(ledType);
 
-  ledType.id = "19";
+  ledType.id = 19;
   ledType.name = "WS2811 White";
   result.push_back(ledType);
 
 
   ledType.type = "2P";
 
-  ledType.id = "50";
+  ledType.id = 50;
   ledType.name = "WS2801";
   result.push_back(ledType);
 
-  ledType.id = "51";
+  ledType.id = 51;
   ledType.name = "APA102";
   result.push_back(ledType);
 
-  ledType.id = "52";
+  ledType.id = 52;
   ledType.name = "LPD8806";
   result.push_back(ledType);
 
-  ledType.id = "54";
+  ledType.id = 54;
   ledType.name = "LPD6803";
   result.push_back(ledType);
 
-  ledType.id = "53";
+  ledType.id = 53;
   ledType.name = "PP9813";
   result.push_back(ledType);
 
@@ -639,32 +639,32 @@ std::vector<LEDType> BusPwm::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
 
-  ledType.id = "41";
+  ledType.id = 41;
   ledType.name = "PWM White";
   ledType.type = "A";
   result.push_back(ledType);
 
-  ledType.id = "42";
+  ledType.id = 42;
   ledType.name = "PWM CCT";
   ledType.type = "AA";
   result.push_back(ledType);
 
-  ledType.id = "43";
+  ledType.id = 43;
   ledType.name = "PWM RGB";
   ledType.type = "AAA";
   result.push_back(ledType);
 
-  ledType.id = "44";
+  ledType.id = 44;
   ledType.name = "PWM RGBW";
   ledType.type = "AAAA";
   result.push_back(ledType);
 
-  ledType.id = "45";
+  ledType.id = 45;
   ledType.name = "PWM RGB+CCT";
   ledType.type = "AAAAA";
   result.push_back(ledType);
 
-  // ledType.id = "46";
+  // ledType.id = 46;
   // ledType.name = "PWM RGB+DCCT";
   // ledType.type = "AAAAAA";
   // result.push_back(ledType);
@@ -719,7 +719,7 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
 std::vector<LEDType> BusOnOff::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
-  ledType.id = "40";
+  ledType.id = 40;
   ledType.name = "On/Off";
   ledType.type = "";
   result.push_back(ledType);
@@ -791,29 +791,26 @@ std::vector<LEDType> BusNetwork::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
 
-  ledType.id = "80";
-  ledType.name = "DDP RGB (network)";
   ledType.type = "V";
+
+  ledType.id = 80;
+  ledType.name = "DDP RGB (network)";
   result.push_back(ledType);
 
-  // ledType.id = "81";
+  // ledType.id = 81";
   // ledType.name = "E1.31 RGB (network)";
-  // ledType.type = "V";
   // result.push_back(ledType);
 
-  ledType.id = "82";
+  ledType.id = 82;
   ledType.name = "Art-Net RGB (network)";
-  ledType.type = "V";
   result.push_back(ledType);
 
-  ledType.id = "88";
+  ledType.id = 88;
   ledType.name = "DDP RGBW (network)";
-  ledType.type = "V";
   result.push_back(ledType);
 
-  ledType.id = "89";
+  ledType.id = 89;
   ledType.name = "Art-Net RGBW (network)";
-  ledType.type = "V";
   result.push_back(ledType);
 
   return result;
@@ -886,7 +883,8 @@ String BusManager::getLEDTypes() {
 
   for(int t = 0; t < types.size(); t++) {
     LEDType type = types.at(t);
-    json += "{\"id\":"+type.id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
+    String id = String(type.id);
+    json += "{\"id\":"+id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
   }
 
   json += "]";

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -945,13 +945,13 @@ String BusManager::getLEDTypes() {
 
   std::vector<LEDType> busTypes;
 
+  busTypes = BusOnOff::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
   busTypes = BusPwm::getLEDTypes();
   types.insert(types.end(), busTypes.begin(), busTypes.end());
 
   busTypes = BusNetwork::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusOnOff::getLEDTypes();
   types.insert(types.end(), busTypes.begin(), busTypes.end());
 
   for(int t = 0; t < types.size(); t++) {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -378,28 +378,27 @@ void BusDigital::cleanup() {
 }
 
 std::vector<LEDType> BusDigital::getLEDTypes() {
-  std::vector<LEDType> types;
-  types.push_back({TYPE_WS2812_RGB, "D", PSTR("WS281x")});
-  types.push_back({TYPE_SK6812_RGBW, "D", PSTR("SK6812/WS2814 RGBW")});
-  types.push_back({TYPE_TM1814, "D", PSTR("TM1814")});
-  types.push_back({TYPE_WS2811_400KHZ, "D", PSTR("400kHz")});
-  types.push_back({TYPE_TM1829, "D", PSTR("TM1829")});
-  types.push_back({TYPE_UCS8903, "D", PSTR("UCS8903")});
-  types.push_back({TYPE_APA106, "D", PSTR("APA106/PL9823")});
-  types.push_back({TYPE_TM1914, "D", PSTR("TM1914")});
-  types.push_back({TYPE_FW1906, "D", PSTR("FW1906 GRBCW")});
-  types.push_back({TYPE_UCS8904, "D", PSTR("UCS8904 RGBW")});
-  types.push_back({TYPE_WS2805, "D", PSTR("WS2805 RGBCW")});
-  types.push_back({TYPE_WS2812_1CH_X3, "D", PSTR("WS2811 White")});
-    //{TYPE_WS2812_2CH_X3, "D", PSTR("WS2811 CCT")},
-    //{TYPE_WS2812_WWA, "D", PSTR("WS2811 WWA")},
-  types.push_back({TYPE_WS2801, "2P", PSTR("WS2801")});
-  types.push_back({TYPE_APA102, "2P", PSTR("APA102")});
-  types.push_back({TYPE_LPD8806, "2P", PSTR("LPD8806")});
-  types.push_back({TYPE_LPD6803, "2P", PSTR("LPD6803")});
-  types.push_back({TYPE_P9813, "2P", PSTR("PP9813")});
-
-  return types;
+  return {
+    {TYPE_WS2812_RGB, "D", PSTR("WS281x")},
+    {TYPE_SK6812_RGBW, "D", PSTR("SK6812/WS2814 RGBW")},
+    {TYPE_TM1814, "D", PSTR("TM1814")},
+    {TYPE_WS2811_400KHZ, "D", PSTR("400kHz")},
+    {TYPE_TM1829, "D", PSTR("TM1829")},
+    {TYPE_UCS8903, "D", PSTR("UCS8903")},
+    {TYPE_APA106, "D", PSTR("APA106/PL9823")},
+    {TYPE_TM1914, "D", PSTR("TM1914")},
+    {TYPE_FW1906, "D", PSTR("FW1906 GRBCW")},
+    {TYPE_UCS8904, "D", PSTR("UCS8904 RGBW")},
+    {TYPE_WS2805, "D", PSTR("WS2805 RGBCW")},
+    {TYPE_WS2812_1CH_X3, "D", PSTR("WS2811 White")},
+      //{TYPE_WS2812_2CH_X3, "D", PSTR("WS2811 CCT")},
+      //{TYPE_WS2812_WWA, "D", PSTR("WS2811 WWA")},
+    {TYPE_WS2801, "2P", PSTR("WS2801")},
+    {TYPE_APA102, "2P", PSTR("APA102")},
+    {TYPE_LPD8806, "2P", PSTR("LPD8806")},
+    {TYPE_LPD6803, "2P", PSTR("LPD6803")},
+    {TYPE_P9813, "2P", PSTR("PP9813")}
+  };
 }
 
 
@@ -581,14 +580,14 @@ void BusPwm::deallocatePins() {
 }
 
 std::vector<LEDType> BusPwm::getLEDTypes() {
-  std::vector<LEDType> types;
-  types.push_back({TYPE_ANALOG_1CH, "A", PSTR("PWM White")});
-  types.push_back({TYPE_ANALOG_2CH, "AA", PSTR("PWM CCT")});
-  types.push_back({TYPE_ANALOG_3CH, "AAA", PSTR("PWM RGB")});
-  types.push_back({TYPE_ANALOG_4CH, "AAAA", PSTR("PWM RGBW")});
-  types.push_back({TYPE_ANALOG_5CH, "AAAAA", PSTR("PWM RGB+CCT")});
-    //{TYPE_ANALOG_6CH, "AAAAAA", PSTR("PWM RGB+DCCT")},
-  return types;
+  return {
+    {TYPE_ANALOG_1CH, "A", PSTR("PWM White")},
+    {TYPE_ANALOG_2CH, "AA", PSTR("PWM CCT")},
+    {TYPE_ANALOG_3CH, "AAA", PSTR("PWM RGB")},
+    {TYPE_ANALOG_4CH, "AAAA", PSTR("PWM RGBW")},
+    {TYPE_ANALOG_5CH, "AAAAA", PSTR("PWM RGB+CCT")},
+      //{TYPE_ANALOG_6CH, "AAAAAA", PSTR("PWM RGB+DCCT")},
+  };
 }
 
 
@@ -636,9 +635,9 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
 }
 
 std::vector<LEDType> BusOnOff::getLEDTypes() {
-  std::vector<LEDType> types;
-  types.push_back({TYPE_ONOFF, "", PSTR("On/Off")});
-  return types;
+  return {
+    {TYPE_ONOFF, "", PSTR("On/Off")}
+  };
 }
 
 
@@ -702,12 +701,12 @@ uint8_t BusNetwork::getPins(uint8_t* pinArray) {
 }
 
 std::vector<LEDType> BusNetwork::getLEDTypes() {
-  std::vector<LEDType> types;
-  types.push_back({TYPE_NET_DDP_RGB, "V", PSTR("DDP RGB (network)")});
-  types.push_back({TYPE_NET_ARTNET_RGB, "V", PSTR("Art-Net RGB (network)")});
-  types.push_back({TYPE_NET_DDP_RGBW, "V", PSTR("DDP RGBW (network)")});
-  types.push_back({TYPE_NET_ARTNET_RGBW, "V", PSTR("Art-Net RGBW (network)")});
-  return types;
+  return {
+    {TYPE_NET_DDP_RGB, "V", PSTR("DDP RGB (network)")},
+    {TYPE_NET_ARTNET_RGB, "V", PSTR("Art-Net RGB (network)")},
+    {TYPE_NET_DDP_RGBW, "V", PSTR("DDP RGBW (network)")},
+    {TYPE_NET_ARTNET_RGBW, "V", PSTR("Art-Net RGBW (network)")}
+  };
 }
 
 void BusNetwork::cleanup() {

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -756,29 +756,23 @@ int BusManager::add(BusConfig &bc) {
   return numBusses++;
 }
 
+static String LEDTypesToJson(const std::vector<LEDType>& types) {
+  String json;
+  for(auto& type: types) {
+    String id = String(type.id);
+    json += "{i:" + id + F(",t:\"") + FPSTR(type.type) + F("\",n:\"") + FPSTR(type.name) + F("\"},");
+  }
+  return json;
+}
+
 String BusManager::getLEDTypes() {
   std::vector<LEDType> types;
   String json = "[";
 
-  std::vector<LEDType> busTypes;
-
-  busTypes = BusDigital::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusOnOff::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusPwm::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusNetwork::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  for(int t = 0; t < types.size(); t++) {
-    LEDType type = types.at(t);
-    String id = String(type.id);
-    json += "{i:" + id + F(",t:\"") + FPSTR(type.type) + F("\",n:\"") + FPSTR(type.name) + F("\"},");
-  }
+  json += LEDTypesToJson(BusDigital::getLEDTypes());
+  json += LEDTypesToJson(BusOnOff::getLEDTypes());
+  json += LEDTypesToJson(BusPwm::getLEDTypes());
+  json += LEDTypesToJson(BusNetwork::getLEDTypes());
 
   json += "]";
   return json;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -378,83 +378,28 @@ void BusDigital::cleanup() {
 }
 
 std::vector<LEDType> BusDigital::getLEDTypes() {
-  std::vector<LEDType> result;
-  LEDType ledType;
+  std::vector<LEDType> types;
+  types.push_back({TYPE_WS2812_RGB, "D", PSTR("WS281x")});
+  types.push_back({TYPE_SK6812_RGBW, "D", PSTR("SK6812/WS2814 RGBW")});
+  types.push_back({TYPE_TM1814, "D", PSTR("TM1814")});
+  types.push_back({TYPE_WS2811_400KHZ, "D", PSTR("400kHz")});
+  types.push_back({TYPE_TM1829, "D", PSTR("TM1829")});
+  types.push_back({TYPE_UCS8903, "D", PSTR("UCS8903")});
+  types.push_back({TYPE_APA106, "D", PSTR("APA106/PL9823")});
+  types.push_back({TYPE_TM1914, "D", PSTR("TM1914")});
+  types.push_back({TYPE_FW1906, "D", PSTR("FW1906 GRBCW")});
+  types.push_back({TYPE_UCS8904, "D", PSTR("UCS8904 RGBW")});
+  types.push_back({TYPE_WS2805, "D", PSTR("WS2805 RGBCW")});
+  types.push_back({TYPE_WS2812_1CH_X3, "D", PSTR("WS2811 White")});
+    //{TYPE_WS2812_2CH_X3, "D", PSTR("WS2811 CCT")},
+    //{TYPE_WS2812_WWA, "D", PSTR("WS2811 WWA")},
+  types.push_back({TYPE_WS2801, "2P", PSTR("WS2801")});
+  types.push_back({TYPE_APA102, "2P", PSTR("APA102")});
+  types.push_back({TYPE_LPD8806, "2P", PSTR("LPD8806")});
+  types.push_back({TYPE_LPD6803, "2P", PSTR("LPD6803")});
+  types.push_back({TYPE_P9813, "2P", PSTR("PP9813")});
 
-  ledType.type = F("D");
-
-  ledType.id = 22;
-  ledType.name = F("WS281x");
-  result.push_back(ledType);
-
-  ledType.id = 30;
-  ledType.name = F("SK6812/WS2814 RGBW");
-  result.push_back(ledType);
-
-  ledType.id = 31;
-  ledType.name = F("TM1814");
-  result.push_back(ledType);
-
-  ledType.id = 24;
-  ledType.name = F("400kHz");
-  result.push_back(ledType);
-
-  ledType.id = 25;
-  ledType.name = F("TM1829");
-  result.push_back(ledType);
-
-  ledType.id = 26;
-  ledType.name = F("UCS8903");
-  result.push_back(ledType);
-
-  ledType.id = 27;
-  ledType.name = F("APA106/PL9823");
-  result.push_back(ledType);
-
-  ledType.id = 33;
-  ledType.name = F("TM1914");
-  result.push_back(ledType);
-
-  ledType.id = 28;
-  ledType.name = F("FW1906 GRBCW");
-  result.push_back(ledType);
-
-  ledType.id = 29;
-  ledType.name = F("UCS8904 RGBW");
-  result.push_back(ledType);
-
-  ledType.id = 32;
-  ledType.name = F("WS2805 RGBCW");
-  result.push_back(ledType);
-
-  ledType.id = 19;
-  ledType.name = F("WS2811 White");
-  result.push_back(ledType);
-
-
-  ledType.type = F("2P");
-
-  ledType.id = 50;
-  ledType.name = F("WS2801");
-  result.push_back(ledType);
-
-  ledType.id = 51;
-  ledType.name = F("APA102");
-  result.push_back(ledType);
-
-  ledType.id = 52;
-  ledType.name = F("LPD8806");
-  result.push_back(ledType);
-
-  ledType.id = 54;
-  ledType.name = F("LPD6803");
-  result.push_back(ledType);
-
-  ledType.id = 53;
-  ledType.name = F("PP9813");
-  result.push_back(ledType);
-
-  return result;
+  return types;
 }
 
 
@@ -636,40 +581,14 @@ void BusPwm::deallocatePins() {
 }
 
 std::vector<LEDType> BusPwm::getLEDTypes() {
-  std::vector<LEDType> result;
-  LEDType ledType;
-
-  ledType.id = 41;
-  ledType.name = F("PWM White");
-  ledType.type = F("A");
-  result.push_back(ledType);
-
-  ledType.id = 42;
-  ledType.name = F("PWM CCT");
-  ledType.type = F("AA");
-  result.push_back(ledType);
-
-  ledType.id = 43;
-  ledType.name = F("PWM RGB");
-  ledType.type = F("AAA");
-  result.push_back(ledType);
-
-  ledType.id = 44;
-  ledType.name = F("PWM RGBW");
-  ledType.type = F("AAAA");
-  result.push_back(ledType);
-
-  ledType.id = 45;
-  ledType.name = F("PWM RGB+CCT");
-  ledType.type = F("AAAAA");
-  result.push_back(ledType);
-
-  // ledType.id = 46;
-  // ledType.name = F("PWM RGB+DCCT");
-  // ledType.type = F("AAAAAA");
-  // result.push_back(ledType);
-
-  return result;
+  std::vector<LEDType> types;
+  types.push_back({TYPE_ANALOG_1CH, "A", PSTR("PWM White")});
+  types.push_back({TYPE_ANALOG_2CH, "AA", PSTR("PWM CCT")});
+  types.push_back({TYPE_ANALOG_3CH, "AAA", PSTR("PWM RGB")});
+  types.push_back({TYPE_ANALOG_4CH, "AAAA", PSTR("PWM RGBW")});
+  types.push_back({TYPE_ANALOG_5CH, "AAAAA", PSTR("PWM RGB+CCT")});
+    //{TYPE_ANALOG_6CH, "AAAAAA", PSTR("PWM RGB+DCCT")},
+  return types;
 }
 
 
@@ -717,14 +636,9 @@ uint8_t BusOnOff::getPins(uint8_t* pinArray) {
 }
 
 std::vector<LEDType> BusOnOff::getLEDTypes() {
-  std::vector<LEDType> result;
-  LEDType ledType;
-  ledType.id = TYPE_ONOFF;
-  ledType.name = F("On/Off");
-  ledType.type = "";
-  result.push_back(ledType);
-  return result;
-
+  std::vector<LEDType> types;
+  types.push_back({TYPE_ONOFF, "", PSTR("On/Off")});
+  return types;
 }
 
 
@@ -788,32 +702,12 @@ uint8_t BusNetwork::getPins(uint8_t* pinArray) {
 }
 
 std::vector<LEDType> BusNetwork::getLEDTypes() {
-  std::vector<LEDType> result;
-  LEDType ledType;
-
-  ledType.type = F("V");
-
-  ledType.id = TYPE_NET_DDP_RGB;
-  ledType.name = F("DDP RGB (network)");
-  result.push_back(ledType);
-
-  // ledType.id = 81";
-  // ledType.name = F("E1.31 RGB (network)");
-  // result.push_back(ledType);
-
-  ledType.id = TYPE_NET_ARTNET_RGB;
-  ledType.name = F("Art-Net RGB (network)");
-  result.push_back(ledType);
-
-  ledType.id = TYPE_NET_DDP_RGBW;
-  ledType.name = F("DDP RGBW (network)");
-  result.push_back(ledType);
-
-  ledType.id = TYPE_NET_ARTNET_RGBW;
-  ledType.name = F("Art-Net RGBW (network)");
-  result.push_back(ledType);
-
-  return result;
+  std::vector<LEDType> types;
+  types.push_back({TYPE_NET_DDP_RGB, "V", PSTR("DDP RGB (network)")});
+  types.push_back({TYPE_NET_ARTNET_RGB, "V", PSTR("Art-Net RGB (network)")});
+  types.push_back({TYPE_NET_DDP_RGBW, "V", PSTR("DDP RGBW (network)")});
+  types.push_back({TYPE_NET_ARTNET_RGBW, "V", PSTR("Art-Net RGBW (network)")});
+  return types;
 }
 
 void BusNetwork::cleanup() {
@@ -884,7 +778,7 @@ String BusManager::getLEDTypes() {
   for(int t = 0; t < types.size(); t++) {
     LEDType type = types.at(t);
     String id = String(type.id);
-    json += "{\"i\":"+id+",\"t\":\""+type.type+"\",\"n\":\""+type.name+"\"},";
+    json += "{i:" + id + F(",t:\"") + FPSTR(type.type) + F("\",n:\"") + FPSTR(type.name) + F("\"},");
   }
 
   json += "]";

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -884,7 +884,7 @@ String BusManager::getLEDTypes() {
   for(int t = 0; t < types.size(); t++) {
     LEDType type = types.at(t);
     String id = String(type.id);
-    json += "{\"id\":"+id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
+    json += "{\"i\":"+id+",\"t\":\""+type.type+"\",\"n\":\""+type.name+"\"},";
   }
 
   json += "]";

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -381,77 +381,77 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
 
-  ledType.type = "D";
+  ledType.type = F("D");
 
   ledType.id = 22;
-  ledType.name = "WS281x";
+  ledType.name = F("WS281x");
   result.push_back(ledType);
 
   ledType.id = 30;
-  ledType.name = "SK6812/WS2814 RGBW";
+  ledType.name = F("SK6812/WS2814 RGBW");
   result.push_back(ledType);
 
   ledType.id = 31;
-  ledType.name = "TM1814";
+  ledType.name = F("TM1814");
   result.push_back(ledType);
 
   ledType.id = 24;
-  ledType.name = "400kHz";
+  ledType.name = F("400kHz");
   result.push_back(ledType);
 
   ledType.id = 25;
-  ledType.name = "TM1829";
+  ledType.name = F("TM1829");
   result.push_back(ledType);
 
   ledType.id = 26;
-  ledType.name = "UCS8903";
+  ledType.name = F("UCS8903");
   result.push_back(ledType);
 
   ledType.id = 27;
-  ledType.name = "APA106/PL9823";
+  ledType.name = F("APA106/PL9823");
   result.push_back(ledType);
 
   ledType.id = 33;
-  ledType.name = "TM1914";
+  ledType.name = F("TM1914");
   result.push_back(ledType);
 
   ledType.id = 28;
-  ledType.name = "FW1906 GRBCW";
+  ledType.name = F("FW1906 GRBCW");
   result.push_back(ledType);
 
   ledType.id = 29;
-  ledType.name = "UCS8904 RGBW";
+  ledType.name = F("UCS8904 RGBW");
   result.push_back(ledType);
 
   ledType.id = 32;
-  ledType.name = "WS2805 RGBCW";
+  ledType.name = F("WS2805 RGBCW");
   result.push_back(ledType);
 
   ledType.id = 19;
-  ledType.name = "WS2811 White";
+  ledType.name = F("WS2811 White");
   result.push_back(ledType);
 
 
-  ledType.type = "2P";
+  ledType.type = F("2P");
 
   ledType.id = 50;
-  ledType.name = "WS2801";
+  ledType.name = F("WS2801");
   result.push_back(ledType);
 
   ledType.id = 51;
-  ledType.name = "APA102";
+  ledType.name = F("APA102");
   result.push_back(ledType);
 
   ledType.id = 52;
-  ledType.name = "LPD8806";
+  ledType.name = F("LPD8806");
   result.push_back(ledType);
 
   ledType.id = 54;
-  ledType.name = "LPD6803";
+  ledType.name = F("LPD6803");
   result.push_back(ledType);
 
   ledType.id = 53;
-  ledType.name = "PP9813";
+  ledType.name = F("PP9813");
   result.push_back(ledType);
 
   return result;
@@ -640,33 +640,33 @@ std::vector<LEDType> BusPwm::getLEDTypes() {
   LEDType ledType;
 
   ledType.id = 41;
-  ledType.name = "PWM White";
-  ledType.type = "A";
+  ledType.name = F("PWM White");
+  ledType.type = F("A");
   result.push_back(ledType);
 
   ledType.id = 42;
-  ledType.name = "PWM CCT";
-  ledType.type = "AA";
+  ledType.name = F("PWM CCT");
+  ledType.type = F("AA");
   result.push_back(ledType);
 
   ledType.id = 43;
-  ledType.name = "PWM RGB";
-  ledType.type = "AAA";
+  ledType.name = F("PWM RGB");
+  ledType.type = F("AAA");
   result.push_back(ledType);
 
   ledType.id = 44;
-  ledType.name = "PWM RGBW";
-  ledType.type = "AAAA";
+  ledType.name = F("PWM RGBW");
+  ledType.type = F("AAAA");
   result.push_back(ledType);
 
   ledType.id = 45;
-  ledType.name = "PWM RGB+CCT";
-  ledType.type = "AAAAA";
+  ledType.name = F("PWM RGB+CCT");
+  ledType.type = F("AAAAA");
   result.push_back(ledType);
 
   // ledType.id = 46;
-  // ledType.name = "PWM RGB+DCCT";
-  // ledType.type = "AAAAAA";
+  // ledType.name = F("PWM RGB+DCCT");
+  // ledType.type = F("AAAAAA");
   // result.push_back(ledType);
 
   return result;
@@ -720,7 +720,7 @@ std::vector<LEDType> BusOnOff::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
   ledType.id = 40;
-  ledType.name = "On/Off";
+  ledType.name = F("On/Off");
   ledType.type = "";
   result.push_back(ledType);
   return result;
@@ -791,26 +791,26 @@ std::vector<LEDType> BusNetwork::getLEDTypes() {
   std::vector<LEDType> result;
   LEDType ledType;
 
-  ledType.type = "V";
+  ledType.type = F("V");
 
   ledType.id = 80;
-  ledType.name = "DDP RGB (network)";
+  ledType.name = F("DDP RGB (network)");
   result.push_back(ledType);
 
   // ledType.id = 81";
-  // ledType.name = "E1.31 RGB (network)";
+  // ledType.name = F("E1.31 RGB (network)");
   // result.push_back(ledType);
 
   ledType.id = 82;
-  ledType.name = "Art-Net RGB (network)";
+  ledType.name = F("Art-Net RGB (network)");
   result.push_back(ledType);
 
   ledType.id = 88;
-  ledType.name = "DDP RGBW (network)";
+  ledType.name = F("DDP RGBW (network)");
   result.push_back(ledType);
 
   ledType.id = 89;
-  ledType.name = "Art-Net RGBW (network)";
+  ledType.name = F("Art-Net RGBW (network)");
   result.push_back(ledType);
 
   return result;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -377,6 +377,86 @@ void BusDigital::cleanup() {
   pinManager.deallocatePin(_pins[0], PinOwner::BusDigital);
 }
 
+std::vector<LEDType> BusDigital::getLEDTypes() {
+  std::vector<LEDType> result;
+  LEDType ledType;
+
+  ledType.type = "D";
+
+  ledType.id = "22";
+  ledType.name = "WS281x";
+  result.push_back(ledType);
+
+  ledType.id = "30";
+  ledType.name = "SK6812/WS2814 RGBW";
+  result.push_back(ledType);
+
+  ledType.id = "31";
+  ledType.name = "TM1814";
+  result.push_back(ledType);
+
+  ledType.id = "24";
+  ledType.name = "400kHz";
+  result.push_back(ledType);
+
+  ledType.id = "25";
+  ledType.name = "TM1829";
+  result.push_back(ledType);
+
+  ledType.id = "26";
+  ledType.name = "UCS8903";
+  result.push_back(ledType);
+
+  ledType.id = "27";
+  ledType.name = "APA106/PL9823";
+  result.push_back(ledType);
+
+  ledType.id = "33";
+  ledType.name = "TM1914";
+  result.push_back(ledType);
+
+  ledType.id = "28";
+  ledType.name = "FW1906 GRBCW";
+  result.push_back(ledType);
+
+  ledType.id = "29";
+  ledType.name = "UCS8904 RGBW";
+  result.push_back(ledType);
+
+  ledType.id = "32";
+  ledType.name = "WS2805 RGBCW";
+  result.push_back(ledType);
+
+  ledType.id = "19";
+  ledType.name = "WS2811 White";
+  result.push_back(ledType);
+
+
+  ledType.type = "2P";
+
+  ledType.id = "50";
+  ledType.name = "WS2801";
+  result.push_back(ledType);
+
+  ledType.id = "51";
+  ledType.name = "APA102";
+  result.push_back(ledType);
+
+  ledType.id = "52";
+  ledType.name = "LPD8806";
+  result.push_back(ledType);
+
+  ledType.id = "54";
+  ledType.name = "LPD6803";
+  result.push_back(ledType);
+
+  ledType.id = "53";
+  ledType.name = "PP9813";
+  result.push_back(ledType);
+
+  return result;
+}
+
 
 BusPwm::BusPwm(BusConfig &bc)
 : Bus(bc.type, bc.start, bc.autoWhite, 1, bc.reversed)
@@ -786,6 +866,34 @@ int BusManager::add(BusConfig &bc) {
   return numBusses++;
 }
 
+String BusManager::getLEDTypes() {
+  std::vector<LEDType> types;
+  String json = "[";
+
+  std::vector<LEDType> busTypes;
+
+  busTypes = BusDigital::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  busTypes = BusOnOff::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  busTypes = BusPwm::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  busTypes = BusNetwork::getLEDTypes();
+  types.insert(types.end(), busTypes.begin(), busTypes.end());
+
+  for(int t = 0; t < types.size(); t++) {
+    LEDType type = types.at(t);
+    json += "{\"id\":"+type.id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
+  }
+
+  json += "]";
+  return json;
+}
+
+
 void BusManager::useParallelOutput(void) {
   _parallelOutputs = 8; // hardcoded since we use NPB I2S x8 methods
   PolyBus::setParallelI2S1Output();
@@ -939,29 +1047,6 @@ uint16_t BusManager::getTotalLength() {
   return len;
 }
 
-String BusManager::getLEDTypes() {
-  std::vector<LEDType> types;
-  String json = "[";
-
-  std::vector<LEDType> busTypes;
-
-  busTypes = BusOnOff::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusPwm::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  busTypes = BusNetwork::getLEDTypes();
-  types.insert(types.end(), busTypes.begin(), busTypes.end());
-
-  for(int t = 0; t < types.size(); t++) {
-    LEDType type = types.at(t);
-    json += "{\"id\":"+type.id+",\"type\":\""+type.type+"\",\"name\":\""+type.name+"\"},";
-  }
-
-  json += "]";
-  return json;
-}
 
 bool PolyBus::useParallelI2S = false;
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -103,6 +103,11 @@ struct ColorOrderMap {
     ColorOrderMapEntry _mappings[WLED_MAX_COLOR_ORDER_MAPPINGS];
 };
 
+struct LEDType {
+  String id;
+  String type;
+  String name;
+};
 
 //parent class of BusDigital, BusPwm, and BusNetwork
 class Bus {
@@ -320,6 +325,7 @@ class BusOnOff : public Bus {
     uint8_t  getPins(uint8_t* pinArray) override;
     void show() override;
     void cleanup() { pinManager.deallocatePin(_pin, PinOwner::BusOnOff); }
+    static std::vector<LEDType> getLEDTypes();
 
   private:
     uint8_t _pin;
@@ -340,6 +346,7 @@ class BusNetwork : public Bus {
     uint8_t  getPins(uint8_t* pinArray) override;
     void show() override;
     void cleanup();
+    static std::vector<LEDType> getLEDTypes();
 
   private:
     IPAddress _client;
@@ -386,6 +393,7 @@ class BusManager {
     //semi-duplicate of strip.getLengthTotal() (though that just returns strip._length, calculated in finalizeInit())
     static uint16_t getTotalLength();
     static uint8_t getNumBusses() { return numBusses; }
+    static String getLEDTypes();
 
     static void                 updateColorOrderMap(const ColorOrderMap &com) { memcpy(&colorOrderMap, &com, sizeof(ColorOrderMap)); }
     static const ColorOrderMap& getColorOrderMap() { return colorOrderMap; }

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -6,6 +6,7 @@
  */
 
 #include "const.h"
+#include <vector>
 
 //colors.cpp
 uint16_t approximateKelvinFromRGB(uint32_t rgb);

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -104,11 +104,11 @@ struct ColorOrderMap {
     ColorOrderMapEntry _mappings[WLED_MAX_COLOR_ORDER_MAPPINGS];
 };
 
-struct LEDType {
+typedef struct {
   uint8_t id;
-  String type;
-  String name;
-};
+  const char *type;
+  const char *name;
+} LEDType;
 
 //parent class of BusDigital, BusPwm, and BusNetwork
 class Bus {

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -263,6 +263,7 @@ class BusDigital : public Bus {
     uint16_t getMaxCurrent() override  { return _milliAmpsMax; }
     void reinit();
     void cleanup();
+    static std::vector<LEDType> getLEDTypes();
 
   private:
     uint8_t _skip;

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -104,7 +104,7 @@ struct ColorOrderMap {
 };
 
 struct LEDType {
-  String id;
+  uint8_t id;
   String type;
   String name;
 };

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -301,6 +301,7 @@ class BusPwm : public Bus {
     uint16_t getFrequency() override { return _frequency; }
     void show() override;
     void cleanup() { deallocatePins(); }
+    static std::vector<LEDType> getLEDTypes();
 
   private:
     uint8_t _pins[5];

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -81,10 +81,10 @@
 					for(var t = 0; t < config.length; t++) {
 						var type = config[t];
 						let opt = d.createElement("option");
-						opt.value = type.id;
-						opt.text = type.name;
-						if(type.type != undefined && type.type != "") {
-							opt.setAttribute('data-type', type.type);
+						opt.value = type.i;
+						opt.text = type.n;
+						if(type.t != undefined && type.t != "") {
+							opt.setAttribute('data-type', type.t);
 						}
 						sel.appendChild(opt);			
 					}

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -69,6 +69,27 @@
 			// maxCO - max Color Order mappings
 			oMaxB = maxB = b; maxD = d, maxA = a, maxV = v; maxM = m; maxPB = p; maxL = l; maxCO = o;
 		}
+		function addLEDTypes(config) {
+			console.log("addLEDTypes")
+			console.log(config);
+			var s = d.getElementsByTagName("select");
+			for (i=0; i<s.length; i++) {
+				// is the field a LED type?
+				if (s[i].name.substring(0,2)=="LT") {
+					var sel = s[i];
+					for(var t = 0; t < config.length; t++) {
+						var type = config[t];
+						let opt = d.createElement("option");
+						opt.value = type.id;
+						opt.text = type.name;
+						if(type.type != undefined && type.type != "") {
+							opt.setAttribute('data-type', type.type);
+						}
+						sel.appendChild(opt);			
+					}
+				}
+			}
+		}
 		function pinsOK() {
 			var ok = true;
 			var nList = d.Sf.querySelectorAll("#mLC input[name^=L]");
@@ -425,18 +446,12 @@ ${i+1}:
 <option value="54" data-type="2P">LPD6803</option>\
 <option value="53" data-type="2P">P9813</option>\
 <option value="19" data-type="D">WS2811 White</option>\
-<option value="40">On/Off</option>\
 <option value="41" data-type="A">PWM White</option>\
 <option value="42" data-type="AA">PWM CCT</option>\
 <option value="43" data-type="AAA">PWM RGB</option>\
 <option value="44" data-type="AAAA">PWM RGBW</option>\
 <option value="45" data-type="AAAAA">PWM RGB+CCT</option>\
 <!--option value="46" data-type="AAAAAA">PWM RGB+DCCT</option-->'}
-<option value="80" data-type="V">DDP RGB (network)</option>
-<!--option value="81" data-type="V">E1.31 RGB (network)</option-->
-<option value="82" data-type="V">Art-Net RGB (network)</option>
-<option value="88" data-type="V">DDP RGBW (network)</option>
-<option value="89" data-type="V">Art-Net RGBW (network)</option>
 </select><br>
 <div id="abl${s}">
 mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -70,6 +70,7 @@
 			oMaxB = maxB = b; maxD = d, maxA = a, maxV = v; maxM = m; maxPB = p; maxL = l; maxCO = o;
 		}
 		function addLEDTypes(config) {
+			var config = getLEDTypes();
 			console.log("addLEDTypes")
 			console.log(config);
 			var s = d.getElementsByTagName("select");
@@ -429,23 +430,7 @@
 <hr class="sml">
 ${i+1}:
 <select name="LT${s}" onchange="UI(true)">${i>=maxB && false ? '' :
-'<option value="22" data-type="D">WS281x</option>\
-<option value="30" data-type="D">SK6812/WS2814 RGBW</option>\
-<option value="31" data-type="D">TM1814</option>\
-<option value="24" data-type="D">400kHz</option>\
-<option value="25" data-type="D">TM1829</option>\
-<option value="26" data-type="D">UCS8903</option>\
-<option value="27" data-type="D">APA106/PL9823</option>\
-<option value="33" data-type="D">TM1914</option>\
-<option value="28" data-type="D">FW1906 GRBCW</option>\
-<option value="29" data-type="D">UCS8904 RGBW</option>\
-<option value="32" data-type="D">WS2805 RGBCW</option>\
-<option value="50" data-type="2P">WS2801</option>\
-<option value="51" data-type="2P">APA102</option>\
-<option value="52" data-type="2P">LPD8806</option>\
-<option value="54" data-type="2P">LPD6803</option>\
-<option value="53" data-type="2P">P9813</option>\
-<option value="19" data-type="D">WS2811 White</option>'}
+''}
 </select><br>
 <div id="abl${s}">
 mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
@@ -485,6 +470,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <div id="dig${s}a" style="display:inline"><br>Auto-calculate white channel from RGB:<br><select name="AW${s}"><option value=0>None</option><option value=1>Brighter</option><option value=2>Accurate</option><option value=3>Dual</option><option value=4>Max</option></select>&nbsp;</div>
 </div>`;
 				f.insertAdjacentHTML("beforeend", cn);
+				addLEDTypes();
 				let sel = d.getElementsByName("LT"+s)[0]
 				if (i >= maxB || digitalB >= maxD) disable(sel,'option[data-type="D"]');
 				if (i >= maxB || twopinB >= 1)     disable(sel,'option[data-type="2P"]');

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -69,28 +69,6 @@
 			// maxCO - max Color Order mappings
 			oMaxB = maxB = b; maxD = d, maxA = a, maxV = v; maxM = m; maxPB = p; maxL = l; maxCO = o;
 		}
-		function addLEDTypes(config) {
-			var config = getLEDTypes();
-			console.log("addLEDTypes")
-			console.log(config);
-			var s = d.getElementsByTagName("select");
-			for (i=0; i<s.length; i++) {
-				// is the field a LED type?
-				if (s[i].name.substring(0,2)=="LT") {
-					var sel = s[i];
-					for(var t = 0; t < config.length; t++) {
-						var type = config[t];
-						let opt = d.createElement("option");
-						opt.value = type.i;
-						opt.text = type.n;
-						if(type.t != undefined && type.t != "") {
-							opt.setAttribute('data-type', type.t);
-						}
-						sel.appendChild(opt);			
-					}
-				}
-			}
-		}
 		function pinsOK() {
 			var ok = true;
 			var nList = d.Sf.querySelectorAll("#mLC input[name^=L]");
@@ -470,7 +448,6 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <div id="dig${s}a" style="display:inline"><br>Auto-calculate white channel from RGB:<br><select name="AW${s}"><option value=0>None</option><option value=1>Brighter</option><option value=2>Accurate</option><option value=3>Dual</option><option value=4>Max</option></select>&nbsp;</div>
 </div>`;
 				f.insertAdjacentHTML("beforeend", cn);
-				addLEDTypes();
 				let sel = d.getElementsByName("LT"+s)[0]
 				if (i >= maxB || digitalB >= maxD) disable(sel,'option[data-type="D"]');
 				if (i >= maxB || twopinB >= 1)     disable(sel,'option[data-type="2P"]');

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -445,13 +445,7 @@ ${i+1}:
 <option value="52" data-type="2P">LPD8806</option>\
 <option value="54" data-type="2P">LPD6803</option>\
 <option value="53" data-type="2P">P9813</option>\
-<option value="19" data-type="D">WS2811 White</option>\
-<option value="41" data-type="A">PWM White</option>\
-<option value="42" data-type="AA">PWM CCT</option>\
-<option value="43" data-type="AAA">PWM RGB</option>\
-<option value="44" data-type="AAAA">PWM RGBW</option>\
-<option value="45" data-type="AAAAA">PWM RGB+CCT</option>\
-<!--option value="46" data-type="AAAAAA">PWM RGB+DCCT</option-->'}
+<option value="19" data-type="D">WS2811 White</option>'}
 </select><br>
 <div id="abl${s}">
 mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -482,8 +482,6 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("IT"),irEnabled);
 #endif    
     sappend('c',SET_F("MSO"),!irApplyToAllSelected);
-
-    oappend(SET_F("} function getLEDTypes(){ return ")); oappend(BusManager::getLEDTypes().c_str()); oappend(SET_F(";"));
   }
 
   if (subPage == SUBPAGE_UI)

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -433,8 +433,6 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('c',SET_F("ABL"),BusManager::ablMilliampsMax() || sumMa > 0);
     sappend('c',SET_F("PPL"),!BusManager::ablMilliampsMax() && sumMa > 0);
 
-    oappend(SET_F("addLEDTypes(")); oappend(BusManager::getLEDTypes().c_str()); oappend(SET_F(");"));
-
     oappend(SET_F("resetCOM("));
     oappend(itoa(WLED_MAX_COLOR_ORDER_MAPPINGS,nS,10));
     oappend(SET_F(");"));
@@ -484,6 +482,8 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('v',SET_F("IT"),irEnabled);
 #endif    
     sappend('c',SET_F("MSO"),!irApplyToAllSelected);
+
+    oappend(SET_F("} function getLEDTypes(){ return ")); oappend(BusManager::getLEDTypes().c_str()); oappend(SET_F(";"));
   }
 
   if (subPage == SUBPAGE_UI)

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -433,6 +433,8 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('c',SET_F("ABL"),BusManager::ablMilliampsMax() || sumMa > 0);
     sappend('c',SET_F("PPL"),!BusManager::ablMilliampsMax() && sumMa > 0);
 
+    oappend(SET_F("addLEDTypes(")); oappend(BusManager::getLEDTypes().c_str()); oappend(SET_F(");"));
+
     oappend(SET_F("resetCOM("));
     oappend(itoa(WLED_MAX_COLOR_ORDER_MAPPINGS,nS,10));
     oappend(SET_F(");"));


### PR DESCRIPTION
First of 2 different PRs to move the hard coding of all the different LED output types and their config from the current settings_led.htm to be fetched from the various Bus classes

This is so that when you add a new Bus, you do not need to edit the settings_led.htm, which is a neater workflow that also allows for easier use of compile-time flags for which output types are available

See the motivation for this change - https://github.com/Aircoookie/WLED/pull/3777