### PR TITLE
Fix AsyncWebServer version pin

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ lib_deps =
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.8.0
     #https://github.com/makuna/NeoPixelBus.git#CoreShaderBeta
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
+    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.2.1
   # for I2C interface
     ;Wire
   # ESP-NOW library
@@ -234,7 +234,7 @@ lib_deps_compat =
   IRremoteESP8266 @ 2.8.2
   makuna/NeoPixelBus @ 2.7.9
   https://github.com/blazoncek/QuickESPNow.git#optional-debug
-  https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
+  https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.2.1
 
 
 [esp32]


### PR DESCRIPTION
We want to always use the tagged version, not complain if the current main is a mismatch.