### PR TITLE
Added some date and time formatting options to scrolling text effect.

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5956,20 +5956,24 @@ uint16_t mode_2Dscrollingtext(void) {
   if (!strlen(text)) { // fallback if empty segment name: display date and time
     sprintf_P(text, PSTR("%s %d, %d %d:%02d%s"), monthShortStr(month(localTime)), day(localTime), year(localTime), AmPmHour, minute(localTime), sec);
   } else {
+    if (text[0] == '#') for (auto &c : text) c = std::toupper(c);
     if      (!strncmp_P(text,PSTR("#DATE"),5)) sprintf_P(text, zero?PSTR("%02d.%02d.%04d"):PSTR("%d.%d.%d"),   day(localTime),   month(localTime),  year(localTime));
     else if (!strncmp_P(text,PSTR("#DDMM"),5)) sprintf_P(text, zero?PSTR("%02d.%02d")     :PSTR("%d.%d"),      day(localTime),   month(localTime));
     else if (!strncmp_P(text,PSTR("#MMDD"),5)) sprintf_P(text, zero?PSTR("%02d/%02d")     :PSTR("%d/%d"),      month(localTime), day(localTime));
     else if (!strncmp_P(text,PSTR("#TIME"),5)) sprintf_P(text, zero?PSTR("%02d:%02d%s")   :PSTR("%2d:%02d%s"), AmPmHour,         minute(localTime), sec);
-    else if (!strncmp_P(text,PSTR("#hhmm"),5)) sprintf_P(text, zero?PSTR("%02d:%02d")     :PSTR("%d:%02d"),    AmPmHour,         minute(localTime));
-    else if (!strncmp_P(text,PSTR("#DD"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        day(localTime));
-    else if (!strncmp_P(text,PSTR("#MMM"),4))  sprintf_P(text, zero?PSTR("%s")            :PSTR("%s"),        monthShortStr(month(localTime)));
-    else if (!strncmp_P(text,PSTR("#MM"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        month(localTime));
-    else if (!strncmp_P(text,PSTR("#YYYY"),5)) sprintf_P(text, zero?PSTR("%04d")          :PSTR("%d"),        year(localTime));
-    else if (!strncmp_P(text,PSTR("#YY"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        year(localTime)-2000);
-    else if (!strncmp_P(text,PSTR("#hh"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        AmPmHour);
-    else if (!strncmp_P(text,PSTR("#mm"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        minute(localTime));
-    else if (!strncmp_P(text,PSTR("#ss"),3))   sprintf_P(text, zero?PSTR("%s")            :PSTR("%s"),        &sec[1]);
-}
+    else if (!strncmp_P(text,PSTR("#HHMM"),5)) sprintf_P(text, zero?PSTR("%02d:%02d")     :PSTR("%d:%02d"),    AmPmHour,         minute(localTime));
+    else if (!strncmp_P(text,PSTR("#HH"),3))   sprintf  (text, zero?    ("%02d")          :    ("%d"),         AmPmHour);
+    else if (!strncmp_P(text,PSTR("#MM"),3))   sprintf  (text, zero?    ("%02d")          :    ("%d"),         minute(localTime));
+    else if (!strncmp_P(text,PSTR("#SS"),3))   sprintf  (text,          ("%02d")                     ,         second(localTime));
+    else if (!strncmp_P(text,PSTR("#DD"),3))   sprintf  (text, zero?    ("%02d")          :    ("%d"),         day(localTime));
+    else if (!strncmp_P(text,PSTR("#DAY"),4))  sprintf  (text,          ("%s")                       ,         dayShortStr(day(localTime)));
+    else if (!strncmp_P(text,PSTR("#DDDD"),5)) sprintf  (text,          ("%s")                       ,         dayStr(day(localTime)));
+    else if (!strncmp_P(text,PSTR("#MO"),3))   sprintf  (text, zero?    ("%02d")          :    ("%d"),         month(localTime));
+    else if (!strncmp_P(text,PSTR("#MON"),4))  sprintf  (text,          ("%s")                       ,         monthShortStr(month(localTime)));
+    else if (!strncmp_P(text,PSTR("#MMMM"),5)) sprintf  (text,          ("%s")                       ,         monthStr(month(localTime)));
+    else if (!strncmp_P(text,PSTR("#YY"),3))   sprintf  (text,          ("%02d")                     ,         year(localTime)%100);
+    else if (!strncmp_P(text,PSTR("#YYYY"),5)) sprintf_P(text, zero?PSTR("%04d")          :    ("%d"),         year(localTime));
+  }
 
   const int  numberOfLetters = strlen(text);
   const unsigned long now = millis(); // reduce millis() calls

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5960,10 +5960,16 @@ uint16_t mode_2Dscrollingtext(void) {
     else if (!strncmp_P(text,PSTR("#DDMM"),5)) sprintf_P(text, zero?PSTR("%02d.%02d")     :PSTR("%d.%d"),      day(localTime),   month(localTime));
     else if (!strncmp_P(text,PSTR("#MMDD"),5)) sprintf_P(text, zero?PSTR("%02d/%02d")     :PSTR("%d/%d"),      month(localTime), day(localTime));
     else if (!strncmp_P(text,PSTR("#TIME"),5)) sprintf_P(text, zero?PSTR("%02d:%02d%s")   :PSTR("%2d:%02d%s"), AmPmHour,         minute(localTime), sec);
-    else if (!strncmp_P(text,PSTR("#HHMM"),5)) sprintf_P(text, zero?PSTR("%02d:%02d")     :PSTR("%d:%02d"),    AmPmHour,         minute(localTime));
-    else if (!strncmp_P(text,PSTR("#HH"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),         AmPmHour);
-    else if (!strncmp_P(text,PSTR("#MM"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        minute(localTime));
-  }
+    else if (!strncmp_P(text,PSTR("#hhmm"),5)) sprintf_P(text, zero?PSTR("%02d:%02d")     :PSTR("%d:%02d"),    AmPmHour,         minute(localTime));
+    else if (!strncmp_P(text,PSTR("#DD"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        day(localTime));
+    else if (!strncmp_P(text,PSTR("#MMM"),4))  sprintf_P(text, zero?PSTR("%s")            :PSTR("%s"),        monthShortStr(month(localTime)));
+    else if (!strncmp_P(text,PSTR("#MM"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        month(localTime));
+    else if (!strncmp_P(text,PSTR("#YYYY"),5)) sprintf_P(text, zero?PSTR("%04d")          :PSTR("%d"),        year(localTime));
+    else if (!strncmp_P(text,PSTR("#YY"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        year(localTime)-2000);
+    else if (!strncmp_P(text,PSTR("#hh"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        AmPmHour);
+    else if (!strncmp_P(text,PSTR("#mm"),3))   sprintf_P(text, zero?PSTR("%02d")          :PSTR("%d"),        minute(localTime));
+    else if (!strncmp_P(text,PSTR("#ss"),3))   sprintf_P(text, zero?PSTR("%s")            :PSTR("%s"),        &sec[1]);
+}
 
   const int  numberOfLetters = strlen(text);
   const unsigned long now = millis(); // reduce millis() calls


### PR DESCRIPTION
Added/updated the following tags to use with the scrolling text effect.

 #hh Hours
 #mm Minutes
 #ss Seconds

 #DD Day
 #MM Month
 #MMM Month as Text
 #YYYY Year
 #YY Two digit Year

Changed #hhmm to lower case to not get confused with month.

This enables more flexible display of time and date on a bigger matrix. Also beeing able to display seconds in smaller font or lower brightness. 