### PR TITLE
WLED 0.15.0-b7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## WLED changelog
 
+#### Build 2410270
+-   WLED 0.15.0-b7 release
+-   Add visual expand button on hover (#4172)
+-   `/json/live` (JSON live data/peek) only enabled when WebSockets are disabled
+-   Bugfixes: #4179, #4215, #4219, #4224, #4228, #4230
+
 #### Build 2410140
 -   WLED 0.15.0-b6 release
 -   Added BRT timezone (#4188 by @LuisFadini)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 #### Build 2410270
 -   WLED 0.15.0-b7 release
+-   Re-license the WLED project from MIT to EUPL (#4194 by @Aircoookie)
+-   Fix alexa devices invisible/uncontrollable (#4214 by @Svennte)
 -   Add visual expand button on hover (#4172)
+-   Usermod: Audioreactive tuning and performance enhancements (by @softhack007)
 -   `/json/live` (JSON live data/peek) only enabled when WebSockets are disabled
--   Bugfixes: #4179, #4215, #4219, #4224, #4228, #4230
+-   Various bugfixes and optimisations: #4179, #4215, #4219, #4222, #4223, #4224, #4228, #4230
 
 #### Build 2410140
 -   WLED 0.15.0-b6 release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wled",
-  "version": "0.15.0-b6",
+  "version": "0.15.0-b7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wled",
-      "version": "0.15.0-b6",
+      "version": "0.15.0-b7",
       "license": "ISC",
       "dependencies": {
         "clean-css": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wled",
-  "version": "0.15.0-b6",
+  "version": "0.15.0-b7",
   "description": "Tools for WLED project",
   "main": "tools/cdata.js",
   "directories": {

--- a/wled00/data/index.css
+++ b/wled00/data/index.css
@@ -1040,7 +1040,7 @@ textarea {
 
 .segname .flr, .pname .flr {
 	transform: rotate(0deg);
-	right: -6px;
+	/*right: -6px;*/
 }
 
 /* segment power wrapper */
@@ -1333,6 +1333,11 @@ TD .checkmark, TD .radiomark {
 .lstI.selected {
 	z-index: 1;
 	box-shadow: 0 0 10px 4px var(--c-1);
+}
+
+.lstI .flr:hover {
+    background: var(--c-6);
+    border-radius: 100%;
 }
 
 #pcont .selected:not([class*="expanded"]) {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -3,12 +3,12 @@
 /*
    Main sketch, global variable declarations
    @title WLED project sketch
-   @version 0.15.0-b6
+   @version 0.15.0-b7
    @author Christian Schwinne
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2410260
+#define VERSION 2410270
 
 //uncomment this if you have a "my_config.h" file you'd like to use
 //#define WLED_USE_MY_CONFIG
@@ -36,12 +36,13 @@
   #undef WLED_ENABLE_ADALIGHT      // disable has priority over enable
 #endif
 //#define WLED_ENABLE_DMX          // uses 3.5kb
-//#define WLED_ENABLE_JSONLIVE     // peek LED output via /json/live (WS binary peek is always enabled)
 #ifndef WLED_DISABLE_LOXONE
   #define WLED_ENABLE_LOXONE       // uses 1.2kb
 #endif
 #ifndef WLED_DISABLE_WEBSOCKETS
   #define WLED_ENABLE_WEBSOCKETS
+#else
+  #define WLED_ENABLE_JSONLIVE     // peek LED output via /json/live (WS binary peek is always enabled)
 #endif
 
 //#define WLED_DISABLE_ESPNOW      // Removes dependence on esp now

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -501,7 +501,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     #endif
     printSetFormValue(settingsScript,PSTR("BD"),serialBaud);
     #ifndef WLED_ENABLE_ADALIGHT
-    settingsScript.print(F("toggle('Serial);"));
+    settingsScript.print(F("toggle('Serial');"));
     #endif
   }
 


### PR DESCRIPTION
- fix for #4172
- fix for #4230
- /json/live enabled when WS disabled