### PR TITLE
Add a parameter for blur amount in the Fire 2012 effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2106,14 +2106,17 @@ uint16_t mode_fire_2012() {
   for (unsigned stripNr=0; stripNr<strips; stripNr++)
     virtualStrip::runStrip(stripNr, &heat[stripNr * SEGLEN], it);
 
-  if (SEGMENT.is2D()) SEGMENT.blur(32);
+  if (SEGMENT.is2D()) {
+    uint8_t blurAmount = SEGMENT.custom2 >> 2;
+    SEGMENT.blur(blurAmount);
+  }
 
   if (it != SEGENV.step)
     SEGENV.step = it;
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_FIRE_2012[] PROGMEM = "Fire 2012@Cooling,Spark rate,,,Boost;;!;1;sx=64,ix=160,m12=1"; // bars
+static const char _data_FX_MODE_FIRE_2012[] PROGMEM = "Fire 2012@Cooling,Spark rate,,2D Blur,Boost;;!;1;sx=64,ix=160,m12=1,c2=128"; // bars
 
 
 // ColorWavesWithPalettes by Mark Kriegsman: https://gist.github.com/kriegsman/8281905786e8b2632aeb


### PR DESCRIPTION
With a larger 2D matrix, blur becomes very expensive in terms of performance. On ESP32 with a 32x24 matrix, the Fire 2012 effect with blur runs at 13 FPS, and without blur at about 30 FPS. Sometimes more, but I couldn't figure out why.

This PR adds a user setting for the blur amount so that you can set it to 0 or any other value for aesthetic reasons.