### PR TITLE
size optimization for "V4" firmware (-flto)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -424,7 +424,9 @@ board = esp32dev
 platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
+  -fno-lto
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=ESP32_8M #-D WLED_DISABLE_BROWNOUT_DET
+  -g3 -ggdb -flto=auto ;; enable size optimization by the linker - comment out when debugging. ("=4" just means "use 4 cores in parallel")
   ${esp32.AR_build_flags}
 lib_deps = ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -268,7 +268,7 @@ AR_lib_deps = kosme/arduinoFFT @ 2.0.1
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
-platform = espressif32@ ~6.3.2
+platform = espressif32@ ~6.6.0                                             ;; supports -flto
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
@@ -281,7 +281,7 @@ lib_deps =
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
-platform = espressif32@ ~6.3.2
+platform = espressif32@ ~6.6.0                                             ;; supports -flto
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -316,7 +316,7 @@ lib_deps =
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
-platform = espressif32@ ~6.3.2
+platform = espressif32@ ~6.6.0                                             ;; supports -flto
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_flags = -g
   -DESP32
@@ -468,7 +468,9 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = ${esp32.extended_partitions}
 build_unflags = ${common.build_unflags}
+  -fno-lto
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=ESP32_WROVER
+  -g3 -ggdb -flto=4 ;; enable size optimization by the linker - comment out when debugging. ("=4" just means "use 4 cores in parallel")
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
   -D DATA_PINS=25
   ${esp32.AR_build_flags}
@@ -540,7 +542,9 @@ platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
+  -fno-lto
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_4M_qspi
+  -g3 -ggdb -flto=4 ;; enable size optimization by the linker - comment out when debugging. ("=4" just means "use 4 cores in parallel")
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   -DLOLIN_WIFI_FIX ; seems to work much better with this
@@ -561,7 +565,9 @@ board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = qio
 board_build.f_flash = 80000000L
 build_unflags = ${common.build_unflags}
+  -fno-lto
 build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=ESP32-S2
+  -g3 -ggdb -flto=4 ;; enable size optimization by the linker - comment out when debugging. ("=4" just means "use 4 cores in parallel")
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DARDUINO_USB_MSC_ON_BOOT=0
   -DARDUINO_USB_DFU_ON_BOOT=0


### PR DESCRIPTION
This is a continuation (and replacement) for 
* #3824 by @deece

Thanks to the contribution made by @deece to [platform-espressif32](https://github.com/platformio/platform-espressif32/pull/1329), link time optimization is now possible in [esp32 framework version 6.6.0](https://github.com/platformio/platform-espressif32/releases/tag/v6.6.0) and above without hacking build scripts  (8266 - no way, sorry).


### Overview and background

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-flto

 * LTO generally reduces firmware size by post-optimizing the binary when the linker runs, considering all pieces of the code instead of looking at each ".cpp.o" in isolation.
* In my first tests, there was no additional speedup, however sometimes the stack usage is more than previously.
* LTO makes it very hard to read exception decoder dumps, so I've added "-g3 -ggdb" which is recommended to improve the situation
* esp32-C3: not possible to apply LTO, due to compiler bugs
* Currently we can only use LTO on "V4" builds. I've enabled it for the 4MB binaries which benefit the most (see table below).


### size comparison

|  firmware           | 0_15 without -flto        | 0_15 with -flto    |
| ---------------------- | --------------------- | -------------------- |
| esp32_wrover    <br> **83.6kB saved**     | RAM:  4.6%  (used 60156 bytes); <br>Flash: 92.3% (used 1572241 bytes) | RAM:  4.6% (used 60140 bytes) <br> Flash:  87.4% (used 1488605 bytes) |
| esp32dev_8M    <br> **80.5kB saved**     | RAM:  18.3% (used 60084 bytes); <br>Flash: 73.0% (used 1530305 bytes) | RAM: 18.3% (used 60052 bytes); <br>Flash: 69.1% (used 1449817 bytes) |
| esp32s3_4M_qspi   <br> **71.7kB saved**   | RAM: 18.4% (used 60288 bytes); <br>Flash: 91.4% (used 1437945 bytes) | RAM:  18.4% (used 60264 bytes); <br>Flash: 86.9% (used 1366221 bytes) |
| lolin_s2_mini       <br> **72.3kB saved**      | RAM:  20.2% (used 66100 bytes); <br>Flash: 92.7% (used 1458094 bytes) | RAM:  20.2% (used 66100 bytes); <br>Flash:  88.1% (used 1385770 bytes) | 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESP32 platform version to improve build optimization and enable link-time optimization support.
  * Adjusted build flags for select ESP32 environments to provide explicit control over optimization and debugging options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->