### PR TITLE
compile warning fix

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -578,8 +578,14 @@
 #else
   #define DEFAULT_LED_PIN 16   // aligns with GPIO2 (D4) on Wemos D1 mini32 compatible boards (if it is unusable it will be reassigned in WS2812FX::finalizeInit())
 #endif
-#define DEFAULT_LED_TYPE TYPE_WS2812_RGB
+
+#ifndef DEFAULT_LED_TYPE
+  #define DEFAULT_LED_TYPE TYPE_WS2812_RGB
+#endif
+
+#ifndef DEFAULT_LED_COUNT
 #define DEFAULT_LED_COUNT 30
+#endif
 
 #define INTERFACE_UPDATE_COOLDOWN 1000 // time in ms to wait between websockets, alexa, and MQTT updates
 


### PR DESCRIPTION
added check for custom compile user defines, otherwise warning message are generated for custom build with DEFAULT_LED_TYPE or DEFAULT_LED_COUNT defined