### PR TITLE
Fix Lissajous effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5180,7 +5180,7 @@ uint16_t mode_2DLissajous(void) {            // By: Andrew Tuline
 
   return FRAMETIME;
 } // mode_2DLissajous()
-static const char _data_FX_MODE_2DLISSAJOUS[] PROGMEM = "Lissajous@X frequency,Fade rate,,,Speed;!;!;2;;c3=15";
+static const char _data_FX_MODE_2DLISSAJOUS[] PROGMEM = "Lissajous@X frequency,Fade rate,,,Speed;!;!;2;c3=15";
 
 
 ///////////////////////


### PR DESCRIPTION
The Lissajous effect's metadata string has an extra semicolon, which is wrong according to [the documentation](https://kno.wled.ge/interfaces/json-api/#effect-metadata).