### PR TITLE
2DGEQ: Getting same sized bar width on 32x32 display

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -7456,7 +7456,7 @@ uint16_t mode_2DGEQ(void) { // By Will Tatam. Code reduction by Ewoud Wijma.
   if ((fadeoutDelay <= 1 ) || ((SEGENV.call % fadeoutDelay) == 0)) SEGMENT.fadeToBlackBy(SEGMENT.speed);
 
   for (int x=0; x < cols; x++) {
-    uint8_t  band       = map(x, 0, cols-1, 0, NUM_BANDS - 1);
+    uint8_t  band       = map(x, 0, cols, 0, NUM_BANDS);
     if (NUM_BANDS < 16) band = map(band, 0, NUM_BANDS - 1, 0, 15); // always use full range. comment out this line to get the previous behaviour.
     band = constrain(band, 0, 15);
     unsigned colorIndex = band * 17;


### PR DESCRIPTION
before a x=32 (n times of 16) had not equal sized bars, but first was a single pixel and later a bar had 3 pixel width. This solves it to have always 2 pixel sized bars.

obsoletes #3752