### PR TITLE
Fix incorrect PWM bit depth on Esp32 with XTAL clock

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -521,35 +521,6 @@
 #endif
 #endif
 
-#ifndef CLOCK_FREQUENCY
-  #ifdef ESP8266
-    // 1 MHz clock
-    #define CLOCK_FREQUENCY 1e6f
-  #else
-    // Use XTAL clock if possible to avoid timer frequency error when setting APB clock < 80 Mhz
-    // https://github.com/espressif/arduino-esp32/blob/2.0.2/cores/esp32/esp32-hal-ledc.c
-    #ifdef SOC_LEDC_SUPPORT_XTAL_CLOCK
-      #define CLOCK_FREQUENCY 40e6f
-    #else
-      #define CLOCK_FREQUENCY 80e6f
-    #endif
-  #endif
-#endif
-
-#ifndef MAX_BIT_WIDTH
-  #ifdef ESP8266
-    #define MAX_BIT_WIDTH 10
-  #else
-    #ifdef SOC_LEDC_TIMER_BIT_WIDE_NUM
-      // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
-      #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
-    #else
-      // ESP32: 20 bit
-      #define MAX_BIT_WIDTH 20
-    #endif
-  #endif
-#endif
-
 #define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
 
 // Size of buffer for API JSON object (increase for more segments)

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -521,6 +521,35 @@
 #endif
 #endif
 
+#ifndef CLOCK_FREQUENCY
+  #ifdef ESP8266
+    // 1 MHz clock
+    #define CLOCK_FREQUENCY 1e6f
+  #else
+    // Use XTAL clock if possible to avoid timer frequency error when setting APB clock < 80 Mhz
+    // https://github.com/espressif/arduino-esp32/blob/2.0.2/cores/esp32/esp32-hal-ledc.c
+    #ifdef SOC_LEDC_SUPPORT_XTAL_CLOCK
+      #define CLOCK_FREQUENCY 40e6f
+    #else
+      #define CLOCK_FREQUENCY 80e6f
+    #endif
+  #endif
+#endif
+
+#ifndef MAX_BIT_WIDTH
+  #ifdef ESP8266
+    #define MAX_BIT_WIDTH 10
+  #else
+    #ifdef SOC_LEDC_TIMER_BIT_WIDE_NUM
+      // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
+      #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
+    #else
+      // ESP32: 32 bit
+      #define MAX_BIT_WIDTH 20
+    #endif
+  #endif
+#endif
+
 #define TOUCH_THRESHOLD 32 // limit to recognize a touch, higher value means more sensitive
 
 // Size of buffer for API JSON object (increase for more segments)

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -544,7 +544,7 @@
       // C6/H2/P4: 20 bit, S2/S3/C2/C3: 14 bit
       #define MAX_BIT_WIDTH SOC_LEDC_TIMER_BIT_WIDE_NUM 
     #else
-      // ESP32: 32 bit
+      // ESP32: 20 bit
       #define MAX_BIT_WIDTH 20
     #endif
   #endif


### PR DESCRIPTION
Fixes incorrect bit depth for ESP32 with XTAL support (new "wave" of ESP32 models like C3).

Currently 0.15 has hardcoded bit depths for ESP8266 and ESP32. Since Arduino 2.0.2, ESP32 models that support external XTAL clock  (C3 for example) are [set to use it instead of the built in APB clock](https://github.com/espressif/arduino-esp32/blob/2.0.2/cores/esp32/esp32-hal-ledc.c#L25). XTAL runs at half the frequency (40 MHz rather than 80 MHz) and so the pin fails to assign correctly due to incorrect bit depth.
My approach was to calculate the correct bit depth on the fly based on what clock the microprocessor supports (including ESP8266). I have tested the code on a regular ESP32, a C3 and an ESP8266 on all currently possible clock settings and everything looks in line with the previous values.

A few notes:
1. I tested performance and it's less than 0.5 ms extra in the worst case I've seen.
2. There's no frequency validation. This can technically cause issues (for example the new ESP32 boards have a smaller range of bit depths compared to the original) but since currently the frequencies are hardcoded and not user configurable I don't think it's a problem.
3. Even before this PR, ESP8266 was configurable with frequencies above 1000 Hz. In my testing (and it's commonly agreed) 8266 cannot reliably produce frequencies above 1000 Hz, causing flickering and poor dimming performance. I think it's worth considering removing these options.