### PR TITLE
Fixed the positioning of the "Download the latest binary" button

### DIFF
--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -17,7 +17,8 @@
 	<h2>WLED Software Update</h2>
 	<form method='POST' action='./update' id='uf' enctype='multipart/form-data' onsubmit="U()">
 		Installed version: <span class="sip">##VERSION##</span><br>
-		Download the latest binary: <a href="https://github.com/Aircoookie/WLED/releases" target="_blank">
+		Download the latest binary: <a href="https://github.com/Aircoookie/WLED/releases" target="_blank" 
+		style="vertical-align: text-bottom; display: inline-flex;">
 		<img src="https://img.shields.io/github/release/Aircoookie/WLED.svg?style=flat-square"></a><br>
 		<input type='file' name='update' required><br> <!--should have accept='.bin', but it prevents file upload from android app-->
 		<button type="submit">Update!</button><br>

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -17,7 +17,7 @@
 	<h2>WLED Software Update</h2>
 	<form method='POST' action='./update' id='uf' enctype='multipart/form-data' onsubmit="U()">
 		Installed version: <span class="sip">##VERSION##</span><br>
-		Downloadd the latest binary:&nbsp;<a href="https://github.com/Aircoookie/WLED/releases" target="_blank" 
+		Download the latest binary:&nbsp;<a href="https://github.com/Aircoookie/WLED/releases" target="_blank" 
 		style="vertical-align: text-bottom; display: inline-flex;">
 		<img src="https://img.shields.io/github/release/Aircoookie/WLED.svg?style=flat-square"></a><br>
 		<input type='file' name='update' required><br> <!--should have accept='.bin', but it prevents file upload from android app-->

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -17,7 +17,7 @@
 	<h2>WLED Software Update</h2>
 	<form method='POST' action='./update' id='uf' enctype='multipart/form-data' onsubmit="U()">
 		Installed version: <span class="sip">##VERSION##</span><br>
-		Download the latest binary: <a href="https://github.com/Aircoookie/WLED/releases" target="_blank" 
+		Downloadd the latest binary:&nbsp;<a href="https://github.com/Aircoookie/WLED/releases" target="_blank" 
 		style="vertical-align: text-bottom; display: inline-flex;">
 		<img src="https://img.shields.io/github/release/Aircoookie/WLED.svg?style=flat-square"></a><br>
 		<input type='file' name='update' required><br> <!--should have accept='.bin', but it prevents file upload from android app-->


### PR DESCRIPTION
Corrects the positioning of the "Download the latest binary" button on the `update.htm` page, where the button was slightly misaligned above the text. 
The issue was resolved by using `vertical-align: text-bottom;`.

Additionally, the alignment of the `<a>` tag with the `<img>` inside it has been improved by applying `display: inline-flex;` 
(see comparison images below).

before:
![before](https://github.com/user-attachments/assets/ebc7c2b8-4161-4627-82c2-b5245e3a2dcc)

after:
![after](https://github.com/user-attachments/assets/e77a7160-21cd-4155-91e5-d251b8b11fec)

Edit: Fixed the issue where the space after "Download the latest binary:" disappeared after building by adding `&nbsp;`.