### PR TITLE
Improved FPS calculation

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -737,7 +737,7 @@ class WS2812FX {  // 96 bytes
       _transitionDur(750),
       _targetFps(WLED_FPS),
       _frametime(FRAMETIME_FIXED),
-      _cumulativeFps(50<<6),
+      _cumulativeFps(50<<7),
       _isServicing(false),
       _isOffRefreshRequired(false),
       _hasWhiteChannel(false),

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -47,6 +47,14 @@
 #define FRAMETIME_FIXED  (1000/WLED_FPS)
 #define FRAMETIME        strip.getFrameTime()
 
+// FPS calculation (can be defined as compile flag for debugging)
+#ifndef FPS_CALC_AVG
+#define FPS_CALC_AVG 7 // average FPS calculation over this many frames (moving average)
+#endif
+#ifndef FPS_MULTIPLIER
+#define FPS_MULTIPLIER 1 // dev option: multiplier to get sub-frame FPS without floats
+#endif
+
 /* each segment uses 82 bytes of SRAM memory, so if you're application fails because of
   insufficient memory, decreasing MAX_NUM_SEGMENTS may help */
 #ifdef ESP8266
@@ -729,7 +737,7 @@ class WS2812FX {  // 96 bytes
       _transitionDur(750),
       _targetFps(WLED_FPS),
       _frametime(FRAMETIME_FIXED),
-      _cumulativeFps(2),
+      _cumulativeFps(50<<6),
       _isServicing(false),
       _isOffRefreshRequired(false),
       _hasWhiteChannel(false),

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -54,6 +54,7 @@
 #ifndef FPS_MULTIPLIER
 #define FPS_MULTIPLIER 1 // dev option: multiplier to get sub-frame FPS without floats
 #endif
+#define FPS_CALC_SHIFT 7 // bit shift for fixed point math
 
 /* each segment uses 82 bytes of SRAM memory, so if you're application fails because of
   insufficient memory, decreasing MAX_NUM_SEGMENTS may help */
@@ -737,7 +738,7 @@ class WS2812FX {  // 96 bytes
       _transitionDur(750),
       _targetFps(WLED_FPS),
       _frametime(FRAMETIME_FIXED),
-      _cumulativeFps(50<<7),
+      _cumulativeFps(50 << FPS_CALC_SHIFT),
       _isServicing(false),
       _isOffRefreshRequired(false),
       _hasWhiteChannel(false),

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1414,7 +1414,7 @@ void WS2812FX::show() {
   size_t diff = showNow - _lastShow;
 
   if (diff > 0) { // skip calculation if no time has passed
-    size_t fpsCurr = (1000<<7) / diff; // fixed point 9.7 bit
+    size_t fpsCurr = (1000 << FPS_CALC_SHIFT) / diff; // fixed point math
     _cumulativeFps = (FPS_CALC_AVG * _cumulativeFps + fpsCurr + FPS_CALC_AVG / 2) / (FPS_CALC_AVG + 1);   // "+FPS_CALC_AVG/2" for proper rounding
     _lastShow = showNow;
   }
@@ -1434,11 +1434,7 @@ bool WS2812FX::isUpdating() const {
  */
 uint16_t WS2812FX::getFps() const {
   if (millis() - _lastShow > 2000) return 0;
-  #ifdef WLED_DEBUG
-  return (FPS_MULTIPLIER * (_cumulativeFps + (random16() & 63))) >> 7;  // + random("0.5") for dithering
-  #else
-  return (FPS_MULTIPLIER * _cumulativeFps) >> 7; // _cumulativeFps is stored in fixed point 9.7 bit
-  #endif
+  return (FPS_MULTIPLIER * _cumulativeFps) >> FPS_CALC_SHIFT; // _cumulativeFps is stored in fixed point
 }
 
 void WS2812FX::setTargetFps(uint8_t fps) {


### PR DESCRIPTION
This improvement is for dev purposes mainly but it also gives a bit smoother FPS return values in normal builds.

Changes:
- fixed point calculation for improved accuracy, 9.7 bit, so max FPS can be 511
~~- dithering (in debug builds only)~~
- averaging and optional multiplier can be set as compile flags

Example for speed testing with long averaging and a 10x multiplier:
```
-D FPS_CALC_AVG=200
-D FPS_MULTIPLIER=10
```
Since the calculation resolution is limited (9.7bit fixed point) `FPS_CALC_AVG `values larger than 200 can hit resolution limit and get stuck before reaching the final value.

If `WLED_DEBUG` is defined, dithering is added to the returned value so sub-frame accuracy is possible in post-processing without enabling the multiplier.