### PR TITLE
Add example runArgs to devcountainer to access serial port.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,13 @@
 		}
 	},
 
+	// To give the container access to a device serial port, you can uncomment one of the following lines.
+	// You can explicitly forward the port. The docker user needs to be able to access this port, and this will only work
+	// if the device is plugged in from the start without reconnecting.
+	// "runArgs": ["--device=/dev/ttyACM0", "--group-add", "dialout"],
+	// Alternatively, you can give more comprehensive access to the host system.
+	// "runArgs": ["--privileged", "-v", "/dev/bus/usb:/dev/bus/usb", "--group-add", "dialout"],
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,10 +13,16 @@
 	},
 
 	// To give the container access to a device serial port, you can uncomment one of the following lines.
-	// You can explicitly forward the port. The docker user needs to be able to access this port, and this will only work
-	// if the device is plugged in from the start without reconnecting.
+	//
+	// You can explicitly just forward the port you want to connect to. Replace `/dev/ttyACM0` with the serial port for
+	// your device. This will only work if the device is plugged in from the start without reconnecting. Adding the
+	// `dialout` group is needed if read/write permisions for the port are limitted to the dialout user.
 	// "runArgs": ["--device=/dev/ttyACM0", "--group-add", "dialout"],
-	// Alternatively, you can give more comprehensive access to the host system.
+	//
+	// Alternatively, you can give more comprehensive access to the host system. This will expose all the host devices to
+	// the container. Adding the `dialout` group is needed if read/write permisions for the port are limitted to the
+	// dialout user. This could allow the container to modify unrelated serial devices, which would be a similar level of
+	// risk to running the build directly on the host.
 	// "runArgs": ["--privileged", "-v", "/dev/bus/usb:/dev/bus/usb", "--group-add", "dialout"],
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,8 @@
 	},
 
 	// To give the container access to a device serial port, you can uncomment one of the following lines.
+	// Note: If running on Windows, you will have to do some additional steps:
+	// https://stackoverflow.com/questions/68527888/how-can-i-use-a-usb-com-port-inside-of-a-vscode-development-container
 	//
 	// You can explicitly just forward the port you want to connect to. Replace `/dev/ttyACM0` with the serial port for
 	// your device. This will only work if the device is plugged in from the start without reconnecting. Adding the


### PR DESCRIPTION
I found this capability to be useful for being able to upload directly from the dev container.