### PR TITLE
Temperature usermod: update OneWire to 2.3.8

### DIFF
--- a/usermods/Temperature/platformio_override.ini
+++ b/usermods/Temperature/platformio_override.ini
@@ -7,6 +7,4 @@
 extends = env:d1_mini
 build_flags = ${common.build_flags_esp8266} -D USERMOD_DALLASTEMPERATURE
 lib_deps = ${env.lib_deps}
-  paulstoffregen/OneWire@~2.3.7
-# you may want to use following with ESP32
-;  https://github.com/blazoncek/OneWire.git # fixes Sensor error on ESP32
+  paulstoffregen/OneWire@~2.3.8

--- a/usermods/Temperature/readme.md
+++ b/usermods/Temperature/readme.md
@@ -43,10 +43,8 @@ default_envs = d1_mini
 ...
 lib_deps =
   ...
-  #For Dallas sensor uncomment following line
-  OneWire@~2.3.7
-  # ... or you may want to use following with ESP32
-;  https://github.com/blazoncek/OneWire.git # fixes Sensor error on ESP32...
+  #For Dallas sensor uncomment following
+    paulstoffregen/OneWire @ ~2.3.8
 ```
 
 ## Change Log
@@ -63,3 +61,7 @@ lib_deps =
 2023-05
 * Rewrite to conform to newer recommendations.
 * Recommended @blazoncek fork of OneWire for ESP32 to avoid Sensor error
+
+2024-09
+* Update OneWire to version 2.3.8, which includes stickbreaker's and garyd9's ESP32 fixes:
+  blazoncek's fork is no longer needed

--- a/usermods/Temperature/readme.md
+++ b/usermods/Temperature/readme.md
@@ -56,8 +56,10 @@ lib_deps =
 * Do not report erroneous low temperatures to MQTT
 * Disable plugin if temperature sensor not detected
 * Report the number of seconds until the first read in the info screen instead of sensor error
+
 2021-04
 * Adaptation for runtime configuration.
+
 2023-05
 * Rewrite to conform to newer recommendations.
 * Recommended @blazoncek fork of OneWire for ESP32 to avoid Sensor error


### PR DESCRIPTION
OneWire 2.3.8 includes stickbreaker's and garyd9's ESP32 fixes, making blazoncek's fork no longer necessary.

This updates the dependency and removes the comment suggesting blazoncek's fork.

I noticed some minor issues that were unrelated to the OneWire version change, so I put them in separate commits prior to the final commit that's the focus of this pull request:
* One of the files had CRLF endings, which my IDE warned me about when I tried to commit my changes to it.
  I ran `git ls-files --eol | awk '$1 == "i/crlf"'` and found three other files in the codebase with CRLF endings.
  So, I figured I should go ahead and make the whole codebase uniformly use LF endings.
* The Temperature usermod's changelog sections weren't rendering properly, so I added blank lines to fix it.

It will probably be the fastest/easiest to review if you view the diffs for each commit separately.