### PR TITLE
Fix default button pin assignment for esp32

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,13 @@
 		}
 	},
 
+	// To give the container access to a device serial port, you can uncomment one of the following lines.
+	// You can explicitly forward the port. The docker user needs to be able to access this port, and this will only work
+	// if the device is plugged in from the start without reconnecting.
+	// "runArgs": ["--device=/dev/ttyACM0", "--group-add", "dialout"],
+	// Alternatively, you can give more comprehensive access to the host system.
+	// "runArgs": ["--privileged", "-v", "/dev/bus/usb:/dev/bus/usb", "--group-add", "dialout"],
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,10 +13,16 @@
 	},
 
 	// To give the container access to a device serial port, you can uncomment one of the following lines.
-	// You can explicitly forward the port. The docker user needs to be able to access this port, and this will only work
-	// if the device is plugged in from the start without reconnecting.
+	//
+	// You can explicitly just forward the port you want to connect to. Replace `/dev/ttyACM0` with the serial port for
+	// your device. This will only work if the device is plugged in from the start without reconnecting. Adding the
+	// `dialout` group is needed if read/write permisions for the port are limitted to the dialout user.
 	// "runArgs": ["--device=/dev/ttyACM0", "--group-add", "dialout"],
-	// Alternatively, you can give more comprehensive access to the host system.
+	//
+	// Alternatively, you can give more comprehensive access to the host system. This will expose all the host devices to
+	// the container. Adding the `dialout` group is needed if read/write permisions for the port are limitted to the
+	// dialout user. This could allow the container to modify unrelated serial devices, which would be a similar level of
+	// risk to running the build directly on the host.
 	// "runArgs": ["--privileged", "-v", "/dev/bus/usb:/dev/bus/usb", "--group-add", "dialout"],
 
 	// Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,8 @@
 	},
 
 	// To give the container access to a device serial port, you can uncomment one of the following lines.
+	// Note: If running on Windows, you will have to do some additional steps:
+	// https://stackoverflow.com/questions/68527888/how-can-i-use-a-usb-com-port-inside-of-a-vscode-development-container
 	//
 	// You can explicitly just forward the port you want to connect to. Replace `/dev/ttyACM0` with the serial port for
 	// your device. This will only work if the device is plugged in from the start without reconnecting. Adding the

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -4,14 +4,16 @@
 # Perform a large number of parallel requests, stress testing the web server
 # TODO: some kind of performance metrics
 
-
-TARGET=$1
+# Accepts two command line arguments:
+# - first argument - mandatory - IP or hostname of target server
+# - second argument - targert type
+HOST=$1
+declare -n TARGET_STR="${2:-JSON_LARGER}_TARGETS"
 
 CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 50"
 
 JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
-
 # Replicate one target many times
 function replicate() {
   printf "${1}?%d " {1..8}
@@ -19,15 +21,10 @@ function replicate() {
 read -a JSON_LARGE_TARGETS <<< $(replicate "json/si")
 read -a JSON_LARGER_TARGETS <<< $(replicate "json/fxdata")
 
-# TODO: argument parsing
-
-# Test static file targets
-#TARGETS=(${JSON_TARGETS[@]})
-#TARGETS=(${FILE_TARGETS[@]})
-TARGETS=(${JSON_LARGER_TARGETS[@]})
-
 # Expand target URLS to full arguments for curl
-FULL_OPTIONS=$(printf "http://${TARGET}/%s -o /dev/null " "${TARGETS[@]}")
+TARGETS=(${TARGET_STR[@]})
+#echo "${TARGETS[@]}"
+FULL_TGT_OPTIONS=$(printf "http://${HOST}/%s -o /dev/null " "${TARGETS[@]}")
+#echo ${FULL_TGT_OPTIONS}
 
-#echo ${FULL_OPTIONS}
-time curl ${CURL_ARGS} ${FULL_OPTIONS}
+time curl ${CURL_ARGS} ${FULL_TGT_OPTIONS}

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Some web server stress tests
+#
+# Perform a large number of parallel requests, stress testing the web server
+# TODO: some kind of performance metrics
+
+
+TARGET=$1
+
+JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
+FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
+CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 2"
+
+# TODO: argument parsing
+
+# Test static file targets
+TARGETS=(${JSON_TARGETS[@]})
+#TARGETS=(${FILE_TARGETS[@]})
+
+# Expand target URLS to full arguments for curl
+FULL_OPTIONS=$(printf "http://${TARGET}/%s -o /dev/null " "${TARGETS[@]}")
+
+#echo ${FULL_OPTIONS}
+time curl ${CURL_ARGS} ${FULL_OPTIONS}

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -18,8 +18,9 @@ JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
 # Replicate one target many times
 function replicate() {
-  printf "${1}?%d " {1..8}
+  printf "${1}?%d " {1..40}
 }
+read -a JSON_TINY_TARGETS <<< $(replicate "json/nodes")
 read -a JSON_SMALL_TARGETS <<< $(replicate "json/info")
 read -a JSON_LARGE_TARGETS <<< $(replicate "json/si")
 read -a JSON_LARGER_TARGETS <<< $(replicate "json/fxdata")

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -4,11 +4,13 @@
 # Perform a large number of parallel requests, stress testing the web server
 # TODO: some kind of performance metrics
 
-# Accepts two command line arguments:
+# Accepts three command line arguments:
 # - first argument - mandatory - IP or hostname of target server
-# - second argument - targert type
+# - second argument - target type (optional)
+# - third argument - xfer count (for replicated targets) (optional)
 HOST=$1
 declare -n TARGET_STR="${2:-JSON_LARGER}_TARGETS"
+REPLICATE_COUNT=$(("${3:-10}"))
 
 PARALLEL_MAX=${PARALLEL_MAX:-50}
 
@@ -18,7 +20,7 @@ JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
 # Replicate one target many times
 function replicate() {
-  printf "${1}?%d " {1..40}
+  printf "${1}?%d " $(seq 1 ${REPLICATE_COUNT})
 }
 read -a JSON_TINY_TARGETS <<< $(replicate "json/nodes")
 read -a JSON_SMALL_TARGETS <<< $(replicate "json/info")

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -15,6 +15,7 @@ REPLICATE_COUNT=$(("${3:-10}"))
 PARALLEL_MAX=${PARALLEL_MAX:-50}
 
 CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max ${PARALLEL_MAX}"
+CURL_PRINT_RESPONSE_ARGS="-w %{http_code}\n"
 
 JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -10,7 +10,9 @@
 HOST=$1
 declare -n TARGET_STR="${2:-JSON_LARGER}_TARGETS"
 
-CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 50"
+PARALLEL_MAX=${PARALLEL_MAX:-50}
+
+CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max ${PARALLEL_MAX}"
 
 JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
@@ -18,6 +20,7 @@ FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
 function replicate() {
   printf "${1}?%d " {1..8}
 }
+read -a JSON_SMALL_TARGETS <<< $(replicate "json/info")
 read -a JSON_LARGE_TARGETS <<< $(replicate "json/si")
 read -a JSON_LARGER_TARGETS <<< $(replicate "json/fxdata")
 

--- a/tools/stress_test.sh
+++ b/tools/stress_test.sh
@@ -7,15 +7,24 @@
 
 TARGET=$1
 
+CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 50"
+
 JSON_TARGETS=('json/state' 'json/info' 'json/si', 'json/palettes' 'json/fxdata' 'settings/s.js?p=2')
 FILE_TARGETS=('' 'iro.js' 'rangetouch.js' 'settings' 'settings/wifi')
-CURL_ARGS="--compressed --parallel --parallel-immediate --parallel-max 2"
+
+# Replicate one target many times
+function replicate() {
+  printf "${1}?%d " {1..8}
+}
+read -a JSON_LARGE_TARGETS <<< $(replicate "json/si")
+read -a JSON_LARGER_TARGETS <<< $(replicate "json/fxdata")
 
 # TODO: argument parsing
 
 # Test static file targets
-TARGETS=(${JSON_TARGETS[@]})
+#TARGETS=(${JSON_TARGETS[@]})
 #TARGETS=(${FILE_TARGETS[@]})
+TARGETS=(${JSON_LARGER_TARGETS[@]})
 
 # Expand target URLS to full arguments for curl
 FULL_OPTIONS=$(printf "http://${TARGET}/%s -o /dev/null " "${TARGETS[@]}")

--- a/tools/udp_test.py
+++ b/tools/udp_test.py
@@ -1,0 +1,46 @@
+import numpy as np
+import socket
+
+class WledRealtimeClient:
+    def __init__(self, wled_controller_ip, num_pixels, udp_port=21324, max_pixels_per_packet=126):
+        self.wled_controller_ip = wled_controller_ip
+        self.num_pixels = num_pixels
+        self.udp_port = udp_port
+        self.max_pixels_per_packet = max_pixels_per_packet
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._prev_pixels = np.full((3, self.num_pixels), 253, dtype=np.uint8)
+        self.pixels = np.full((3, self.num_pixels), 1, dtype=np.uint8)
+    
+    def update(self):
+        # Truncate values and cast to integer
+        self.pixels = np.clip(self.pixels, 0, 255).astype(np.uint8)
+        p = np.copy(self.pixels)
+        
+        idx = np.where(~np.all(p == self._prev_pixels, axis=0))[0]
+        num_pixels = len(idx)
+        n_packets = (num_pixels + self.max_pixels_per_packet - 1) // self.max_pixels_per_packet
+        idx_split = np.array_split(idx, n_packets)
+        
+        header = bytes([1, 2])  # WARLS protocol header
+        for packet_indices in idx_split:
+            data = bytearray(header)
+            for i in packet_indices:
+                data.extend([i, *p[:, i]])  # Index and RGB values
+            self._sock.sendto(bytes(data), (self.wled_controller_ip, self.udp_port))
+        
+        self._prev_pixels = np.copy(p)
+
+
+
+################################## LED blink test ##################################
+if __name__ == "__main__":
+    WLED_CONTROLLER_IP = "192.168.1.153"
+    NUM_PIXELS = 255 # Amount of LEDs on your strip
+    import time
+    wled = WledRealtimeClient(WLED_CONTROLLER_IP, NUM_PIXELS)
+    print('Starting LED blink test')
+    while True:
+        for i in range(NUM_PIXELS):
+            wled.pixels[1, i] = 255 if wled.pixels[1, i] == 0 else 0
+        wled.update()
+        time.sleep(.01)

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2106,14 +2106,17 @@ uint16_t mode_fire_2012() {
   for (unsigned stripNr=0; stripNr<strips; stripNr++)
     virtualStrip::runStrip(stripNr, &heat[stripNr * SEGLEN], it);
 
-  if (SEGMENT.is2D()) SEGMENT.blur(32);
+  if (SEGMENT.is2D()) {
+    uint8_t blurAmount = SEGMENT.custom2 >> 2;
+    SEGMENT.blur(blurAmount);
+  }
 
   if (it != SEGENV.step)
     SEGENV.step = it;
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_FIRE_2012[] PROGMEM = "Fire 2012@Cooling,Spark rate,,,Boost;;!;1;sx=64,ix=160,m12=1"; // bars
+static const char _data_FX_MODE_FIRE_2012[] PROGMEM = "Fire 2012@Cooling,Spark rate,,2D Blur,Boost;;!;1;sx=64,ix=160,m12=1,c2=128"; // bars
 
 
 // ColorWavesWithPalettes by Mark Kriegsman: https://gist.github.com/kriegsman/8281905786e8b2632aeb

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2098,7 +2098,7 @@ uint16_t mode_fire_2012() {
 
       // Step 4.  Map from heat cells to LED colors
       for (int j = 0; j < SEGLEN; j++) {
-        SEGMENT.setPixelColor(indexToVStrip(j, stripNr), ColorFromPalette(SEGPALETTE, MIN(heat[j],240), 255, NOBLEND));
+        SEGMENT.setPixelColor(indexToVStrip(j, stripNr), ColorFromPalette(SEGPALETTE, min(heat[j], byte(240)), 255, NOBLEND));
       }
     }
   };
@@ -2108,7 +2108,9 @@ uint16_t mode_fire_2012() {
 
   if (SEGMENT.is2D()) {
     uint8_t blurAmount = SEGMENT.custom2 >> 2;
-    SEGMENT.blur(blurAmount);
+    if (blurAmount > 48) blurAmount += blurAmount-48;             // extra blur when slider > 192  (bush burn)
+    if (blurAmount < 16) SEGMENT.blurCols(SEGMENT.custom2 >> 1);  // no side-burn when slider < 64 (faster)
+    else SEGMENT.blur(blurAmount);
   }
 
   if (it != SEGENV.step)

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7456,7 +7456,7 @@ uint16_t mode_2DGEQ(void) { // By Will Tatam. Code reduction by Ewoud Wijma.
   if ((fadeoutDelay <= 1 ) || ((SEGENV.call % fadeoutDelay) == 0)) SEGMENT.fadeToBlackBy(SEGMENT.speed);
 
   for (int x=0; x < cols; x++) {
-    uint8_t  band       = map(x, 0, cols-1, 0, NUM_BANDS - 1);
+    uint8_t  band       = map(x, 0, cols, 0, NUM_BANDS);
     if (NUM_BANDS < 16) band = map(band, 0, NUM_BANDS - 1, 0, 15); // always use full range. comment out this line to get the previous behaviour.
     band = constrain(band, 0, 15);
     unsigned colorIndex = band * 17;

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -602,6 +602,16 @@ typedef struct Segment {
     uint32_t color_from_palette(uint16_t, bool mapping, bool wrap, uint8_t mcol, uint8_t pbri = 255) const;
     uint32_t color_wheel(uint8_t pos) const;
 
+    // 2D Blur: shortcuts for bluring columns or rows only (50% faster than full 2D blur)
+    inline void blurCols(fract8 blur_amount, bool smear = false) { // blur all columns
+      const unsigned cols = virtualWidth();
+      for (unsigned k = 0; k < cols; k++) blurCol(k, blur_amount, smear); 
+    }
+    inline void blurRows(fract8 blur_amount, bool smear = false) { // blur all rows
+      const unsigned rows = virtualHeight();
+      for ( unsigned i = 0; i < rows; i++) blurRow(i, blur_amount, smear); 
+    }
+
     // 2D matrix
     uint16_t virtualWidth(void)  const; // segment width in virtual pixels (accounts for groupping and spacing)
     uint16_t virtualHeight(void) const; // segment height in virtual pixels (accounts for groupping and spacing)

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -180,7 +180,7 @@ void IRAM_ATTR Segment::setPixelColorXY(int x, int y, uint32_t col)
 
   if (reverse  ) x = virtualWidth()  - x - 1;
   if (reverse_y) y = virtualHeight() - y - 1;
-  if (transpose) { unsigned t = x; x = y; y = t; } // swap X & Y if segment transposed
+  if (transpose) { std::swap(x,y); } // swap X & Y if segment transposed
 
   x *= groupLength(); // expand to physical pixels
   y *= groupLength(); // expand to physical pixels
@@ -261,12 +261,12 @@ void Segment::setPixelColorXY(float x, float y, uint32_t col, bool aa)
 #endif
 
 // returns RGBW values of pixel
-uint32_t IRAM_ATTR Segment::getPixelColorXY(int x, int y) {
+uint32_t IRAM_ATTR Segment::getPixelColorXY(int x, int y) const {
   if (!isActive()) return 0; // not active
   if (x >= virtualWidth() || y >= virtualHeight() || x<0 || y<0) return 0;  // if pixel would fall out of virtual segment just exit
   if (reverse  ) x = virtualWidth()  - x - 1;
   if (reverse_y) y = virtualHeight() - y - 1;
-  if (transpose) { unsigned t = x; x = y; y = t; } // swap X & Y if segment transposed
+  if (transpose) { std::swap(x,y); } // swap X & Y if segment transposed
   x *= groupLength(); // expand to physical pixels
   y *= groupLength(); // expand to physical pixels
   if (x >= width() || y >= height()) return 0;

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -8,10 +8,10 @@
  * color blend function
  */
 uint32_t color_blend(uint32_t color1, uint32_t color2, uint16_t blend, bool b16) {
-  if(blend == 0)   return color1;
+  if (blend == 0) return color1;
   unsigned blendmax = b16 ? 0xFFFF : 0xFF;
-  if(blend == blendmax) return color2;
-  uint8_t shift = b16 ? 16 : 8;
+  if (blend == blendmax) return color2;
+  unsigned shift = b16 ? 16 : 8;
 
   uint32_t w1 = W(color1);
   uint32_t r1 = R(color1);
@@ -73,22 +73,19 @@ uint32_t color_fade(uint32_t c1, uint8_t amount, bool video)
   uint32_t g = G(c1);
   uint32_t b = B(c1);
   uint32_t w = W(c1);
-  if (video)  {
-    uint32_t scale = amount; // 32bit for faster calculation
-    scaledcolor = (((r * scale) >> 8) << 16) + ((r && scale) ? 1 : 0);
-    scaledcolor |= (((g * scale) >> 8) << 8) + ((g && scale) ? 1 : 0);
-    scaledcolor |= ((b * scale) >> 8) + ((b && scale) ? 1 : 0);
+  uint32_t scale = amount + !video; // 32bit for faster calculation
+  if (video) {
+    scaledcolor  = (((r * scale) >> 8) << 16) + ((r && scale) ? 1 : 0);
+    scaledcolor |= (((g * scale) >> 8) << 8)  + ((g && scale) ? 1 : 0);
+    scaledcolor |=  ((b * scale) >> 8)        + ((b && scale) ? 1 : 0);
     scaledcolor |= (((w * scale) >> 8) << 24) + ((w && scale) ? 1 : 0);
-    return scaledcolor;
-  }
-  else  {
-    uint32_t scale = 1 + amount;
-    scaledcolor = ((r * scale) >> 8) << 16;
+  } else {
+    scaledcolor  = ((r * scale) >> 8) << 16;
     scaledcolor |= ((g * scale) >> 8) << 8;
-    scaledcolor |= (b * scale) >> 8;
+    scaledcolor |=  (b * scale) >> 8;
     scaledcolor |= ((w * scale) >> 8) << 24;
-    return scaledcolor;
   }
+  return scaledcolor;
 }
 
 void setRandomColor(byte* rgb)
@@ -140,25 +137,25 @@ CRGBPalette16 generateHarmonicRandomPalette(CRGBPalette16 &basepalette)
     case 1: // triadic
       harmonics[0] = basehue + 113 + random8(15);
       harmonics[1] = basehue + 233 + random8(15);
-      harmonics[2] = basehue -7 + random8(15);
+      harmonics[2] = basehue -   7 + random8(15);
       break;
 
     case 2: // split-complementary
       harmonics[0] = basehue + 145 + random8(10);
       harmonics[1] = basehue + 205 + random8(10);
-      harmonics[2] = basehue - 5 + random8(10);
+      harmonics[2] = basehue -   5 + random8(10);
       break;
     
     case 3: // square
-      harmonics[0] = basehue + 85 + random8(10);
+      harmonics[0] = basehue +  85 + random8(10);
       harmonics[1] = basehue + 175 + random8(10);
       harmonics[2] = basehue + 265 + random8(10);
      break;
 
     case 4: // tetradic
-      harmonics[0] = basehue + 80 + random8(20);
+      harmonics[0] = basehue +  80 + random8(20);
       harmonics[1] = basehue + 170 + random8(20);
-      harmonics[2] = basehue + random8(30)-15;
+      harmonics[2] = basehue -  15 + random8(30);
      break;
   }
 
@@ -384,13 +381,13 @@ bool colorFromHexString(byte* rgb, const char* in) {
   return true;
 }
 
-float minf (float v, float w)
+static inline float minf(float v, float w)
 {
   if (w > v) return v;
   return w;
 }
 
-float maxf (float v, float w)
+static inline float maxf(float v, float w)
 {
   if (w > v) return w;
   return v;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -108,9 +108,16 @@
     #define WLED_MAX_BUTTONS 4
   #endif
 #else
-  #if WLED_MAX_BUTTONS < 2
-    #undef WLED_MAX_BUTTONS
-    #define WLED_MAX_BUTTONS 2
+  #ifdef ESP8266
+    #if WLED_MAX_BUTTONS < 2
+      #undef WLED_MAX_BUTTONS
+      #define WLED_MAX_BUTTONS 2
+    #endif
+  #else
+    #if WLED_MAX_BUTTONS < 4
+      #undef WLED_MAX_BUTTONS
+      #define WLED_MAX_BUTTONS 4
+    #endif
   #endif
 #endif
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -528,6 +528,35 @@
 #endif
 #endif
 
+#ifndef CLOCK_FREQUENCY
+  #ifdef ESP8266
+    // 1 MHz clock
+    #define CLOCK_FREQUENCY 1e6f
+  #else
+    // Use XTAL clock if possible to avoid timer frequency error when setting APB clock < 80 Mhz
+    // https://github.com/espressif/arduino-esp32/blob/2.0.2/cores/esp32/esp32-hal-ledc.c
+    #ifdef SOC_LEDC_SUPPORT_XTAL_CLOCK
+      #define CLOCK_FREQUENCY 40e6f
+    #else
+      #define CLOCK_FREQUENCY 80e6f
+    #endif
+  #endif
+#endif
+
+#ifndef MAX_BIT_WIDTH
+  #ifdef ESP8266
+    #define MAX_BIT_WIDTH 10
+  #else
+    #ifdef SOC_LEDC_TIMER_BIT_WIDE_NUM
+      // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
+      #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
+    #else
+      // ESP32: 32 bit
+      #define MAX_BIT_WIDTH 20
+    #endif
+  #endif
+#endif
+
 #define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
 
 // Size of buffer for API JSON object (increase for more segments)

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -551,7 +551,7 @@
       // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
       #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
     #else
-      // ESP32: 32 bit
+      // ESP32: 20 bit
       #define MAX_BIT_WIDTH 20
     #endif
   #endif

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -528,35 +528,6 @@
 #endif
 #endif
 
-#ifndef CLOCK_FREQUENCY
-  #ifdef ESP8266
-    // 1 MHz clock
-    #define CLOCK_FREQUENCY 1e6f
-  #else
-    // Use XTAL clock if possible to avoid timer frequency error when setting APB clock < 80 Mhz
-    // https://github.com/espressif/arduino-esp32/blob/2.0.2/cores/esp32/esp32-hal-ledc.c
-    #ifdef SOC_LEDC_SUPPORT_XTAL_CLOCK
-      #define CLOCK_FREQUENCY 40e6f
-    #else
-      #define CLOCK_FREQUENCY 80e6f
-    #endif
-  #endif
-#endif
-
-#ifndef MAX_BIT_WIDTH
-  #ifdef ESP8266
-    #define MAX_BIT_WIDTH 10
-  #else
-    #ifdef SOC_LEDC_TIMER_BIT_WIDE_NUM
-      // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
-      #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
-    #else
-      // ESP32: 20 bit
-      #define MAX_BIT_WIDTH 20
-    #endif
-  #endif
-#endif
-
 #define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
 
 // Size of buffer for API JSON object (increase for more segments)

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -34,7 +34,7 @@
 			if (d.um_p[0]==-1) d.um_p.shift();	// remove filler
 			d.Sf.SDA.max = d.Sf.SCL.max = d.Sf.MOSI.max = d.Sf.SCLK.max = d.Sf.MISO.max = d.max_gpio;
 			//for (let i of d.getElementsByTagName("input")) if (i.type === "number" && i.name.replace("[]","").substr(-3) === "pin") i.max = d.max_gpio;
-			pinDropdowns(); // convert INPUT to SELECT for pins
+			pinDD(); // convert INPUT to SELECT for pins
 		});
 		// error event
 		scE.addEventListener("error", (ev) => {
@@ -165,25 +165,25 @@
 			urows += `<input type="${t==="int"?"number":t}" name="${k}:${f}${a?"[]":""}" ${c} oninput="check(this,'${k.substr(k.indexOf(":")+1)}')"><br>`;
 		}
 	}
-	function pinDropdowns() {
+	function pinDD() {
 		for (let i of d.Sf.elements) {
 			if (i.type === "number" && (i.name.includes("pin") || ["SDA","SCL","MOSI","MISO","SCLK"].includes(i.name))) { //select all pin select elements
 				let v = parseInt(i.value);
-				let sel = addDropdown(i.name,0);
+				let sel = addDD(i.name,0);
 				for (var j = -1; j <= d.max_gpio; j++) {
 					if (d.rsvd.includes(j)) continue;
 					let foundPin = pins.indexOf(j);
 					let txt = (j === -1) ? "unused" : `${j}`;
 					if (foundPin >= 0 && j !== v) txt += ` ${pinO[foundPin]=="if"?"global":pinO[foundPin]}`; // already reserved pin
 					if (d.ro_gpio.includes(j)) txt += " (R/O)";
-					let opt = addOption(sel, txt, j);
+					let opt = addO(sel, txt, j);
 					if (j === v) opt.selected = true; // this is "our" pin
 					else if (pins.includes(j)) opt.disabled = true; // someone else's pin
 				}
 				let um = i.name.split(":")[0];
 				d.extra.forEach((o)=>{
 					if (o[um] && o[um].pin) o[um].pin.forEach((e)=>{
-						let opt = addOption(sel,e[0],e[1]);
+						let opt = addO(sel,e[0],e[1]);
 						if (e[1]==v) opt.selected = true;
 					});
 				});
@@ -219,7 +219,7 @@
 		}
 	}
 	// https://stackoverflow.com/questions/39729741/javascript-change-input-text-to-select-option
-	function addDropdown(um,fld) {
+	function addDD(um,fld) {
 		let sel = d.createElement('select');
 		if (typeof(fld) === "string") {	// parameter from usermod (field name)
 			if (fld.includes("pin")) sel.classList.add("pin");
@@ -255,7 +255,8 @@
 		}
 		return null;
 	}
-	function addOption(sel,txt,val) {
+	var addDropdown = addDD; // backwards compatibility
+	function addO(sel,txt,val) {
 		if (sel===null) return; // select object missing
 		let opt = d.createElement("option");
 		opt.value = val;
@@ -267,8 +268,9 @@
 		}
 		return opt;
 	}
+	var addOption = addO; // backwards compatibility
 	// https://stackoverflow.com/questions/26440494/insert-text-after-this-input-element-with-javascript
-	function addInfo(name,el,txt, txt2="") {
+	function addI(name,el,txt, txt2="") {
 		let obj = d.getElementsByName(name);
 		if (!obj.length) return;
 		if (typeof el === "string" && obj[0]) obj[0].placeholder = el;
@@ -277,9 +279,10 @@
 			if (txt2!="") obj[el].insertAdjacentHTML('beforebegin', txt2 + '&nbsp;');  //add pre texts
 		}
 	}
+	var addInfo = addI; // backwards compatibility
 	// add Help Button
 	function addHB(um) {
-		addInfo(um + ':help',0,`<button onclick="location.href='https://kno.wled.ge/usermods/${um}'" type="button">?</button>`);
+		addI(um + ':help',0,`<button onclick="location.href='https://kno.wled.ge/usermods/${um}'" type="button">?</button>`);
 	}
 	// load settings and insert values into DOM
 	function ldS() {

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -860,20 +860,19 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   uint16_t spcI    = selseg.spacing;
   pos = req.indexOf(F("&S=")); //segment start
   if (pos > 0) {
-    startI = getNumVal(&req, pos);
+    startI = std::abs(getNumVal(&req, pos));
   }
   pos = req.indexOf(F("S2=")); //segment stop
   if (pos > 0) {
-    stopI = getNumVal(&req, pos);
+    stopI = std::abs(getNumVal(&req, pos));
   }
   pos = req.indexOf(F("GP=")); //segment grouping
   if (pos > 0) {
-    grpI = getNumVal(&req, pos);
-    if (grpI == 0) grpI = 1;
+    grpI = std::max(1,getNumVal(&req, pos));
   }
   pos = req.indexOf(F("SP=")); //segment spacing
   if (pos > 0) {
-    spcI = getNumVal(&req, pos);
+    spcI = std::max(0,getNumVal(&req, pos));
   }
   strip.setSegment(selectedSeg, startI, stopI, grpI, spcI, UINT16_MAX, startY, stopY);
 

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -231,7 +231,9 @@ bool requestJSONBufferLock(uint8_t module)
 #endif  
   // If the lock is still held - by us, or by another task
   if (jsonBufferLock) {
-    DEBUG_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));
+    DEBUG_PRINT(F("ERROR: Locking JSON buffer ("));
+    DEBUG_PRINT(module);
+    DEBUG_PRINT(F(") failed! (still locked by "));
     DEBUG_PRINT(jsonBufferLock);
     DEBUG_PRINTLN(")");
 #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -148,7 +148,7 @@ void sappends(char stype, const char* key, char* val)
 
 bool oappendi(int i)
 {
-  char s[11];
+  char s[12]; // 32bit signed number can have 10 digits plus - sign
   sprintf(s, "%d", i);
   return oappend(s);
 }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -231,11 +231,7 @@ bool requestJSONBufferLock(uint8_t module)
 #endif  
   // If the lock is still held - by us, or by another task
   if (jsonBufferLock) {
-    DEBUG_PRINT(F("ERROR: Locking JSON buffer ("));
-    DEBUG_PRINT(module);
-    DEBUG_PRINT(F(") failed! (still locked by "));
-    DEBUG_PRINT(jsonBufferLock);
-    DEBUG_PRINTLN(")");
+    DEBUG_PRINTF_P(PSTR("ERROR: Locking JSON buffer (%d) failed! (still locked by %d)\n"), module, jsonBufferLock);
 #ifdef ARDUINO_ARCH_ESP32
     xSemaphoreGiveRecursive(jsonBufferLockMutex);
 #endif
@@ -243,9 +239,7 @@ bool requestJSONBufferLock(uint8_t module)
   }
 
   jsonBufferLock = module ? module : 255;
-  DEBUG_PRINT(F("JSON buffer locked. ("));
-  DEBUG_PRINT(jsonBufferLock);
-  DEBUG_PRINTLN(")");
+  DEBUG_PRINTF_P(PSTR("JSON buffer locked. (%d)\n"), jsonBufferLock);
   pDoc->clear();
   return true;
 }
@@ -253,9 +247,7 @@ bool requestJSONBufferLock(uint8_t module)
 
 void releaseJSONBufferLock()
 {
-  DEBUG_PRINT(F("JSON buffer released. ("));
-  DEBUG_PRINT(jsonBufferLock);
-  DEBUG_PRINTLN(")");
+  DEBUG_PRINTF_P(PSTR("JSON buffer released. (%d)\n"), jsonBufferLock);
   jsonBufferLock = 0;
 #ifdef ARDUINO_ARCH_ESP32
   xSemaphoreGiveRecursive(jsonBufferLockMutex);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -277,10 +277,14 @@ WLED_GLOBAL char otaPass[33] _INIT(DEFAULT_OTA_PASS);
 
 // Hardware and pin config
 #ifndef BTNPIN
-  #define BTNPIN 0,-1
+  #ifdef ESP8266
+    #define BTNPIN 0,-1
+  #else
+    #define BTNPIN 0,-1,-1,-1
+  #endif
 #endif
 #ifndef BTNTYPE
-  #define BTNTYPE BTN_TYPE_PUSH,BTN_TYPE_NONE
+  #define BTNTYPE BTN_TYPE_PUSH
 #endif
 #ifndef RLYPIN
 WLED_GLOBAL int8_t rlyPin _INIT(-1);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -814,6 +814,7 @@ WLED_GLOBAL int8_t spi_sclk  _INIT(SPISCLKPIN);
 // global ArduinoJson buffer
 #if defined(ARDUINO_ARCH_ESP32)
 WLED_GLOBAL JsonDocument *pDoc _INIT(nullptr);
+WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(xSemaphoreCreateRecursiveMutex());
 #else
 WLED_GLOBAL StaticJsonDocument<JSON_BUFFER_SIZE> gDoc;
 WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);


### PR DESCRIPTION
When using the BTNPIN compile flag to assign button pins in 0.15 you must define your pins and then add leading "-1" until WLED_MAX_BUTTONS, which is expected behavior (https://github.com/Aircoookie/WLED/issues/3953). However if you don't define BTNPIN at compile a similar issue occurs on ESP32 due to the default def only having 2 pins. I added an if statement to define 4 default pins in case we're compiling for ESP32. 

I also changed the BTNTYPE def. It currently has a def for 2 pins with the second being BTN_TYPE_NONE. However since BTN_TYPE_NONE = 0 any type not configured will automatically evaluate to BTN_TYPE_NONE.