### PR TITLE
Improve jsonBufferLock management

### DIFF
--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -231,7 +231,9 @@ bool requestJSONBufferLock(uint8_t module)
 #endif  
   // If the lock is still held - by us, or by another task
   if (jsonBufferLock) {
-    DEBUG_PRINT(F("ERROR: Locking JSON buffer failed! (still locked by "));
+    DEBUG_PRINT(F("ERROR: Locking JSON buffer ("));
+    DEBUG_PRINT(module);
+    DEBUG_PRINT(F(") failed! (still locked by "));
     DEBUG_PRINT(jsonBufferLock);
     DEBUG_PRINTLN(")");
 #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -231,11 +231,7 @@ bool requestJSONBufferLock(uint8_t module)
 #endif  
   // If the lock is still held - by us, or by another task
   if (jsonBufferLock) {
-    DEBUG_PRINT(F("ERROR: Locking JSON buffer ("));
-    DEBUG_PRINT(module);
-    DEBUG_PRINT(F(") failed! (still locked by "));
-    DEBUG_PRINT(jsonBufferLock);
-    DEBUG_PRINTLN(")");
+    DEBUG_PRINTF_P(PSTR("ERROR: Locking JSON buffer (%d) failed! (still locked by %d)\n"), module, jsonBufferLock);
 #ifdef ARDUINO_ARCH_ESP32
     xSemaphoreGiveRecursive(jsonBufferLockMutex);
 #endif
@@ -243,9 +239,7 @@ bool requestJSONBufferLock(uint8_t module)
   }
 
   jsonBufferLock = module ? module : 255;
-  DEBUG_PRINT(F("JSON buffer locked. ("));
-  DEBUG_PRINT(jsonBufferLock);
-  DEBUG_PRINTLN(")");
+  DEBUG_PRINTF_P(PSTR("JSON buffer locked. (%d)\n"), jsonBufferLock);
   pDoc->clear();
   return true;
 }
@@ -253,9 +247,7 @@ bool requestJSONBufferLock(uint8_t module)
 
 void releaseJSONBufferLock()
 {
-  DEBUG_PRINT(F("JSON buffer released. ("));
-  DEBUG_PRINT(jsonBufferLock);
-  DEBUG_PRINTLN(")");
+  DEBUG_PRINTF_P(PSTR("JSON buffer released. (%d)\n"), jsonBufferLock);
   jsonBufferLock = 0;
 #ifdef ARDUINO_ARCH_ESP32
   xSemaphoreGiveRecursive(jsonBufferLockMutex);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -810,6 +810,7 @@ WLED_GLOBAL int8_t spi_sclk  _INIT(SPISCLKPIN);
 // global ArduinoJson buffer
 #if defined(ARDUINO_ARCH_ESP32)
 WLED_GLOBAL JsonDocument *pDoc _INIT(nullptr);
+WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(xSemaphoreCreateRecursiveMutex());
 #else
 WLED_GLOBAL StaticJsonDocument<JSON_BUFFER_SIZE> gDoc;
 WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);


### PR DESCRIPTION
This patch set fixes some hangs and potential crashes with jsonBufferLock contention.

- On ESP8266, avoid calling delay() in system context.  This fixes some crashes if the lock is contended during web server callbacks. As it is not possible to wait in system context, immediately return failure.
- On ESP32, use a recursive semaphore instead of a delay() loop.  This improves overall performance as the CPU doesn't cycle needlessly, and fixes hanging up for the timeout interval in cases when the contention is from the same task, eg. two web requests.
- Use DEBUG_PRINTF_P for the debug messages, a tiny code size savings.
