### PR TITLE
Add support for ESP32-S3 WROOM-2 (solves #4099)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -556,6 +556,32 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 monitor_filters = esp32_exception_decoder
 
+[env:esp32S3_wroom2]
+;; For ESP32-S3 WROOM-2, a.k.a. ESP32-S3 DevKitC-1 v1.1
+;; with >= 16MB FLASH and >= 8MB PSRAM (memory_type: opi_opi)
+platform = ${esp32s3.platform}
+platform_packages = ${esp32s3.platform_packages}
+board = esp32s3camlcd ;; this is the only standard board with "opi_opi"
+board_build.arduino.memory_type = opi_opi
+upload_speed = 921600
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=ESP32-S3_WROOM-2
+  -D CONFIG_LITTLEFS_FOR_IDF_3_2 -D WLED_WATCHDOG_TIMEOUT=0
+  -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
+  ;; -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
+  -DBOARD_HAS_PSRAM
+  -D LEDPIN=38 ;; buildin LED
+  -D BTNPIN=0 -D RLYPIN=16 -D IRPIN=17 -D AUDIOPIN=-1
+  ${esp32.AR_build_flags}
+  -D SR_DMTYPE=1 -D I2S_SDPIN=13 -D I2S_CKPIN=14 -D I2S_WSPIN=15 -D MCLK_PIN=4  ;; I2S mic
+lib_deps = ${esp32s3.lib_deps}
+  ${esp32.AR_lib_deps}
+
+board_build.partitions = ${esp32.extreme_partitions}
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+monitor_filters = esp32_exception_decoder
+
 [env:esp32s3_4M_qspi]
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
 board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM 

--- a/platformio.ini
+++ b/platformio.ini
@@ -570,8 +570,9 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   ;; -D ARDUINO_USB_CDC_ON_BOOT=1 -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
-  -D LEDPIN=38 ;; buildin LED
+  -D LEDPIN=38 -D DATA_PINS=38 ;; buildin WS2812b LED
   -D BTNPIN=0 -D RLYPIN=16 -D IRPIN=17 -D AUDIOPIN=-1
+  -D WLED_DEBUG
   ${esp32.AR_build_flags}
   -D SR_DMTYPE=1 -D I2S_SDPIN=13 -D I2S_CKPIN=14 -D I2S_WSPIN=15 -D MCLK_PIN=4  ;; I2S mic
 lib_deps = ${esp32s3.lib_deps}

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -201,7 +201,12 @@ bool PinManager::isPinOk(byte gpio, bool output)
     if (gpio > 18 && gpio < 21) return false;     // 19 + 20 = USB-JTAG. Not recommended for other uses.
     #endif
     if (gpio > 21 && gpio < 33) return false;     // 22 to 32: not connected + SPI FLASH
-    if (gpio > 32 && gpio < 38) return !psramFound(); // 33 to 37: not available if using _octal_ SPI Flash or _octal_ PSRAM
+    #if CONFIG_ESPTOOLPY_FLASHMODE_OPI            // 33-37: never available if using _octal_ Flash (opi_opi)
+    if (gpio > 32 && gpio < 38) return false;
+    #endif
+    #if CONFIG_SPIRAM_MODE_OCT                    // 33-37: not available if using _octal_ PSRAM (qio_opi), but free to use on _quad_ PSRAM (qio_qspi)
+    if (gpio > 32 && gpio < 38) return !psramFound();
+    #endif
     // 38 to 48 are for general use. Be careful about straping pins GPIO45 and GPIO46 - these may be pull-up or pulled-down on your board.
   #elif defined(CONFIG_IDF_TARGET_ESP32S2)
     // strapping pins: 0, 45 & 46

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -380,6 +380,12 @@ void WLED::setup()
     case FM_QOUT: DEBUG_PRINT(F("(QOUT)"));break;
     case FM_DIO:  DEBUG_PRINT(F("(DIO)")); break;
     case FM_DOUT: DEBUG_PRINT(F("(DOUT)"));break;
+    #if defined(CONFIG_IDF_TARGET_ESP32S3) && CONFIG_ESPTOOLPY_FLASHMODE_OPI
+    case FM_FAST_READ: DEBUG_PRINT(F("(OPI)")); break;
+    #else
+    case FM_FAST_READ: DEBUG_PRINT(F("(fast_read)")); break;
+    #endif
+    case FM_SLOW_READ: DEBUG_PRINT(F("(slow_read)")); break;
     default: break;
   }
   #endif


### PR DESCRIPTION
build environment and pinmanager support for S3 WROOM-2 (N32R8V, N16R8V)


debug output at startup:
```log
rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
Octal Flash Mode Enabled
For OPI Flash, Use Default Flash Boot Mode
mode:SLOW_RD, clock div:1
load:0x3fce3808,len:0x3ac
load:0x403c9700,len:0x9b4
load:0x403cc700,len:0x28fc
entry 0x403c98bc

---WLED 0.15.0-b7 2410270 INIT---

esp32 v4.4.4
arduino-esp32 v2.0.9
CPU:   ESP32-S3 rev.0, 2 core(s), 240 MHz.
FLASH: 32 MB, Mode 4 (OPI), speed 80 MHz.
heap 309840
JSON buffer allocated: 65534
PSRAM: 8125kB/8189kB
```