### PR TITLE
Add Test mode usermod to load pattern on multi-button hold

### DIFF
--- a/usermods/Test_Mode/README.md
+++ b/usermods/Test_Mode/README.md
@@ -1,0 +1,26 @@
+# Usermod Test Mode
+This usermod allows you to load a specific test pattern (brightness, color, effect, palette) by holding down a designated number of buttons.
+
+It was developed for quality control on pre-assembled QuinLED boards with PWM outputs to control "dumb" LEDs.   
+To test a digital output you can simply connect it to an addressable LED, which will either work properly or not.  
+This doesn't work with analog outputs, because the MOSFET can fail "closed" and thus still light up the LED. The whole dimming range must be tested.
+
+## Installation
+
+Add -D USERMOD_TEST_MODE to your build_flags and compile WLED.
+
+If you want, you can modify the usermod behavior with these additional flags:
+
+| Flag                    | Default Value | Description                                                                                                  |
+|-------------------------|---------------|--------------------------------------------------------------------------------------------------------------|
+| -D TEST_MODE_BUTTONS    | 2             | Number of buttons to hold down simultaneously to load the test pattern.                                      |
+| -D TEST_MODE_BRIGHTNESS | 60            | Brightness to set the LEDs to. Accepted values are 0-255.                                                    |
+| -D TEST_MODE_COLOR      | ULTRAWHITE    | Color to set the LEDs to. Accepted values are WLED color macro names or other types WLED accepts (e.g. hex). |
+| -D TEST_MODE_EFFECT     | FX_MODE_FADE  | Effect to set the LEDs to. Accepted values are WLED effect macro names or numbers.                           |
+| -D TEST_MODE_PALETTE    | 0             | Palette to set the LEDs to. Accepted values are WLED palette numbers.                                        |
+
+## Usage
+The usermod is enabled by default. To use it, first configure a number of buttons in WLED that's equal or higher than what TEST_MODE_BUTTONS has been set to (by default, 2). Once the buttons are configured, simply hold down that number of buttons and the test mode pattern will load. Once that happens, the usermod will automatically disable itself. However, it will keep handling button presses for the current boot until WLED has been restarted. If you want to load the test pattern again, you can manually re-enable the usermod in the "Usermods" settings page, but it will keep disabling itself after each use. This was done so that the boards can be tested on the assembly line once without risking that the final user accidentally triggers the test pattern during normal use.
+
+## Authors
+- PaoloTK [@PaoloTK](https://github.com/PaoloTK)

--- a/usermods/Test_Mode/test_mode.h
+++ b/usermods/Test_Mode/test_mode.h
@@ -2,20 +2,24 @@
 
 #include "wled.h"
 
-#ifndef TEST_BUTTONS_NUMBER
-  #define TEST_BUTTONS_NUMBER 0
+#ifndef TEST_MODE_BUTTONS
+  #define TEST_MODE_BUTTONS 2
 #endif
 
-#ifndef TEST_BRIGHTNESS
-  #define TEST_BRIGHTNESS 60
+#ifndef TEST_MODE_BRIGHTNESS
+  #define TEST_MODE_BRIGHTNESS 60
 #endif
 
-#ifndef TEST_COLOR
-  #define TEST_COLOR ULTRAWHITE
+#ifndef TEST_MODE_COLOR
+  #define TEST_MODE_COLOR ULTRAWHITE
 #endif
 
-#ifndef TEST_EFFECT
-  #define TEST_EFFECT FX_MODE_FADE
+#ifndef TEST_MODE_EFFECT
+  #define TEST_MODE_EFFECT FX_MODE_FADE
+#endif
+
+#ifndef TEST_MODE_PALETTE
+  #define TEST_MODE_PALETTE 0
 #endif
 
 class TestModeUsermod : public Usermod {
@@ -45,7 +49,7 @@ class TestModeUsermod : public Usermod {
 };
 
 void TestModeUsermod::loop() {
-  if (!enabled || TEST_BUTTONS_NUMBER < 1) { return; }
+  if (!enabled || TEST_MODE_BUTTONS < 1) { return; }
 
   if (millis() - lastTime > 1000) {
     lastTime = millis();
@@ -55,16 +59,18 @@ void TestModeUsermod::loop() {
         heldButtons += 1;
       }
     }
-    if (heldButtons >= TEST_BUTTONS_NUMBER) {
+    if (heldButtons >= TEST_MODE_BUTTONS) {
       DEBUG_PRINTLN(F("Test Mode activated"));
       testModeActivated = true;
 
-      bri = TEST_BRIGHTNESS;
+      bri = TEST_MODE_BRIGHTNESS;
       Segment& seg = strip.getMainSegment();
-      seg.setMode(TEST_EFFECT, false);
-      seg.setColor(0, TEST_COLOR);
+      seg.setMode(TEST_MODE_EFFECT, false);
+      seg.setColor(0, TEST_MODE_COLOR);
+      seg.setPalette(TEST_MODE_PALETTE);
       stateUpdated(CALL_MODE_DIRECT_CHANGE);
 
+      // Disable usermod so next boot is clean
       enable(false);
       serializeConfig();
     }
@@ -129,4 +135,4 @@ uint16_t TestModeUsermod::getId() { return USERMOD_ID_TEST_MODE; }
 
 // add more strings here to reduce flash memory usage
 const char TestModeUsermod::_name[]    PROGMEM = "Test Mode";
-const char TestModeUsermod::_enabled[] PROGMEM = "enabled";
+const char TestModeUsermod::_enabled[] PROGMEM = "Enabled";

--- a/usermods/Test_Mode/test_mode.h
+++ b/usermods/Test_Mode/test_mode.h
@@ -2,16 +2,28 @@
 
 #include "wled.h"
 
-// TODO: check if pin_manager.h needs this usermod 
-// implementation of both buttons pressed:
-// https://discord.com/channels/473448917040758787/1144310280751435817/1160697530783387688
+#ifndef TEST_BUTTONS_NUMBER
+  #define TEST_BUTTONS_NUMBER 0
+#endif
+
+#ifndef TEST_BRIGHTNESS
+  #define TEST_BRIGHTNESS 60
+#endif
+
+#ifndef TEST_EFFECT
+  #define TEST_EFFECT FX_MODE_FADE
+#endif
+
+// TODO: Move away from inlining all functions
 
 class TestModeUsermod : public Usermod {
   private:
     bool enabled = true;
     bool initDone = false;
-    bool firstButton = false;
-    bool secondButton = false;
+    unsigned long lastTime = 0;
+    int8_t testButtons[WLED_MAX_BUTTONS];
+    int8_t heldButtons = 0;
+    bool active = false;
 
   public:
     // strings to reduce flash memory usage (used more than twice)
@@ -25,24 +37,67 @@ class TestModeUsermod : public Usermod {
 
     void loop() {
       if (!enabled) { return; }
+
+      if (millis() - lastTime > 1000) {
+        lastTime = millis();
+        heldButtons = 0;
+        for (unsigned i=0; i<WLED_MAX_BUTTONS; i++) {
+          if (testButtons[i] == 1) {
+            heldButtons += 1;
+          }
+        }
+        if (TEST_BUTTONS_NUMBER > 0 && heldButtons >= TEST_BUTTONS_NUMBER) {
+          DEBUG_PRINT(F("Test Mode activated"));
+          active = true;
+          bri = TEST_BRIGHTNESS;
+          stateUpdated(CALL_MODE_DIRECT_CHANGE);
+          effectCurrent = TEST_EFFECT;
+          colorUpdated(CALL_MODE_DIRECT_CHANGE);
+          enable(false);
+          serializeConfig();
+        }
+      
+      }
+
       return;
     }
 
     bool handleButton(uint8_t b) override {
       yield();
-      // ignore certain button types as they may have other consequences
-      if (!enabled
-       || buttonType[b] == BTN_TYPE_NONE
-       || buttonType[b] == BTN_TYPE_RESERVED
-       || buttonType[b] == BTN_TYPE_PIR_SENSOR
-       || buttonType[b] == BTN_TYPE_ANALOG
-       || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {
-        return false;
+      // once test mode has been activated keep handling buttons for this boot
+      if (!active) {
+        if (!enabled
+        // ignore certain button types as they may have other consequences
+        || buttonType[b] == BTN_TYPE_NONE
+        || buttonType[b] == BTN_TYPE_RESERVED
+        || buttonType[b] == BTN_TYPE_PIR_SENSOR
+        || buttonType[b] == BTN_TYPE_ANALOG
+        || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {
+          return false;
+        }
       }
 
       bool handled = false;
       // do your button handling here
-      Serial.println("Button has been pressed: " + String(b));
+      unsigned long now = millis();
+
+      if (isButtonPressed(b)) { //pressed
+        if (!buttonPressedBefore[b]) buttonPressedTime[b] = now;
+        buttonPressedBefore[b] = true;
+
+        if (now - buttonPressedTime[b] > 600) {
+            testButtons[b] = 1;
+            // DEBUG_PRINT(F("Button held: ")); DEBUG_PRINTLN(b);
+        }
+        buttonLongPressed[b] = true;
+      }
+      else if (!isButtonPressed(b) && buttonPressedBefore[b]) {
+        testButtons[b] = 0;
+        // DEBUG_PRINT(F("Button released: ")); DEBUG_PRINTLN(b);
+        buttonPressedBefore[b] = false;
+        buttonLongPressed[b] = false;
+      }
+
       handled = true;
       return handled;
     }

--- a/usermods/Test_Mode/test_mode.h
+++ b/usermods/Test_Mode/test_mode.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "wled.h"
+
+// TODO: check if pin_manager.h needs this usermod 
+// implementation of both buttons pressed:
+// https://discord.com/channels/473448917040758787/1144310280751435817/1160697530783387688
+
+class TestModeUsermod : public Usermod {
+  private:
+    bool enabled = true;
+    bool initDone = false;
+    bool firstButton = false;
+    bool secondButton = false;
+
+  public:
+    // strings to reduce flash memory usage (used more than twice)
+    static const char _name[];
+    static const char _enabled[];
+    inline void enable(bool enable) { enabled = enable; }
+    inline bool isEnabled() { return enabled; }
+    void setup() {
+      initDone = true;
+    }
+
+    void loop() {
+      if (!enabled) { return; }
+      return;
+    }
+
+    bool handleButton(uint8_t b) override {
+      yield();
+      // ignore certain button types as they may have other consequences
+      if (!enabled
+       || buttonType[b] == BTN_TYPE_NONE
+       || buttonType[b] == BTN_TYPE_RESERVED
+       || buttonType[b] == BTN_TYPE_PIR_SENSOR
+       || buttonType[b] == BTN_TYPE_ANALOG
+       || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {
+        return false;
+      }
+
+      bool handled = false;
+      // do your button handling here
+      Serial.println("Button has been pressed: " + String(b));
+      handled = true;
+      return handled;
+    }
+
+    void addToConfig(JsonObject& root) override
+    {
+      JsonObject top = root.createNestedObject(FPSTR(_name));
+      top[FPSTR(_enabled)] = enabled;
+    }
+
+    bool readFromConfig(JsonObject& root) override
+    {
+      JsonObject top = root[FPSTR(_name)];
+
+      bool configComplete = !top.isNull();
+
+      configComplete &= getJsonValue(top[FPSTR(_enabled)], enabled);
+
+      return configComplete;
+    }
+
+    uint16_t getId() override
+    {
+      return USERMOD_ID_TEST_MODE;
+    }
+};
+
+// add more strings here to reduce flash memory usage
+const char TestModeUsermod::_name[]    PROGMEM = "Test Mode";
+const char TestModeUsermod::_enabled[] PROGMEM = "enabled";

--- a/usermods/Test_Mode/test_mode.h
+++ b/usermods/Test_Mode/test_mode.h
@@ -14,8 +14,6 @@
   #define TEST_EFFECT FX_MODE_FADE
 #endif
 
-// TODO: Move away from inlining all functions
-
 class TestModeUsermod : public Usermod {
   private:
     bool enabled = true;
@@ -23,107 +21,108 @@ class TestModeUsermod : public Usermod {
     unsigned long lastTime = 0;
     int8_t testButtons[WLED_MAX_BUTTONS];
     int8_t heldButtons = 0;
-    bool active = false;
+    bool testModeActivated = false;
 
   public:
     // strings to reduce flash memory usage (used more than twice)
     static const char _name[];
     static const char _enabled[];
+
     inline void enable(bool enable) { enabled = enable; }
     inline bool isEnabled() { return enabled; }
-    void setup() {
-      initDone = true;
-    }
 
-    void loop() {
-      if (!enabled) { return; }
+    void setup() { initDone = true; }
+    void loop();
 
-      if (millis() - lastTime > 1000) {
-        lastTime = millis();
-        heldButtons = 0;
-        for (unsigned i=0; i<WLED_MAX_BUTTONS; i++) {
-          if (testButtons[i] == 1) {
-            heldButtons += 1;
-          }
-        }
-        if (TEST_BUTTONS_NUMBER > 0 && heldButtons >= TEST_BUTTONS_NUMBER) {
-          DEBUG_PRINT(F("Test Mode activated"));
-          active = true;
-          bri = TEST_BRIGHTNESS;
-          stateUpdated(CALL_MODE_DIRECT_CHANGE);
-          effectCurrent = TEST_EFFECT;
-          colorUpdated(CALL_MODE_DIRECT_CHANGE);
-          enable(false);
-          serializeConfig();
-        }
-      
-      }
-
-      return;
-    }
-
-    bool handleButton(uint8_t b) override {
-      yield();
-      // once test mode has been activated keep handling buttons for this boot
-      if (!active) {
-        if (!enabled
-        // ignore certain button types as they may have other consequences
-        || buttonType[b] == BTN_TYPE_NONE
-        || buttonType[b] == BTN_TYPE_RESERVED
-        || buttonType[b] == BTN_TYPE_PIR_SENSOR
-        || buttonType[b] == BTN_TYPE_ANALOG
-        || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {
-          return false;
-        }
-      }
-
-      bool handled = false;
-      // do your button handling here
-      unsigned long now = millis();
-
-      if (isButtonPressed(b)) { //pressed
-        if (!buttonPressedBefore[b]) buttonPressedTime[b] = now;
-        buttonPressedBefore[b] = true;
-
-        if (now - buttonPressedTime[b] > 600) {
-            testButtons[b] = 1;
-            // DEBUG_PRINT(F("Button held: ")); DEBUG_PRINTLN(b);
-        }
-        buttonLongPressed[b] = true;
-      }
-      else if (!isButtonPressed(b) && buttonPressedBefore[b]) {
-        testButtons[b] = 0;
-        // DEBUG_PRINT(F("Button released: ")); DEBUG_PRINTLN(b);
-        buttonPressedBefore[b] = false;
-        buttonLongPressed[b] = false;
-      }
-
-      handled = true;
-      return handled;
-    }
-
-    void addToConfig(JsonObject& root) override
-    {
-      JsonObject top = root.createNestedObject(FPSTR(_name));
-      top[FPSTR(_enabled)] = enabled;
-    }
-
-    bool readFromConfig(JsonObject& root) override
-    {
-      JsonObject top = root[FPSTR(_name)];
-
-      bool configComplete = !top.isNull();
-
-      configComplete &= getJsonValue(top[FPSTR(_enabled)], enabled);
-
-      return configComplete;
-    }
-
-    uint16_t getId() override
-    {
-      return USERMOD_ID_TEST_MODE;
-    }
+    bool handleButton(uint8_t b) override;
+    void addToConfig(JsonObject& root) override;
+    bool readFromConfig(JsonObject& root) override;
+    uint16_t getId() override;
 };
+
+void TestModeUsermod::loop() {
+  if (!enabled || TEST_BUTTONS_NUMBER < 1) { return; }
+
+  if (millis() - lastTime > 1000) {
+    lastTime = millis();
+    heldButtons = 0;
+    for (unsigned i=0; i<WLED_MAX_BUTTONS; i++) {
+      if (testButtons[i] == 1) {
+        heldButtons += 1;
+      }
+    }
+    if (heldButtons >= TEST_BUTTONS_NUMBER) {
+      DEBUG_PRINT(F("Test Mode activated"));
+      testModeActivated = true;
+
+      bri = TEST_BRIGHTNESS;
+      stateUpdated(CALL_MODE_DIRECT_CHANGE);
+      effectCurrent = TEST_EFFECT;
+      colorUpdated(CALL_MODE_FX_CHANGED);
+      strip.setColor(0, ULTRAWHITE);
+      colorUpdated(CALL_MODE_DIRECT_CHANGE);
+
+      enable(false);
+      serializeConfig();
+    }
+  }
+}
+
+bool TestModeUsermod::handleButton(uint8_t b) {
+  yield();
+  // once test mode has been activated keep handling buttons for this boot
+  if (!testModeActivated) {
+    if (!enabled
+    // ignore certain button types as they may have other consequences
+    || buttonType[b] == BTN_TYPE_NONE
+    || buttonType[b] == BTN_TYPE_RESERVED
+    || buttonType[b] == BTN_TYPE_PIR_SENSOR
+    || buttonType[b] == BTN_TYPE_ANALOG
+    || buttonType[b] == BTN_TYPE_ANALOG_INVERTED) {
+      return false;
+    }
+  }
+
+  bool handled = false;
+  // do your button handling here
+  unsigned long now = millis();
+
+  if (isButtonPressed(b)) { //pressed
+    if (!buttonPressedBefore[b]) buttonPressedTime[b] = now;
+    buttonPressedBefore[b] = true;
+    // Button held
+    if (now - buttonPressedTime[b] > 600) {
+        testButtons[b] = 1;
+    }
+    buttonLongPressed[b] = true;
+  }
+  // Button released
+  else if (!isButtonPressed(b) && buttonPressedBefore[b]) {
+    testButtons[b] = 0;
+    buttonPressedBefore[b] = false;
+    buttonLongPressed[b] = false;
+  }
+
+  handled = true;
+  return handled;
+}
+
+void TestModeUsermod::addToConfig(JsonObject& root) {
+  JsonObject top = root.createNestedObject(FPSTR(_name));
+  top[FPSTR(_enabled)] = enabled;
+}
+
+bool TestModeUsermod::readFromConfig(JsonObject& root) {
+  JsonObject top = root[FPSTR(_name)];
+
+  bool configComplete = !top.isNull();
+
+  configComplete &= getJsonValue(top[FPSTR(_enabled)], enabled);
+
+  return configComplete;
+}
+
+uint16_t TestModeUsermod::getId() { return USERMOD_ID_TEST_MODE; }
 
 // add more strings here to reduce flash memory usage
 const char TestModeUsermod::_name[]    PROGMEM = "Test Mode";

--- a/usermods/Test_Mode/test_mode.h
+++ b/usermods/Test_Mode/test_mode.h
@@ -10,6 +10,10 @@
   #define TEST_BRIGHTNESS 60
 #endif
 
+#ifndef TEST_COLOR
+  #define TEST_COLOR ULTRAWHITE
+#endif
+
 #ifndef TEST_EFFECT
   #define TEST_EFFECT FX_MODE_FADE
 #endif
@@ -52,15 +56,14 @@ void TestModeUsermod::loop() {
       }
     }
     if (heldButtons >= TEST_BUTTONS_NUMBER) {
-      DEBUG_PRINT(F("Test Mode activated"));
+      DEBUG_PRINTLN(F("Test Mode activated"));
       testModeActivated = true;
 
       bri = TEST_BRIGHTNESS;
+      Segment& seg = strip.getMainSegment();
+      seg.setMode(TEST_EFFECT, false);
+      seg.setColor(0, TEST_COLOR);
       stateUpdated(CALL_MODE_DIRECT_CHANGE);
-      effectCurrent = TEST_EFFECT;
-      colorUpdated(CALL_MODE_FX_CHANGED);
-      strip.setColor(0, ULTRAWHITE);
-      colorUpdated(CALL_MODE_DIRECT_CHANGE);
 
       enable(false);
       serializeConfig();

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -200,6 +200,7 @@
 #define USERMOD_ID_INA226                50     //Usermod "usermod_ina226.h"
 #define USERMOD_ID_AHT10                 51     //Usermod "usermod_aht10.h"
 #define USERMOD_ID_LD2410                52     //Usermod "usermod_ld2410.h"
+#define USERMOD_ID_TEST_MODE             53     //USermod "test_mode.h"
 
 //Access point behavior
 #define AP_BEHAVIOR_BOOT_NO_CONN          0     //Open AP when no connection after boot

--- a/wled00/usermods_list.cpp
+++ b/wled00/usermods_list.cpp
@@ -178,6 +178,10 @@
   #include "../usermods/Internal_Temperature_v2/usermod_internal_temperature.h"
 #endif
 
+#ifdef USERMOD_TEST_MODE
+  #include "../usermods/Test_Mode/test_mode.h"
+#endif
+
 #if defined(WLED_USE_SD_MMC) || defined(WLED_USE_SD_SPI)
 // This include of SD.h and SD_MMC.h must happen here, else they won't be
 // resolved correctly (when included in mod's header only)
@@ -453,5 +457,9 @@ void registerUsermods()
   
   #ifdef USERMOD_LD2410
   usermods.add(new LD2410Usermod());
+  #endif
+
+  #ifdef USERMOD_TEST_MODE
+  usermods.add(new TestModeUsermod());
   #endif
 }


### PR DESCRIPTION
This usermod allows you to load a specific test pattern (brightness, color, effect, palette) by holding down a designated number of buttons.

It was developed for quality control on pre-assembled QuinLED boards with PWM outputs to control "dumb" LEDs.
To test a digital output you can simply connect it to an addressable LED, which will either work properly or not.
This doesn't work with analog outputs, because the MOSFET can fail "closed" and thus still light up the LED. The whole dimming range must be tested.

The test pattern is triggered by holding down multiple buttons, and then automatically disables itself so that it can be used on first boot on the assembly line and then be invisible to the user. If for some reason the user wants to test the outputs with the pattern, they can manually enable the usermod again.