### PR TITLE
Usermod F-string hygiene

### DIFF
--- a/usermods/Animated_Staircase/Animated_Staircase.h
+++ b/usermods/Animated_Staircase/Animated_Staircase.h
@@ -425,10 +425,10 @@ class Animated_Staircase : public Usermod {
     }
 
     void appendConfigData() {
-      //oappend(SET_F("dd=addDropdown('staircase','selectfield');"));
-      //oappend(SET_F("addOption(dd,'1st value',0);"));
-      //oappend(SET_F("addOption(dd,'2nd value',1);"));
-      //oappend(SET_F("addInfo('staircase:selectfield',1,'additional info');"));  // 0 is field type, 1 is actual field
+      //oappend(F("dd=addDropdown('staircase','selectfield');"));
+      //oappend(F("addOption(dd,'1st value',0);"));
+      //oappend(F("addOption(dd,'2nd value',1);"));
+      //oappend(F("addInfo('staircase:selectfield',1,'additional info');"));  // 0 is field type, 1 is actual field
     }
 
 

--- a/usermods/BME68X_v2/usermod_bme68x.h
+++ b/usermods/BME68X_v2/usermod_bme68x.h
@@ -767,22 +767,22 @@ void UsermodBME68X::appendConfigData() {
 	// snprintf_P(charbuffer, 127, PSTR("addInfo('%s:%s',1,'*) Set to minus to deactivate (all sensors)');"), UMOD_NAME, _nameTemp); oappend(charbuffer);
 
 	/* Dropdown for Celsius/Fahrenheit*/
-	oappend(SET_F("dd=addDropdown('"));
+	oappend(F("dd=addDropdown('"));
 	oappend(UMOD_NAME);
-	oappend(SET_F("','"));
+	oappend(F("','"));
 	oappend(_nameTempScale);
-	oappend(SET_F("');"));
-	oappend(SET_F("addOption(dd,'Celsius',0);"));
-	oappend(SET_F("addOption(dd,'Fahrenheit',1);"));
+	oappend(F("');"));
+	oappend(F("addOption(dd,'Celsius',0);"));
+	oappend(F("addOption(dd,'Fahrenheit',1);"));
 
 	/* i²C Address*/
-	oappend(SET_F("dd=addDropdown('"));
+	oappend(F("dd=addDropdown('"));
 	oappend(UMOD_NAME);
-	oappend(SET_F("','"));
+	oappend(F("','"));
 	oappend(_nameI2CAdr);
-	oappend(SET_F("');"));
-	oappend(SET_F("addOption(dd,'0x76',0x76);"));
-	oappend(SET_F("addOption(dd,'0x77',0x77);"));
+	oappend(F("');"));
+	oappend(F("addOption(dd,'0x76',0x76);"));
+	oappend(F("addOption(dd,'0x77',0x77);"));
 }
 
 /**

--- a/usermods/Battery/usermod_v2_Battery.h
+++ b/usermods/Battery/usermod_v2_Battery.h
@@ -478,29 +478,29 @@ class UsermodBattery : public Usermod
     void appendConfigData()
     {
       // Total: 462 Bytes
-      oappend(SET_F("td=addDropdown('Battery','type');"));              // 34 Bytes
-      oappend(SET_F("addOption(td,'Unkown','0');"));                    // 28 Bytes
-      oappend(SET_F("addOption(td,'LiPo','1');"));                      // 26 Bytes
-      oappend(SET_F("addOption(td,'LiOn','2');"));                      // 26 Bytes
-      oappend(SET_F("addInfo('Battery:type',1,'<small style=\"color:orange\">requires reboot</small>');")); // 81 Bytes
-      oappend(SET_F("addInfo('Battery:min-voltage',1,'v');"));          // 38 Bytes
-      oappend(SET_F("addInfo('Battery:max-voltage',1,'v');"));          // 38 Bytes
-      oappend(SET_F("addInfo('Battery:interval',1,'ms');"));            // 36 Bytes
-      oappend(SET_F("addInfo('Battery:HA-discovery',1,'');"));          // 38 Bytes
-      oappend(SET_F("addInfo('Battery:auto-off:threshold',1,'%');"));   // 45 Bytes
-      oappend(SET_F("addInfo('Battery:indicator:threshold',1,'%');"));  // 46 Bytes
-      oappend(SET_F("addInfo('Battery:indicator:duration',1,'s');"));   // 45 Bytes
+      oappend(F("td=addDropdown('Battery','type');"));              // 34 Bytes
+      oappend(F("addOption(td,'Unkown','0');"));                    // 28 Bytes
+      oappend(F("addOption(td,'LiPo','1');"));                      // 26 Bytes
+      oappend(F("addOption(td,'LiOn','2');"));                      // 26 Bytes
+      oappend(F("addInfo('Battery:type',1,'<small style=\"color:orange\">requires reboot</small>');")); // 81 Bytes
+      oappend(F("addInfo('Battery:min-voltage',1,'v');"));          // 38 Bytes
+      oappend(F("addInfo('Battery:max-voltage',1,'v');"));          // 38 Bytes
+      oappend(F("addInfo('Battery:interval',1,'ms');"));            // 36 Bytes
+      oappend(F("addInfo('Battery:HA-discovery',1,'');"));          // 38 Bytes
+      oappend(F("addInfo('Battery:auto-off:threshold',1,'%');"));   // 45 Bytes
+      oappend(F("addInfo('Battery:indicator:threshold',1,'%');"));  // 46 Bytes
+      oappend(F("addInfo('Battery:indicator:duration',1,'s');"));   // 45 Bytes
       
       // this option list would exeed the oappend() buffer
       // a list of all presets to select one from
-      // oappend(SET_F("bd=addDropdown('Battery:low-power-indicator', 'preset');"));
-      // the loop generates: oappend(SET_F("addOption(bd, 'preset name', preset id);"));
+      // oappend(F("bd=addDropdown('Battery:low-power-indicator', 'preset');"));
+      // the loop generates: oappend(F("addOption(bd, 'preset name', preset id);"));
       // for(int8_t i=1; i < 42; i++) {
-      //   oappend(SET_F("addOption(bd, 'Preset#"));
+      //   oappend(F("addOption(bd, 'Preset#"));
       //   oappendi(i);
-      //   oappend(SET_F("',"));
+      //   oappend(F("',"));
       //   oappendi(i);
-      //   oappend(SET_F(");"));
+      //   oappend(F(");"));
       // }
     }
 

--- a/usermods/EXAMPLE_v2/usermod_v2_example.h
+++ b/usermods/EXAMPLE_v2/usermod_v2_example.h
@@ -287,11 +287,11 @@ class MyExampleUsermod : public Usermod {
      */
     void appendConfigData() override
     {
-      oappend(SET_F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(SET_F(":great")); oappend(SET_F("',1,'<i>(this is a great config value)</i>');"));
-      oappend(SET_F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(SET_F(":testString")); oappend(SET_F("',1,'enter any string you want');"));
-      oappend(SET_F("dd=addDropdown('")); oappend(String(FPSTR(_name)).c_str()); oappend(SET_F("','testInt');"));
-      oappend(SET_F("addOption(dd,'Nothing',0);"));
-      oappend(SET_F("addOption(dd,'Everything',42);"));
+      oappend(F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(F(":great")); oappend(F("',1,'<i>(this is a great config value)</i>');"));
+      oappend(F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(F(":testString")); oappend(F("',1,'enter any string you want');"));
+      oappend(F("dd=addDropdown('")); oappend(String(FPSTR(_name)).c_str()); oappend(F("','testInt');"));
+      oappend(F("addOption(dd,'Nothing',0);"));
+      oappend(F("addOption(dd,'Everything',42);"));
     }
 
 

--- a/usermods/Internal_Temperature_v2/usermod_internal_temperature.h
+++ b/usermods/Internal_Temperature_v2/usermod_internal_temperature.h
@@ -149,11 +149,11 @@ public:
     void appendConfigData()
     {
     // Display 'ms' next to the 'Loop Interval' setting
-    oappend(SET_F("addInfo('Internal Temperature:Loop Interval', 1, 'ms');"));
+    oappend(F("addInfo('Internal Temperature:Loop Interval', 1, 'ms');"));
     // Display '°C' next to the 'Activation Threshold' setting
-    oappend(SET_F("addInfo('Internal Temperature:Activation Threshold', 1, '°C');"));
+    oappend(F("addInfo('Internal Temperature:Activation Threshold', 1, '°C');"));
     // Display '0 = Disabled' next to the 'Preset To Activate' setting
-    oappend(SET_F("addInfo('Internal Temperature:Preset To Activate', 1, '0 = unused');"));
+    oappend(F("addInfo('Internal Temperature:Preset To Activate', 1, '0 = unused');"));
     }
 
   bool readFromConfig(JsonObject &root)

--- a/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
+++ b/usermods/PIR_sensor_switch/usermod_PIR_sensor_switch.h
@@ -511,8 +511,8 @@ void PIRsensorSwitch::addToConfig(JsonObject &root)
 
 void PIRsensorSwitch::appendConfigData()
 {
-  oappend(SET_F("addInfo('PIRsensorSwitch:HA-discovery',1,'HA=Home Assistant');"));     // 0 is field type, 1 is actual field
-  oappend(SET_F("addInfo('PIRsensorSwitch:override',1,'Cancel timer on change');"));    // 0 is field type, 1 is actual field
+  oappend(F("addInfo('PIRsensorSwitch:HA-discovery',1,'HA=Home Assistant');"));     // 0 is field type, 1 is actual field
+  oappend(F("addInfo('PIRsensorSwitch:override',1,'Cancel timer on change');"));    // 0 is field type, 1 is actual field
   for (int i = 0; i < PIR_SENSOR_MAX_SENSORS; i++) {
     char str[128];
     sprintf_P(str, PSTR("addInfo('PIRsensorSwitch:pin[]',%d,'','#%d');"), i, i);

--- a/usermods/ST7789_display/ST7789_display.h
+++ b/usermods/ST7789_display/ST7789_display.h
@@ -377,10 +377,10 @@ class St7789DisplayUsermod : public Usermod {
 
 
     void appendConfigData() override {
-      oappend(SET_F("addInfo('ST7789:pin[]',0,'','SPI CS');"));
-      oappend(SET_F("addInfo('ST7789:pin[]',1,'','SPI DC');"));
-      oappend(SET_F("addInfo('ST7789:pin[]',2,'','SPI RST');"));
-      oappend(SET_F("addInfo('ST7789:pin[]',3,'','SPI BL');"));
+      oappend(F("addInfo('ST7789:pin[]',0,'','SPI CS');"));
+      oappend(F("addInfo('ST7789:pin[]',1,'','SPI DC');"));
+      oappend(F("addInfo('ST7789:pin[]',2,'','SPI RST');"));
+      oappend(F("addInfo('ST7789:pin[]',3,'','SPI BL');"));
     }
 
     /*

--- a/usermods/Temperature/usermod_temperature.h
+++ b/usermods/Temperature/usermod_temperature.h
@@ -435,10 +435,10 @@ bool UsermodTemperature::readFromConfig(JsonObject &root) {
 }
 
 void UsermodTemperature::appendConfigData() {
-  oappend(SET_F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(SET_F(":")); oappend(String(FPSTR(_parasite)).c_str());
-  oappend(SET_F("',1,'<i>(if no Vcc connected)</i>');"));  // 0 is field type, 1 is actual field
-  oappend(SET_F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(SET_F(":")); oappend(String(FPSTR(_parasitePin)).c_str());
-  oappend(SET_F("',1,'<i>(for external MOSFET)</i>');"));  // 0 is field type, 1 is actual field
+  oappend(F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(F(":")); oappend(String(FPSTR(_parasite)).c_str());
+  oappend(F("',1,'<i>(if no Vcc connected)</i>');"));  // 0 is field type, 1 is actual field
+  oappend(F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(F(":")); oappend(String(FPSTR(_parasitePin)).c_str());
+  oappend(F("',1,'<i>(for external MOSFET)</i>');"));  // 0 is field type, 1 is actual field
 }
 
 float UsermodTemperature::getTemperature() {

--- a/usermods/boblight/boblight.h
+++ b/usermods/boblight/boblight.h
@@ -305,14 +305,14 @@ class BobLightUsermod : public Usermod {
     }
 
     void appendConfigData() override {
-      //oappend(SET_F("dd=addDropdown('usermod','selectfield');"));
-      //oappend(SET_F("addOption(dd,'1st value',0);"));
-      //oappend(SET_F("addOption(dd,'2nd value',1);"));
-      oappend(SET_F("addInfo('BobLight:top',1,'LEDs');"));                // 0 is field type, 1 is actual field
-      oappend(SET_F("addInfo('BobLight:bottom',1,'LEDs');"));             // 0 is field type, 1 is actual field
-      oappend(SET_F("addInfo('BobLight:left',1,'LEDs');"));               // 0 is field type, 1 is actual field
-      oappend(SET_F("addInfo('BobLight:right',1,'LEDs');"));              // 0 is field type, 1 is actual field
-      oappend(SET_F("addInfo('BobLight:pct',1,'Depth of scan [%]');"));   // 0 is field type, 1 is actual field
+      //oappend(F("dd=addDropdown('usermod','selectfield');"));
+      //oappend(F("addOption(dd,'1st value',0);"));
+      //oappend(F("addOption(dd,'2nd value',1);"));
+      oappend(F("addInfo('BobLight:top',1,'LEDs');"));                // 0 is field type, 1 is actual field
+      oappend(F("addInfo('BobLight:bottom',1,'LEDs');"));             // 0 is field type, 1 is actual field
+      oappend(F("addInfo('BobLight:left',1,'LEDs');"));               // 0 is field type, 1 is actual field
+      oappend(F("addInfo('BobLight:right',1,'LEDs');"));              // 0 is field type, 1 is actual field
+      oappend(F("addInfo('BobLight:pct',1,'Depth of scan [%]');"));   // 0 is field type, 1 is actual field
     }
 
     void addToConfig(JsonObject& root) override {

--- a/usermods/multi_relay/usermod_multi_relay.h
+++ b/usermods/multi_relay/usermod_multi_relay.h
@@ -264,7 +264,7 @@ void MultiRelay::handleOffTimer() {
 void MultiRelay::InitHtmlAPIHandle() {  // https://github.com/me-no-dev/ESPAsyncWebServer
   DEBUG_PRINTLN(F("Relays: Initialize HTML API"));
 
-  server.on(SET_F("/relays"), HTTP_GET, [this](AsyncWebServerRequest *request) {
+  server.on(F("/relays"), HTTP_GET, [this](AsyncWebServerRequest *request) {
     DEBUG_PRINTLN(F("Relays: HTML API"));
     String janswer;
     String error = "";
@@ -765,10 +765,10 @@ void MultiRelay::addToConfig(JsonObject &root) {
 }
 
 void MultiRelay::appendConfigData() {
-  oappend(SET_F("addInfo('MultiRelay:PCF8574-address',1,'<i>(not hex!)</i>');"));
-  oappend(SET_F("addInfo('MultiRelay:broadcast-sec',1,'(MQTT message)');"));
-  //oappend(SET_F("addInfo('MultiRelay:relay-0:pin',1,'(use -1 for PCF8574)');"));
-  oappend(SET_F("d.extra.push({'MultiRelay':{pin:[['P0',100],['P1',101],['P2',102],['P3',103],['P4',104],['P5',105],['P6',106],['P7',107]]}});"));
+  oappend(F("addInfo('MultiRelay:PCF8574-address',1,'<i>(not hex!)</i>');"));
+  oappend(F("addInfo('MultiRelay:broadcast-sec',1,'(MQTT message)');"));
+  //oappend(F("addInfo('MultiRelay:relay-0:pin',1,'(use -1 for PCF8574)');"));
+  oappend(F("d.extra.push({'MultiRelay':{pin:[['P0',100],['P1',101],['P2',102],['P3',103],['P4',104],['P5',105],['P6',106],['P7',107]]}});"));
 }
 
 /**

--- a/usermods/pixels_dice_tray/pixels_dice_tray.h
+++ b/usermods/pixels_dice_tray/pixels_dice_tray.h
@@ -387,23 +387,23 @@ class PixelsDiceTrayUsermod : public Usermod {
     // To work around this, add info text to the end of the preceding item.
     //
     // See addInfo in wled00/data/settings_um.htm for details on what this function does.
-    oappend(SET_F(
+    oappend(F(
         "addInfo('DiceTray:ble_scan_duration',1,'<br><br><i>Set to \"*\" to "
         "connect to any die.<br>Leave Blank to disable.</i><br><i "
         "class=\"warn\">Saving will replace \"*\" with die names.</i>','');"));
 #if USING_TFT_DISPLAY
-    oappend(SET_F("ddr=addDropdown('DiceTray','rotation');"));
-    oappend(SET_F("addOption(ddr,'0 deg',0);"));
-    oappend(SET_F("addOption(ddr,'90 deg',1);"));
-    oappend(SET_F("addOption(ddr,'180 deg',2);"));
-    oappend(SET_F("addOption(ddr,'270 deg',3);"));
-    oappend(SET_F(
+    oappend(F("ddr=addDropdown('DiceTray','rotation');"));
+    oappend(F("addOption(ddr,'0 deg',0);"));
+    oappend(F("addOption(ddr,'90 deg',1);"));
+    oappend(F("addOption(ddr,'180 deg',2);"));
+    oappend(F("addOption(ddr,'270 deg',3);"));
+    oappend(F(
         "addInfo('DiceTray:rotation',1,'<br><i class=\"warn\">DO NOT CHANGE "
         "SPI PINS.</i><br><i class=\"warn\">CHANGES ARE IGNORED.</i>','');"));
-    oappend(SET_F("addInfo('TFT:pin[]',0,'','SPI CS');"));
-    oappend(SET_F("addInfo('TFT:pin[]',1,'','SPI DC');"));
-    oappend(SET_F("addInfo('TFT:pin[]',2,'','SPI RST');"));
-    oappend(SET_F("addInfo('TFT:pin[]',3,'','SPI BL');"));
+    oappend(F("addInfo('TFT:pin[]',0,'','SPI CS');"));
+    oappend(F("addInfo('TFT:pin[]',1,'','SPI DC');"));
+    oappend(F("addInfo('TFT:pin[]',2,'','SPI RST');"));
+    oappend(F("addInfo('TFT:pin[]',3,'','SPI BL');"));
 #endif
   }
 

--- a/usermods/sht/usermod_sht.h
+++ b/usermods/sht/usermod_sht.h
@@ -310,22 +310,22 @@ void ShtUsermod::onMqttConnect(bool sessionPresent) {
  * @return void
  */
 void ShtUsermod::appendConfigData() {
-  oappend(SET_F("dd=addDropdown('"));
+  oappend(F("dd=addDropdown('"));
   oappend(_name);
-  oappend(SET_F("','"));
+  oappend(F("','"));
   oappend(_shtType);
-  oappend(SET_F("');"));
-  oappend(SET_F("addOption(dd,'SHT30',0);"));
-  oappend(SET_F("addOption(dd,'SHT31',1);"));
-  oappend(SET_F("addOption(dd,'SHT35',2);"));
-  oappend(SET_F("addOption(dd,'SHT85',3);"));
-  oappend(SET_F("dd=addDropdown('"));
+  oappend(F("');"));
+  oappend(F("addOption(dd,'SHT30',0);"));
+  oappend(F("addOption(dd,'SHT31',1);"));
+  oappend(F("addOption(dd,'SHT35',2);"));
+  oappend(F("addOption(dd,'SHT85',3);"));
+  oappend(F("dd=addDropdown('"));
   oappend(_name);
-  oappend(SET_F("','"));
+  oappend(F("','"));
   oappend(_unitOfTemp);
-  oappend(SET_F("');"));
-  oappend(SET_F("addOption(dd,'Celsius',0);"));
-  oappend(SET_F("addOption(dd,'Fahrenheit',1);"));
+  oappend(F("');"));
+  oappend(F("addOption(dd,'Celsius',0);"));
+  oappend(F("addOption(dd,'Fahrenheit',1);"));
 }
 
 /**

--- a/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
+++ b/usermods/usermod_v2_four_line_display_ALT/usermod_v2_four_line_display_ALT.h
@@ -1202,21 +1202,21 @@ void FourLineDisplayUsermod::onUpdateBegin(bool init) {
 //}
 
 void FourLineDisplayUsermod::appendConfigData() {
-  oappend(SET_F("dd=addDropdown('4LineDisplay','type');"));
-  oappend(SET_F("addOption(dd,'None',0);"));
-  oappend(SET_F("addOption(dd,'SSD1306',1);"));
-  oappend(SET_F("addOption(dd,'SH1106',2);"));
-  oappend(SET_F("addOption(dd,'SSD1306 128x64',3);"));
-  oappend(SET_F("addOption(dd,'SSD1305',4);"));
-  oappend(SET_F("addOption(dd,'SSD1305 128x64',5);"));
-  oappend(SET_F("addOption(dd,'SSD1309 128x64',9);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI',6);"));
-  oappend(SET_F("addOption(dd,'SSD1306 SPI 128x64',7);"));
-  oappend(SET_F("addOption(dd,'SSD1309 SPI 128x64',8);"));
-  oappend(SET_F("addInfo('4LineDisplay:type',1,'<br><i class=\"warn\">Change may require reboot</i>','');"));
-  oappend(SET_F("addInfo('4LineDisplay:pin[]',0,'','SPI CS');"));
-  oappend(SET_F("addInfo('4LineDisplay:pin[]',1,'','SPI DC');"));
-  oappend(SET_F("addInfo('4LineDisplay:pin[]',2,'','SPI RST');"));
+  oappend(F("dd=addDropdown('4LineDisplay','type');"));
+  oappend(F("addOption(dd,'None',0);"));
+  oappend(F("addOption(dd,'SSD1306',1);"));
+  oappend(F("addOption(dd,'SH1106',2);"));
+  oappend(F("addOption(dd,'SSD1306 128x64',3);"));
+  oappend(F("addOption(dd,'SSD1305',4);"));
+  oappend(F("addOption(dd,'SSD1305 128x64',5);"));
+  oappend(F("addOption(dd,'SSD1309 128x64',9);"));
+  oappend(F("addOption(dd,'SSD1306 SPI',6);"));
+  oappend(F("addOption(dd,'SSD1306 SPI 128x64',7);"));
+  oappend(F("addOption(dd,'SSD1309 SPI 128x64',8);"));
+  oappend(F("addInfo('4LineDisplay:type',1,'<br><i class=\"warn\">Change may require reboot</i>','');"));
+  oappend(F("addInfo('4LineDisplay:pin[]',0,'','SPI CS');"));
+  oappend(F("addInfo('4LineDisplay:pin[]',1,'','SPI DC');"));
+  oappend(F("addInfo('4LineDisplay:pin[]',2,'','SPI RST');"));
 }
 
 /*

--- a/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
+++ b/usermods/usermod_v2_rotary_encoder_ui_ALT/usermod_v2_rotary_encoder_ui_ALT.h
@@ -1090,8 +1090,8 @@ void RotaryEncoderUIUsermod::addToConfig(JsonObject &root) {
 }
 
 void RotaryEncoderUIUsermod::appendConfigData() {
-  oappend(SET_F("addInfo('Rotary-Encoder:PCF8574-address',1,'<i>(not hex!)</i>');"));
-  oappend(SET_F("d.extra.push({'Rotary-Encoder':{pin:[['P0',100],['P1',101],['P2',102],['P3',103],['P4',104],['P5',105],['P6',106],['P7',107]]}});"));
+  oappend(F("addInfo('Rotary-Encoder:PCF8574-address',1,'<i>(not hex!)</i>');"));
+  oappend(F("d.extra.push({'Rotary-Encoder':{pin:[['P0',100],['P1',101],['P2',102],['P3',103],['P4',104],['P5',105],['P6',106],['P7',107]]}});"));
 }
 
 /**

--- a/usermods/usermod_v2_word_clock/usermod_v2_word_clock.h
+++ b/usermods/usermod_v2_word_clock/usermod_v2_word_clock.h
@@ -433,8 +433,8 @@ class WordClockUsermod : public Usermod
 
     void appendConfigData()
     {
-      oappend(SET_F("addInfo('WordClockUsermod:ledOffset', 1, 'Number of LEDs before the letters');"));
-      oappend(SET_F("addInfo('WordClockUsermod:Norddeutsch', 1, 'Viertel vor instead of Dreiviertel');"));
+      oappend(F("addInfo('WordClockUsermod:ledOffset', 1, 'Number of LEDs before the letters');"));
+      oappend(F("addInfo('WordClockUsermod:Norddeutsch', 1, 'Viertel vor instead of Dreiviertel');"));
     }
 
     /*

--- a/usermods/wireguard/wireguard.h
+++ b/usermods/wireguard/wireguard.h
@@ -54,13 +54,13 @@ class WireguardUsermod : public Usermod {
     }
 
     void appendConfigData() {
-        oappend(SET_F("addInfo('WireGuard:host',1,'Server Hostname');"));           // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:port',1,'Server Port');"));               // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:ip',1,'Device IP');"));                   // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:psk',1,'Pre Shared Key (optional)');"));  // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:pem',1,'Private Key');"));                // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:pub',1,'Public Key');"));                 // 0 is field type, 1 is actual field
-        oappend(SET_F("addInfo('WireGuard:tz',1,'POSIX timezone string');"));       // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:host',1,'Server Hostname');"));           // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:port',1,'Server Port');"));               // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:ip',1,'Device IP');"));                   // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:psk',1,'Pre Shared Key (optional)');"));  // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:pem',1,'Private Key');"));                // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:pub',1,'Public Key');"));                 // 0 is field type, 1 is actual field
+        oappend(F("addInfo('WireGuard:tz',1,'POSIX timezone string');"));       // 0 is field type, 1 is actual field
     }
 
     void addToConfig(JsonObject& root) {


### PR DESCRIPTION
Another missing remnant of the end-oappend work: migrating usermods to use F() instead of F_STR() so as to pass the FlashStringHelper type along to the print() layer.  Usermods calling `oappend(F_STR("")` on ESP8266 will crash without the shim in #4222.  This could be considered an alternative fix: correct the source, rather than provide a workaround at a runtime cost.