### PR TITLE
Improved framerate control code - strip.show(), strip.service()

### DIFF
--- a/usermods/audioreactive/audio_reactive.h
+++ b/usermods/audioreactive/audio_reactive.h
@@ -75,7 +75,7 @@ static uint8_t  soundAgc = 0;                   // Automagic gain control: 0 - n
 //static float    volumeSmth = 0.0f;              // either sampleAvg or sampleAgc depending on soundAgc; smoothed sample
 static float FFT_MajorPeak = 1.0f;              // FFT: strongest (peak) frequency
 static float FFT_Magnitude = 0.0f;              // FFT: volume (magnitude) of peak frequency
-static bool samplePeak = false;      // Boolean flag for peak - used in effects. Responding routine may reset this flag. Auto-reset after strip.getMinShowDelay()
+static bool samplePeak = false;      // Boolean flag for peak - used in effects. Responding routine may reset this flag. Auto-reset after strip.getFrameTime()
 static bool udpSamplePeak = false;   // Boolean flag for peak. Set at the same time as samplePeak, but reset by transmitAudioData
 static unsigned long timeOfPeak = 0; // time of last sample peak detection.
 static uint8_t fftResult[NUM_GEQ_CHANNELS]= {0};// Our calculated freq. channel result table to be used by effects
@@ -536,8 +536,8 @@ static void detectSamplePeak(void) {
 #endif
 
 static void autoResetPeak(void) {
-  uint16_t MinShowDelay = MAX(50, strip.getMinShowDelay());  // Fixes private class variable compiler error. Unsure if this is the correct way of fixing the root problem. -THATDONFC
-  if (millis() - timeOfPeak > MinShowDelay) {          // Auto-reset of samplePeak after a complete frame has passed.
+  uint16_t peakDelay = max(uint16_t(50), strip.getFrameTime());
+  if (millis() - timeOfPeak > peakDelay) {          // Auto-reset of samplePeak after at least one complete frame has passed.
     samplePeak = false;
     if (audioSyncEnabled == 0) udpSamplePeak = false;  // this is normally reset by transmitAudioData
   }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -48,8 +48,8 @@
 #define FRAMETIME        strip.getFrameTime()
 #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
   #define MIN_FRAME_DELAY  2                                              // minimum wait between repaints, to keep other functions like WiFi alive 
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)
-  #define MIN_FRAME_DELAY  4                                              // S2 is slower than normal esp32, and only has one core
+#elif defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
+  #define MIN_FRAME_DELAY  3                                              // S2/C3 are slower than normal esp32, and only have one core
 #else
   #define MIN_FRAME_DELAY  8                                              // 8266 legacy MIN_SHOW_DELAY
 #endif

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -44,20 +44,15 @@
 
 /* Not used in all effects yet */
 #define WLED_FPS         42
+#define FRAMETIME_FIXED  (1000/WLED_FPS)
 #define FRAMETIME        strip.getFrameTime()
 #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)    // all ESP32 except -C3(very slow, untested)
-  #define FRAMETIME_FIXED  (strip.getFrameTime() < 10 ? 12 : 24)            // allow faster FRAMETIME_FIXED when target FPS >= 100  
   #define MIN_SHOW_DELAY   (max(2, (_frametime*5)/8))                       // supports higher framerates and better animation control -- 5/8 = 62%
   // used to initialize for strip attributes:
-  #define WLED_FPS_SLOW    42
-  #define FRAMETIME_FIXED_SLOW  (24)                                        // 1000/42 = 24ms
 #else
-  #define FRAMETIME_FIXED  (1000/WLED_FPS)
   #define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)                       // legacy MIN_SHOW_DELAY - creates more idle loops, but reduces framerates
-  #define WLED_FPS_SLOW     WLED_FPS
-  #define FRAMETIME_FIXED_SLOW FRAMETIME_FIXED
 #endif
-#define FPS_UNLIMITED    119
+#define FPS_UNLIMITED    120
 
 /* each segment uses 82 bytes of SRAM memory, so if you're application fails because of
   insufficient memory, decreasing MAX_NUM_SEGMENTS may help */
@@ -737,8 +732,8 @@ class WS2812FX {  // 96 bytes
       _length(DEFAULT_LED_COUNT),
       _brightness(DEFAULT_BRIGHTNESS),
       _transitionDur(750),
-      _targetFps(WLED_FPS_SLOW),
-      _frametime(FRAMETIME_FIXED_SLOW),
+      _targetFps(WLED_FPS),
+      _frametime(FRAMETIME_FIXED),
       _cumulativeFps(2),
       _isServicing(false),
       _isOffRefreshRequired(false),

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -47,8 +47,7 @@
 #define FRAMETIME_FIXED  (1000/WLED_FPS)
 #define FRAMETIME        strip.getFrameTime()
 #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)    // all ESP32 except -C3(very slow, untested)
-  #define MIN_SHOW_DELAY   (max(2, (_frametime*5)/8))                       // supports higher framerates and better animation control -- 5/8 = 62%
-  // used to initialize for strip attributes:
+  #define MIN_SHOW_DELAY   3                                              // supports higher framerates and better animation control
 #else
   #define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)                       // legacy MIN_SHOW_DELAY - creates more idle loops, but reduces framerates
 #endif

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -46,10 +46,12 @@
 #define WLED_FPS         42
 #define FRAMETIME_FIXED  (1000/WLED_FPS)
 #define FRAMETIME        strip.getFrameTime()
-#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)    // all ESP32 except -C3(very slow, untested)
-  #define MIN_SHOW_DELAY   3                                              // supports higher framerates and better animation control
+#if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32S2)
+  #define MIN_FRAME_DELAY  2                                              // minimum wait between repaints, to keep other functions like WiFi alive 
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+  #define MIN_FRAME_DELAY  4                                              // S2 is slower than normal esp32, and only has one core
 #else
-  #define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)                       // legacy MIN_SHOW_DELAY - creates more idle loops, but reduces framerates
+  #define MIN_FRAME_DELAY  8                                              // 8266 legacy MIN_SHOW_DELAY
 #endif
 #define FPS_UNLIMITED    0
 
@@ -842,7 +844,7 @@ class WS2812FX {  // 96 bytes
       getMappedPixelIndex(uint16_t index) const;
 
     inline uint16_t getFrameTime() const    { return _frametime; }        // returns amount of time a frame should take (in ms)
-    inline uint16_t getMinShowDelay() const { return MIN_SHOW_DELAY; }    // returns minimum amount of time strip.service() can be delayed (constant)
+    inline uint16_t getMinShowDelay() const { return MIN_FRAME_DELAY; }   // returns minimum amount of time strip.service() can be delayed (constant)
     inline uint16_t getLength() const       { return _length; }           // returns actual amount of LEDs on a strip (2D matrix may have less LEDs than W*H)
     inline uint16_t getTransition() const   { return _transitionDur; }    // returns currently set transition time (in ms)
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -52,7 +52,7 @@
 #else
   #define MIN_SHOW_DELAY   (_frametime < 16 ? 8 : 15)                       // legacy MIN_SHOW_DELAY - creates more idle loops, but reduces framerates
 #endif
-#define FPS_UNLIMITED    120
+#define FPS_UNLIMITED    0
 
 /* each segment uses 82 bytes of SRAM memory, so if you're application fails because of
   insufficient memory, decreasing MAX_NUM_SEGMENTS may help */

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1314,7 +1314,7 @@ void WS2812FX::service() {
 
   #if defined(ARDUINO_ARCH_ESP32) && !defined(CONFIG_IDF_TARGET_ESP32C3)
   if (elapsed < 2) return;                                                       // keep wifi alive
-  if ( !_triggered && (_targetFps != FPS_UNLIMITED) && (_targetFps > 0)) {
+  if ( !_triggered && (_targetFps != FPS_UNLIMITED)) {
     if (elapsed < MIN_SHOW_DELAY) return;                                        // WLEDMM too early for service
   }
   #else  // legacy
@@ -1450,9 +1450,9 @@ uint16_t WS2812FX::getFps() const {
 }
 
 void WS2812FX::setTargetFps(uint8_t fps) {
-  if (fps > 0 && fps <= 120) _targetFps = fps;
-  _frametime = 1000 / _targetFps;
-  if (fps == FPS_UNLIMITED) _frametime = 3;     // unlimited mode
+  if (fps <= 120) _targetFps = fps;
+  if (_targetFps > 0) _frametime = 1000 / _targetFps;
+  else _frametime = 3;     // unlimited mode
 }
 
 void WS2812FX::setMode(uint8_t segid, uint8_t m) {

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -380,6 +380,10 @@
 			gId('psu').innerHTML = s;
 			gId('psu2').innerHTML = s2;
 			gId("json").style.display = d.Sf.IT.value==8 ? "" : "none";
+
+			// show/hide unlimited FPS message
+			gId('fpsNone').style.display = (d.Sf.FR.value == 0) ? 'block':'none';
+			gId('fpsHelp').style.display = (d.Sf.FR.value == 0)? 'none':'block';
 		}
 		function lastEnd(i) {
 			if (i-- < 1) return 0;
@@ -870,7 +874,9 @@ Swap: <select id="xw${s}" name="XW${s}">
 			<option value="2">Linear (never wrap)</option>
 			<option value="3">None (not recommended)</option>
 		</select><br>
-		Target refresh rate: <input type="number" class="s" min="1" max="120" name="FR" required> FPS
+		Target refresh rate: <input type="number" class="s" min="0" max="120" name="FR" oninput="UI()" required> FPS
+		<div id="fpsHelp" style="display: block;"><i>use 0 for unlimited</i><br></div>
+		<div id="fpsNone" style="color:orange; display: none;">Unlimited FPS Mode<br></div>
 		<hr class="sml">
 		<div id="cfg">Config template: <input type="file" name="data2" accept=".json"><button type="button" class="sml" onclick="loadCfg(d.Sf.data2)">Apply</button><br></div>
 		<hr>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -876,7 +876,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 		</select><br>
 		Target refresh rate: <input type="number" class="s" min="0" max="120" name="FR" oninput="UI()" required> FPS
 		<div id="fpsHelp" style="display: block;"><i>use 0 for unlimited</i><br></div>
-		<div id="fpsNone" style="color:orange; display: none;">Unlimited FPS Mode<br></div>
+		<div id="fpsNone" class="warn" style="display: none;">Unlimited FPS Mode<br></div>
 		<hr class="sml">
 		<div id="cfg">Config template: <input type="file" name="data2" accept=".json"><button type="button" class="sml" onclick="loadCfg(d.Sf.data2)">Apply</button><br></div>
 		<hr>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -875,7 +875,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 			<option value="2">Linear (never wrap)</option>
 			<option value="3">None (not recommended)</option>
 		</select><br>
-		Target refresh rate: <input type="number" class="s" min="0" max="120" name="FR" oninput="UI()" required> FPS
+		Target refresh rate: <input type="number" class="s" min="0" max="250" name="FR" oninput="UI()" required> FPS
 		<div id="fpsNone" class="warn" style="display: none;">&#9888; Unlimited FPS Mode  is experimental &#9888;<br></div>
 		<div id="fpsHigh" class="warn" style="display: none;">&#9888; High FPS Mode is experimental.<br></div>
 		<div id="fpsWarn" class="warn" style="display: none;">Please <a class="lnk" href="sec#backup">backup</a> WLED configuration and presets first!<br></div>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -381,9 +381,10 @@
 			gId('psu2').innerHTML = s2;
 			gId("json").style.display = d.Sf.IT.value==8 ? "" : "none";
 
-			// show/hide unlimited FPS message
+			// show/hide FPS warning messages
 			gId('fpsNone').style.display = (d.Sf.FR.value == 0) ? 'block':'none';
-			gId('fpsHelp').style.display = (d.Sf.FR.value == 0)? 'none':'block';
+			gId('fpsWarn').style.display = (d.Sf.FR.value == 0) || (d.Sf.FR.value >= 80) ? 'block':'none';
+			gId('fpsHigh').style.display = (d.Sf.FR.value >= 80) ? 'block':'none';
 		}
 		function lastEnd(i) {
 			if (i-- < 1) return 0;
@@ -875,8 +876,9 @@ Swap: <select id="xw${s}" name="XW${s}">
 			<option value="3">None (not recommended)</option>
 		</select><br>
 		Target refresh rate: <input type="number" class="s" min="0" max="120" name="FR" oninput="UI()" required> FPS
-		<div id="fpsHelp" style="display: block;"><i>use 0 for unlimited</i><br></div>
-		<div id="fpsNone" class="warn" style="display: none;">Unlimited FPS Mode<br></div>
+		<div id="fpsNone" class="warn" style="display: none;">&#9888; Unlimited FPS Mode  is experimental &#9888;<br></div>
+		<div id="fpsHigh" class="warn" style="display: none;">&#9888; High FPS Mode is experimental.<br></div>
+		<div id="fpsWarn" class="warn" style="display: none;">Please <a class="lnk" href="sec#backup">backup</a> WLED configuration and presets first!<br></div>
 		<hr class="sml">
 		<div id="cfg">Config template: <input type="file" name="data2" accept=".json"><button type="button" class="sml" onclick="loadCfg(d.Sf.data2)">Apply</button><br></div>
 		<hr>

--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -57,7 +57,7 @@
 		<h3>Software Update</h3>
 		<button type="button" onclick="U()">Manual OTA Update</button><br>
 		Enable ArduinoOTA: <input type="checkbox" name="AO">
-		<hr>
+		<hr id="backup">
 		<h3>Backup & Restore</h3>
 		<div class="warn">&#9888; Restoring presets/configuration will OVERWRITE your current presets/configuration.<br>
 		Incorrect upload or configuration may require a factory reset or re-flashing of your ESP.</div>


### PR DESCRIPTION
Reworked framerate control loop, to allow more fluent animations and support higher framerates

#### the problem (in a nutshell) 
![image](https://github.com/user-attachments/assets/ee73f2a3-ad34-46da-b46e-bb1b119525ec)


#### solution
* separated fps calculation (strip.show) from framerate control (strip.service)
* improved condition for early exit in strip.service
* made MIN_SHOW_DELAY depend on target fps
* strip.show now considers the complete time of effect calculation + show; old code wrongly used the time between completion of last show and start of next effect drawing, causing unexpected slowdown and sometimes leading to stuttering effects.
* added "unlimited FPS mode" for testing (use Target FPS = 120)
* increased warning limits for "slow strip" and "slow effects" (WLED_DEBUG)

As 8266 and esp32-c3 might suffer from higher CPU load, these chips use the previous MIN_SHOW_DELAY logic that causes more idle loops.

#### Comparison, Using a 64x64 "network DDP" output (esp32_wrover)
* Akemi : old code 38 fps, new code 53 fps
* Black Hole: old code 40 fps, new code 54 fps
* Lissajous: old code 37 fps, new code 51 fps