### PR TITLE
Complete transition of UsermodManager and PinManager away from classes

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -326,36 +326,33 @@ class Usermod {
     template<typename T> static inline void oappend(const T& t) { oappend_shim->print(t); };
 };
 
-class UsermodManager {
-  private:
-    static Usermod* ums[WLED_MAX_USERMODS];
-    static byte numMods;
+namespace UsermodManager {
+  extern byte numMods;
 
-  public:
-    static void loop();
-    static void handleOverlayDraw();
-    static bool handleButton(uint8_t b);
-    static bool getUMData(um_data_t **um_data, uint8_t mod_id = USERMOD_ID_RESERVED); // USERMOD_ID_RESERVED will poll all usermods
-    static void setup();
-    static void connected();
-    static void appendConfigData(Print&);
-    static void addToJsonState(JsonObject& obj);
-    static void addToJsonInfo(JsonObject& obj);
-    static void readFromJsonState(JsonObject& obj);
-    static void addToConfig(JsonObject& obj);
-    static bool readFromConfig(JsonObject& obj);
+  void loop();
+  void handleOverlayDraw();
+  bool handleButton(uint8_t b);
+  bool getUMData(um_data_t **um_data, uint8_t mod_id = USERMOD_ID_RESERVED); // USERMOD_ID_RESERVED will poll all usermods
+  void setup();
+  void connected();
+  void appendConfigData(Print&);
+  void addToJsonState(JsonObject& obj);
+  void addToJsonInfo(JsonObject& obj);
+  void readFromJsonState(JsonObject& obj);
+  void addToConfig(JsonObject& obj);
+  bool readFromConfig(JsonObject& obj);
 #ifndef WLED_DISABLE_MQTT
-    static void onMqttConnect(bool sessionPresent);
-    static bool onMqttMessage(char* topic, char* payload);
+  void onMqttConnect(bool sessionPresent);
+  bool onMqttMessage(char* topic, char* payload);
 #endif
 #ifndef WLED_DISABLE_ESPNOW
-    static bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len);
+  bool onEspNowMessage(uint8_t* sender, uint8_t* payload, uint8_t len);
 #endif
-    static void onUpdateBegin(bool);
-    static void onStateChange(uint8_t);
-    static bool add(Usermod* um);
-    static Usermod* lookup(uint16_t mod_id);
-    static inline byte getModCount() {return numMods;};
+  void onUpdateBegin(bool);
+  void onStateChange(uint8_t);
+  bool add(Usermod* um);
+  Usermod* lookup(uint16_t mod_id);
+  inline byte getModCount() {return numMods;};
 };
 
 //usermods_list.cpp

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -13,6 +13,16 @@
   #endif
 #endif
 
+// Pin management state variables
+#ifdef ESP8266
+static uint32_t pinAlloc = 0UL;     // 1 bit per pin, we use first 17bits
+#else
+static uint64_t pinAlloc = 0ULL;     // 1 bit per pin, we use 50 bits on ESP32-S3
+static uint16_t ledcAlloc = 0;    // up to 16 LEDC channels (WLED_MAX_ANALOG_CHANNELS)
+#endif
+static uint8_t i2cAllocCount = 0; // allow multiple allocation of I2C bus pins but keep track of allocations
+static uint8_t spiAllocCount = 0; // allow multiple allocation of SPI bus pins but keep track of allocations
+static PinOwner ownerTag[WLED_NUM_PINS] = { PinOwner::None };
 
 /// Actual allocation/deallocation routines
 bool PinManager::deallocatePin(byte gpio, PinOwner tag)
@@ -273,13 +283,3 @@ void PinManager::deallocateLedc(byte pos, byte channels)
   }
 }
 #endif
-
-#ifdef ESP8266
-uint32_t PinManager::pinAlloc = 0UL;
-#else
-uint64_t PinManager::pinAlloc = 0ULL;
-uint16_t PinManager::ledcAlloc = 0;
-#endif
-uint8_t PinManager::i2cAllocCount = 0;
-uint8_t PinManager::spiAllocCount = 0;
-PinOwner PinManager::ownerTag[WLED_NUM_PINS] = { PinOwner::None };

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -9,6 +9,12 @@
 #endif
 #include "const.h" // for USERMOD_* values
 
+#ifdef ESP8266
+#define WLED_NUM_PINS (GPIO_PIN_COUNT+1) // somehow they forgot GPIO 16 (0-16==17)
+#else
+#define WLED_NUM_PINS (GPIO_PIN_COUNT)
+#endif
+
 typedef struct PinManagerPinType {
   int8_t pin;
   bool   isOutput;
@@ -70,53 +76,39 @@ enum struct PinOwner : uint8_t {
 };
 static_assert(0u == static_cast<uint8_t>(PinOwner::None), "PinOwner::None must be zero, so default array initialization works as expected");
 
-class PinManager {
-  private:
-    #ifdef ESP8266
-    #define WLED_NUM_PINS (GPIO_PIN_COUNT+1) // somehow they forgot GPIO 16 (0-16==17)
-    static uint32_t pinAlloc;     // 1 bit per pin, we use first 17bits
-    #else
-    #define WLED_NUM_PINS (GPIO_PIN_COUNT)
-    static uint64_t pinAlloc;     // 1 bit per pin, we use 50 bits on ESP32-S3
-    static uint16_t ledcAlloc;    // up to 16 LEDC channels (WLED_MAX_ANALOG_CHANNELS)
-    #endif
-    static uint8_t i2cAllocCount; // allow multiple allocation of I2C bus pins but keep track of allocations
-    static uint8_t spiAllocCount; // allow multiple allocation of SPI bus pins but keep track of allocations
-    static PinOwner ownerTag[WLED_NUM_PINS];
+namespace PinManager {
+  // De-allocates a single pin
+  bool deallocatePin(byte gpio, PinOwner tag);
+  // De-allocates multiple pins but only if all can be deallocated (PinOwner has to be specified)
+  bool deallocateMultiplePins(const uint8_t *pinArray, byte arrayElementCount, PinOwner tag);
+  bool deallocateMultiplePins(const managed_pin_type *pinArray, byte arrayElementCount, PinOwner tag);
+  // Allocates a single pin, with an owner tag.
+  // De-allocation requires the same owner tag (or override)
+  bool allocatePin(byte gpio, bool output, PinOwner tag);
+  // Allocates all the pins, or allocates none of the pins, with owner tag.
+  // Provided to simplify error condition handling in clients
+  // using more than one pin, such as I2C, SPI, rotary encoders,
+  // ethernet, etc..
+  bool allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount, PinOwner tag );
 
-  public:
-    // De-allocates a single pin
-    static bool deallocatePin(byte gpio, PinOwner tag);
-    // De-allocates multiple pins but only if all can be deallocated (PinOwner has to be specified)
-    static bool deallocateMultiplePins(const uint8_t *pinArray, byte arrayElementCount, PinOwner tag);
-    static bool deallocateMultiplePins(const managed_pin_type *pinArray, byte arrayElementCount, PinOwner tag);
-    // Allocates a single pin, with an owner tag.
-    // De-allocation requires the same owner tag (or override)
-    static bool allocatePin(byte gpio, bool output, PinOwner tag);
-    // Allocates all the pins, or allocates none of the pins, with owner tag.
-    // Provided to simplify error condition handling in clients
-    // using more than one pin, such as I2C, SPI, rotary encoders,
-    // ethernet, etc..
-    static bool allocateMultiplePins(const managed_pin_type * mptArray, byte arrayElementCount, PinOwner tag );
+  [[deprecated("Replaced by three-parameter allocatePin(gpio, output, ownerTag), for improved debugging")]]
+  inline bool allocatePin(byte gpio, bool output = true) { return allocatePin(gpio, output, PinOwner::None); }
+  [[deprecated("Replaced by two-parameter deallocatePin(gpio, ownerTag), for improved debugging")]]
+  inline void deallocatePin(byte gpio) { deallocatePin(gpio, PinOwner::None); }
 
-    [[deprecated("Replaced by three-parameter allocatePin(gpio, output, ownerTag), for improved debugging")]]
-    static inline bool allocatePin(byte gpio, bool output = true) { return allocatePin(gpio, output, PinOwner::None); }
-    [[deprecated("Replaced by two-parameter deallocatePin(gpio, ownerTag), for improved debugging")]]
-    static inline void deallocatePin(byte gpio) { deallocatePin(gpio, PinOwner::None); }
+  // will return true for reserved pins
+  bool isPinAllocated(byte gpio, PinOwner tag = PinOwner::None);
+  // will return false for reserved pins
+  bool isPinOk(byte gpio, bool output = true);
+  
+  bool isReadOnlyPin(byte gpio);
 
-    // will return true for reserved pins
-    static bool isPinAllocated(byte gpio, PinOwner tag = PinOwner::None);
-    // will return false for reserved pins
-    static bool isPinOk(byte gpio, bool output = true);
-    
-    static bool isReadOnlyPin(byte gpio);
+  PinOwner getPinOwner(byte gpio);
 
-    static PinOwner getPinOwner(byte gpio);
-
-    #ifdef ARDUINO_ARCH_ESP32
-    static byte allocateLedc(byte channels);
-    static void deallocateLedc(byte pos, byte channels);
-    #endif
+  #ifdef ARDUINO_ARCH_ESP32
+  byte allocateLedc(byte channels);
+  void deallocateLedc(byte pos, byte channels);
+  #endif
 };
 
 //extern PinManager pinManager;

--- a/wled00/um_manager.cpp
+++ b/wled00/um_manager.cpp
@@ -3,6 +3,9 @@
  * Registration and management utility for v2 usermods
  */
 
+static Usermod* ums[WLED_MAX_USERMODS] = {nullptr};
+byte UsermodManager::numMods = 0;
+
 //Usermod Manager internals
 void UsermodManager::setup()             { for (unsigned i = 0; i < numMods; i++) ums[i]->setup(); }
 void UsermodManager::connected()         { for (unsigned i = 0; i < numMods; i++) ums[i]->connected(); }
@@ -69,8 +72,6 @@ bool UsermodManager::add(Usermod* um)
   return true;
 }
 
-Usermod* UsermodManager::ums[WLED_MAX_USERMODS] = {nullptr};
-byte UsermodManager::numMods = 0;
 
 /* Usermod v2 interface shim for oappend */
 Print* Usermod::oappend_shim = nullptr;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -896,9 +896,6 @@ WLED_GLOBAL uint32_t ledMaps _INIT(0); // bitfield representation of available l
 WLED_GLOBAL uint16_t ledMaps _INIT(0); // bitfield representation of available ledmaps
 #endif
 
-// Usermod manager
-WLED_GLOBAL UsermodManager usermods _INIT(UsermodManager());
-
 // global I2C SDA pin (used for usermods)
 #ifndef I2CSDAPIN
 WLED_GLOBAL int8_t i2c_sda  _INIT(-1);


### PR DESCRIPTION
In C++, the standard collection for a group of global functions is a namespace.  Complete the transition of UsermodManager and PinManager away from classes, as they're no longer meaningful data structures.

This is purely a syntactic change and should have no functional effects.