### PR TITLE
Add the ability to toggle the reception of palette synchronizations

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -486,6 +486,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   CJSON(receiveNotificationBrightness, if_sync_recv["bri"]);
   CJSON(receiveNotificationColor, if_sync_recv["col"]);
   CJSON(receiveNotificationEffects, if_sync_recv["fx"]);
+  CJSON(receiveNotificationPalette, if_sync_recv["pal"]);
   CJSON(receiveGroups, if_sync_recv["grp"]);
   CJSON(receiveSegmentOptions, if_sync_recv["seg"]);
   CJSON(receiveSegmentBounds, if_sync_recv["sb"]);
@@ -973,6 +974,7 @@ void serializeConfig() {
   if_sync_recv["bri"] = receiveNotificationBrightness;
   if_sync_recv["col"] = receiveNotificationColor;
   if_sync_recv["fx"]  = receiveNotificationEffects;
+  if_sync_recv["pal"] = receiveNotificationPalette;
   if_sync_recv["grp"] = receiveGroups;
   if_sync_recv["seg"] = receiveSegmentOptions;
   if_sync_recv["sb"]  = receiveSegmentBounds;

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3201,7 +3201,7 @@ function simplifyUI() {
 	createDropdown("palw", "Change palette");
 	createDropdown("fx", "Change effect", [gId("fxFind"), gId("fxlist")]);
 
-	// Hide pallete label
+	// Hide palette label
 	gId("pall").style.display = "none";
 	gId("Colors").insertBefore(document.createElement("br"), gId("pall"));
 	// Hide effect label

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -138,7 +138,7 @@ Use ESP-NOW sync: <input type="checkbox" name="EN"><br><i>(in AP mode or no WiFi
 	</tr>
 </table>
 <h3>Receive</h3>
-<nowrap><input type="checkbox" name="RB">Brightness,</nowrap> <nowrap><input type="checkbox" name="RC">Color,</nowrap> <nowrap>and <input type="checkbox" name="RX">Effects</nowrap><br>
+<nowrap><input type="checkbox" name="RB">Brightness,</nowrap> <nowrap><input type="checkbox" name="RC">Color,</nowrap> <nowrap><input type="checkbox" name="RX">Effects,</nowrap> <nowrap>and <input type="checkbox" name="RP">Palette</nowrap><br>
 <input type="checkbox" name="SO"> Segment options, <input type="checkbox" name="SG"> bounds
 <h3>Send</h3>
 Enable Sync on start: <input type="checkbox" name="SS"><br>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -380,6 +380,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     receiveNotificationBrightness = request->hasArg(F("RB"));
     receiveNotificationColor = request->hasArg(F("RC"));
     receiveNotificationEffects = request->hasArg(F("RX"));
+    receiveNotificationPalette = request->hasArg(F("RP"));
     receiveSegmentOptions = request->hasArg(F("SO"));
     receiveSegmentBounds = request->hasArg(F("SG"));
     sendNotifications = request->hasArg(F("SS"));

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -221,7 +221,7 @@ void parseNotifyPacket(uint8_t *udpIn) {
     if (!(receiveGroups & 0x01)) return;
   } else if (!(receiveGroups & udpIn[36])) return;
 
-  bool someSel = (receiveNotificationBrightness || receiveNotificationColor || receiveNotificationEffects);
+  bool someSel = (receiveNotificationBrightness || receiveNotificationColor || receiveNotificationEffects || receiveNotificationPalette);
 
   // set transition time before making any segment changes
   if (version > 3) {
@@ -311,6 +311,9 @@ void parseNotifyPacket(uint8_t *udpIn) {
         selseg.setMode(udpIn[11+ofs]);
         selseg.speed     = udpIn[12+ofs];
         selseg.intensity = udpIn[13+ofs];
+      }
+      if (receiveNotificationPalette || !someSel) {
+        DEBUG_PRINTF_P(PSTR("Apply palette: %u\n"), id);
         selseg.palette   = udpIn[14+ofs];
       }
       if (receiveNotificationColor || !someSel) {
@@ -352,14 +355,16 @@ void parseNotifyPacket(uint8_t *udpIn) {
   }
 
   // simple effect sync, applies to all selected segments
-  if (applyEffects && (version < 11 || !receiveSegmentOptions)) {
+  if ((applyEffects || receiveNotificationPalette) && (version < 11 || !receiveSegmentOptions)) {
     for (size_t i = 0; i < strip.getSegmentsNum(); i++) {
       Segment& seg = strip.getSegment(i);
       if (!seg.isActive() || !seg.isSelected()) continue;
-      seg.setMode(udpIn[8]);
-      seg.speed = udpIn[9];
-      if (version > 2) seg.intensity = udpIn[16];
-      if (version > 4) seg.setPalette(udpIn[19]);
+      if (applyEffects) {
+        seg.setMode(udpIn[8]);
+        seg.speed = udpIn[9];
+        if (version > 2) seg.intensity = udpIn[16];
+      }
+      if (version > 4 && receiveNotificationPalette) seg.setPalette(udpIn[19]);
     }
     stateChanged = true;
   }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -676,6 +676,7 @@ WLED_GLOBAL send_notification_t    notifyG  _INIT(0b00001111);
 #define receiveNotificationBrightness receiveN.Brightness
 #define receiveNotificationColor      receiveN.Color
 #define receiveNotificationEffects    receiveN.Effects
+#define receiveNotificationPalette    receiveN.Palette
 #define receiveSegmentOptions         receiveN.SegmentOptions
 #define receiveSegmentBounds          receiveN.SegmentBounds
 #define receiveDirect                 receiveN.Direct
@@ -687,6 +688,7 @@ WLED_GLOBAL send_notification_t    notifyG  _INIT(0b00001111);
 WLED_GLOBAL bool receiveNotificationBrightness _INIT(true);       // apply brightness from incoming notifications
 WLED_GLOBAL bool receiveNotificationColor      _INIT(true);       // apply color
 WLED_GLOBAL bool receiveNotificationEffects    _INIT(true);       // apply effects setup
+WLED_GLOBAL bool receiveNotificationPalette    _INIT(true);      // apply palette
 WLED_GLOBAL bool receiveSegmentOptions         _INIT(false);      // apply segment options
 WLED_GLOBAL bool receiveSegmentBounds          _INIT(false);      // apply segment bounds (start, stop, offset)
 WLED_GLOBAL bool receiveDirect _INIT(true);                       // receive UDP/Hyperion realtime

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -688,7 +688,7 @@ WLED_GLOBAL send_notification_t    notifyG  _INIT(0b00001111);
 WLED_GLOBAL bool receiveNotificationBrightness _INIT(true);       // apply brightness from incoming notifications
 WLED_GLOBAL bool receiveNotificationColor      _INIT(true);       // apply color
 WLED_GLOBAL bool receiveNotificationEffects    _INIT(true);       // apply effects setup
-WLED_GLOBAL bool receiveNotificationPalette    _INIT(true);      // apply palette
+WLED_GLOBAL bool receiveNotificationPalette    _INIT(true);       // apply palette
 WLED_GLOBAL bool receiveSegmentOptions         _INIT(false);      // apply segment options
 WLED_GLOBAL bool receiveSegmentBounds          _INIT(false);      // apply segment bounds (start, stop, offset)
 WLED_GLOBAL bool receiveDirect _INIT(true);                       // receive UDP/Hyperion realtime

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -506,6 +506,7 @@ void getSettingsJS(byte subPage, char* dest)
     sappend('c',SET_F("RB"),receiveNotificationBrightness);
     sappend('c',SET_F("RC"),receiveNotificationColor);
     sappend('c',SET_F("RX"),receiveNotificationEffects);
+    sappend('c',SET_F("RP"),receiveNotificationPalette);
     sappend('c',SET_F("SO"),receiveSegmentOptions);
     sappend('c',SET_F("SG"),receiveSegmentBounds);
     sappend('c',SET_F("SS"),sendNotifications);


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
This PR adds the ability to toggle the reception of palette synchronizations on a node.

- adds a new global `receiveNotificationPalette`
- adds a checkbox for "Palette" to the "Sync Setup" configuration page. (see screenshot)
- adds request handling of new form checkbox.
- adds logic to prevent the application of palette changes during synchronization.
- adds json serialization and deserialization of new configuration item.

Supported issues:
- https://github.com/Aircoookie/WLED/issues/2397

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

I want to keep the palette synchronized across all nodes, but need to preserve the effect on some of them.

## 🧪 Testing ##
Tested on four ESP32 nodes.  Verified palettes can be synchronized without effects, and effects can be synchronized without palettes. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##
![image](https://github.com/user-attachments/assets/44c215a1-9b67-40f1-a12e-69c7d1c9eb1f)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [WLED code standards].
