### PR TITLE
Fix default pin assignement for unassigned buttons, take 2

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -429,6 +429,10 @@ void WLED::setup()
 
   DEBUG_PRINT(F("heap ")); DEBUG_PRINTLN(ESP.getFreeHeap());
 
+  // Set all button pins without an assigned type to -1.
+  // This is necessary because partially initializing an array fills the remaining elements with 0, which is a valid GPIO.
+  for (unsigned i=0; i<WLED_MAX_BUTTONS; i++) if (buttonType[i] == BTN_TYPE_NONE) btnPin[i] = -1;
+
   bool fsinit = false;
   DEBUGFS_PRINTLN(F("Mount FS"));
 #ifdef ARDUINO_ARCH_ESP32

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -277,10 +277,10 @@ WLED_GLOBAL char otaPass[33] _INIT(DEFAULT_OTA_PASS);
 
 // Hardware and pin config
 #ifndef BTNPIN
-  #define BTNPIN 0,-1
+  #define BTNPIN 0
 #endif
 #ifndef BTNTYPE
-  #define BTNTYPE BTN_TYPE_PUSH,BTN_TYPE_NONE
+  #define BTNTYPE BTN_TYPE_PUSH
 #endif
 #ifndef RLYPIN
 WLED_GLOBAL int8_t rlyPin _INIT(-1);


### PR DESCRIPTION
Follow up on https://github.com/Aircoookie/WLED/issues/3953
Fill btnPin array with -1 unless corresponding member of buttonType array has been set to a value != 0 (BTN_TYPE_NONE). 
0.14 branch had a similar implementation where it filled all elements except the first with -1, but since in 0.15 you can define multiple button pins at compile time it was removed. 
Because of this change it is no longer necessary to specify the second pin and type on the default BTNPIN and BTNTYPE defs.

Credit to @softhack007 for the idea.