### PR TITLE
fixed refs to removed usermod

### DIFF
--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -111,7 +111,6 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ;
 ; Use 4 Line Display usermod with SPI display
 ;   -D USERMOD_FOUR_LINE_DISPLAY
-;   -D USE_ALT_DISPlAY # mandatory
 ;   -DFLD_SPI_DEFAULT
 ;   -D FLD_TYPE=SSD1306_SPI64
 ;   -D FLD_PIN_CLOCKSPI=14
@@ -377,7 +376,6 @@ build_flags = ${common.build_flags} ${esp32.build_flags}
   -D USERMOD_DALLASTEMPERATURE
   -D USERMOD_FOUR_LINE_DISPLAY
   -D TEMPERATURE_PIN=23
-  -D USE_ALT_DISPlAY ; new versions of USERMOD_FOUR_LINE_DISPLAY and USERMOD_ROTARY_ENCODER_UI
   -D USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32.lib_deps}
   OneWire@~2.3.5

--- a/usermods/usermod_v2_four_line_display_ALT/readme.md
+++ b/usermods/usermod_v2_four_line_display_ALT/readme.md
@@ -1,16 +1,12 @@
 # I2C/SPI 4 Line Display Usermod ALT
 
 Thank you to the authors of the original version of these usermods. It would not have been possible without them!
-"usermod_v2_four_line_display"
-"usermod_v2_rotary_encoder_ui"
+"usermod_v2_four_line_display" (old but gold, removed since release 0.15.0)
+"usermod_v2_rotary_encoder_ui" (old but gold, removed since release 0.15.0)
 
-The core of these usermods are a copy of the originals. The main changes are to the FourLineDisplay usermod.
-The display usermod UI has been completely changed.
+The core of these usermods are a copy of the originals, the display usermod UI has been completely changed.
 
-
-The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod.
-Without the display, it functions identical to the original.
-The original "usermod_v2_auto_save" will not work with the display just yet.
+## Functionalities
 
 Press the encoder to cycle through the options:
 * Brightness
@@ -18,26 +14,18 @@ Press the encoder to cycle through the options:
 * Intensity
 * Palette
 * Effect
-* Main Color (only if display is used)
-* Saturation (only if display is used)
+* Main Color
+* Saturation
 
-Press and hold the encoder to display Network Info. If AP is active, it will display AP, SSID and password
+Press and hold the encoder to display Network Info. If AP is active, it will display the AP, SSID and Password
 
-Also shows if the timer is enabled
+Also shows if the timer is enabled.
 
 [See the pair of usermods in action](https://www.youtube.com/watch?v=ulZnBt9z3TI)
 
 ## Installation
 
-Please refer to the original `usermod_v2_rotary_encoder_ui` readme for the main instructions.
-
-Copy the example `platformio_override.sample.ini` from the usermod_v2_rotary_encoder_ui_ALT folder to the root directory of your particular build and rename it to `platformio_override.ini`.
-
-This file should be placed in the same directory as `platformio.ini`.
-
-Then, to activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE SENSITIVE) to the `usermods_list.cpp` file,
-                                        or add `-D USE_ALT_DISPlAY` to the original `platformio_override.ini.sample` file
-
+Copy the example `\usermods\usermod_v2_rotary_encoder_ui_ALT\platformio–override.sample.ini` to the root directory of your particular build and rename it to `platformio_override.ini`.
 
 ## Configuration
 
@@ -73,6 +61,10 @@ These options are configurable in Config > Usermods
 ### PlatformIO requirements
 
 Note: the Four Line Display usermod requires the libraries `U8g2` and `Wire`.
+
+## Compatibility
+
+The original "usermod_v2_auto_save" will not work with the display just yet.
 
 ## Change Log
 

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/platformio–override.sample.ini
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/platformio–override.sample.ini
@@ -7,7 +7,7 @@ platform = ${esp32.platform}
 build_unflags = ${common.build_unflags}
 build_flags =
     ${common.build_flags_esp32}
-    -D USERMOD_FOUR_LINE_DISPLAY -D USE_ALT_DISPlAY
+    -D USERMOD_FOUR_LINE_DISPLAY
     -D USERMOD_ROTARY_ENCODER_UI -D ENCODER_DT_PIN=18 -D ENCODER_CLK_PIN=5 -D ENCODER_SW_PIN=19
 upload_speed = 460800
 lib_deps =

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/readme.md
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/readme.md
@@ -1,16 +1,12 @@
 # Rotary Encoder UI Usermod ALT
 
 Thank you to the authors of the original version of these usermods. It would not have been possible without them!
-"usermod_v2_four_line_display"
-"usermod_v2_rotary_encoder_ui"
+"usermod_v2_four_line_display" (old but gold, removed since release 0.15.0)
+"usermod_v2_rotary_encoder_ui" (old but gold, removed since release 0.15.0)
 
-The core of these usermods are a copy of the originals. The main changes are to the FourLineDisplay usermod.
-The display usermod UI has been completely changed.
+The core of these usermods are a copy of the originals, the changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod.
 
-
-The changes made to the RotaryEncoder usermod were made to support the new UI in the display usermod.
-Without the display, it functions identical to the original.
-The original "usermod_v2_auto_save" will not work with the display just yet.
+## Functionalities
 
 Press the encoder to cycle through the options:
 * Brightness
@@ -21,8 +17,7 @@ Press the encoder to cycle through the options:
 * Main Color (only if display is used)
 * Saturation (only if display is used)
 
-Press and hold the encoder to display Network Info
-    if AP is active, it will display the AP, SSID and Password
+Press and hold the encoder to display Network Info. If AP is active, it will display the AP, SSID and Password
 
 Also shows if the timer is enabled.
 
@@ -30,9 +25,7 @@ Also shows if the timer is enabled.
 
 ## Installation
 
-Copy the example `platformio_override.sample.ini` to the root directory of your particular build and rename it to `platformio_override.ini`.
-
-To activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE SENSITIVE) to the `usermods_list.cpp` file, or add `-D USE_ALT_DISPlAY` to your `platformio_override.ini` file
+Copy the example `platformio–override.sample.ini` to the root directory of your particular build and rename it to `platformio_override.ini`.
 
 ### Define Your Options
 
@@ -40,7 +33,6 @@ To activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE 
 * `USERMOD_FOUR_LINE_DISPLAY`       - define this to have this the Four Line Display mod included wled00\usermods_list.cpp
                                         also tells this usermod that the display is available
                                         (see the Four Line Display usermod `readme.md` for more details)
-* `USE_ALT_DISPlAY`                 - Mandatory to use Four Line Display
 * `ENCODER_DT_PIN`                  - defaults to 18
 * `ENCODER_CLK_PIN`                 - defaults to 5
 * `ENCODER_SW_PIN`                  - defaults to 19
@@ -50,7 +42,8 @@ To activate this alternative usermod, add `#define USE_ALT_DISPlAY` (NOTE: CASE 
 
 ### PlatformIO requirements
 
-Note: the Four Line Display usermod requires the libraries `U8g2` and `Wire`.
+No special requirements.
+
 
 ## Change Log
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -584,7 +584,7 @@
 #endif
 
 #ifndef DEFAULT_LED_COUNT
-#define DEFAULT_LED_COUNT 30
+  #define DEFAULT_LED_COUNT 30
 #endif
 
 #define INTERFACE_UPDATE_COOLDOWN 1000 // time in ms to wait between websockets, alexa, and MQTT updates

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -578,8 +578,14 @@
 #else
   #define DEFAULT_LED_PIN 16   // aligns with GPIO2 (D4) on Wemos D1 mini32 compatible boards (if it is unusable it will be reassigned in WS2812FX::finalizeInit())
 #endif
-#define DEFAULT_LED_TYPE TYPE_WS2812_RGB
+
+#ifndef DEFAULT_LED_TYPE
+  #define DEFAULT_LED_TYPE TYPE_WS2812_RGB
+#endif
+
+#ifndef DEFAULT_LED_COUNT
 #define DEFAULT_LED_COUNT 30
+#endif
 
 #define INTERFACE_UPDATE_COOLDOWN 1000 // time in ms to wait between websockets, alexa, and MQTT updates
 


### PR DESCRIPTION
cleaned up old references to "USE_ALT_DISPlAY" that aren't used anymore in the code/source files
fixed readme.md documents and updated instructions
removed referencies to old usermods