### PR TITLE
boot-up delay to fix wifi not starting in some setups

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -343,6 +343,9 @@ void WLED::setup()
   #ifdef ARDUINO_ARCH_ESP32
   pinMode(hardwareRX, INPUT_PULLDOWN); delay(1);        // suppress noise in case RX pin is floating (at low noise energy) - see issue #3128
   #endif
+  #ifdef WLED_BOOTUPDELAY
+  delay(WLED_BOOTUPDELAY); // delay to let voltage stabilize, helps with boot issues on some setups
+  #endif
   Serial.begin(115200);
   #if !ARDUINO_USB_CDC_ON_BOOT
   Serial.setTimeout(50);  // this causes troubles on new MCUs that have a "virtual" USB Serial (HWCDC)


### PR DESCRIPTION
adding a new #define option to allow users to add a delay before hardware init
use
-D WLED_BOOTUPDELAY=500
in platformio env definition to add 500ms of delay before hardware init

the idea is to let power stabilise for a little longer before hardware initialisation, this seems to help with some setups that have issues with wifi not connecting at bootup. On two of my setups that have issues with wifi at boot, this helps.
