### PR TITLE
Added BRT timezone

### DIFF
--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -156,6 +156,7 @@
 			<option value="20">AKST/AKDT (Anchorage)</option>
 			<option value="21">MX-CST</option>
 			<option value="22">PKT (Pakistan)</option>
+			<option value="23">BRT (Brasília)</option>
 		</select><br>
 		UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 		Current local time is <span class="times">unknown</span>.<br>

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -36,8 +36,9 @@ Timezone* tz;
 #define TZ_ANCHORAGE           20
 #define TZ_MX_CENTRAL          21
 #define TZ_PAKISTAN            22
+#define TZ_BRASILIA            23
 
-#define TZ_COUNT               23
+#define TZ_COUNT               24
 #define TZ_INIT               255
 
 byte tzCurrent = TZ_INIT; //uninitialized
@@ -135,6 +136,10 @@ static const std::pair<TimeChangeRule, TimeChangeRule> TZ_TABLE[] PROGMEM = {
     /* TZ_PAKISTAN */ {
       {Last, Sun, Mar, 1, 300},     //Pakistan Standard Time = UTC + 5 hours
       {Last, Sun, Mar, 1, 300}
+    },
+    /* TZ_BRASILIA */ {
+      {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
+      {Last, Sun, Mar, 1, -180}
     }
 };
 


### PR DESCRIPTION
Added the Brasília timezone, which is widely used across most regions of Brazil.