### PR TITLE
Esp8266 oappend fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -197,6 +197,7 @@ build_flags =
   ; decrease code cache size and increase IRAM to fit all pixel functions
   -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48 ;; in case of linker errors like "section `.text1' will not fit in region `iram1_0_seg'"
   ; -D PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48_SECHEAP_SHARED ;; (experimental) adds some extra heap, but may cause slowdown
+  -D NON32XFER_HANDLER ;; ask forgiveness for PROGMEM misuse
 
 lib_deps =
   #https://github.com/lorol/LITTLEFS.git

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -324,6 +324,10 @@ class Usermod {
   protected:
     // Shim for oappend(), which used to exist in utils.cpp
     template<typename T> static inline void oappend(const T& t) { oappend_shim->print(t); };
+#ifdef ESP8266
+    // Handle print(PSTR()) without crashing by detecting PROGMEM strings
+    static void oappend(const char* c) { if ((intptr_t) c >= 0x40000000) oappend_shim->print(FPSTR(c)); else oappend_shim->print(c); };
+#endif
 };
 
 class UsermodManager {


### PR DESCRIPTION
The `oappend` shim logic introduced in #4152 also has issues with `SET_F()`, as it casts away the helper type needed for `print()` to identify PROGMEM strings.  Improve the shim logic to safely handle this case in two different ways:

1. Detect PROGMEM addresses and re-apply the helper type, allowing the correct overload of `print()` to be called;
2. Ask the platform to forgive us if we make a mistake, and handle it gracefully (if very slowly).

Fixes #4219.