### PR TITLE
Demystified some byte definitions of WiZmote ESP-NOW message

### DIFF
--- a/wled00/remote.cpp
+++ b/wled00/remote.cpp
@@ -25,11 +25,11 @@
 typedef struct WizMoteMessageStructure {
   uint8_t program;  // 0x91 for ON button, 0x81 for all others
   uint8_t seq[4];   // Incremetal sequence number 32 bit unsigned integer LSB first
-  uint8_t byte5;    // Unknown (seen 0x20)
+  uint8_t dt1;      // Button Data Type (0x32)
   uint8_t button;   // Identifies which button is being pressed
-  uint8_t byte8;    // Unknown, but always 0x01
-  uint8_t byte9;    // Unnkown, but always 0x64
-
+  uint8_t dt2;      // Battery Level Data Type (0x01)
+  uint8_t batLevel; // Battery Level 0-100
+  
   uint8_t byte10;   // Unknown, maybe checksum
   uint8_t byte11;   // Unknown, maybe checksum
   uint8_t byte12;   // Unknown, maybe checksum


### PR DESCRIPTION
Better defines the data coming in from a WiZmote over ESP-NOW.
Of interest is batLevel which denotes the WiZmote's self reported battery level.