### PR TITLE
replaced repeated progress() calculation calls with a variable

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -363,6 +363,7 @@ typedef struct Segment {
     };
     uint8_t startY;  // start Y coodrinate 2D (top); there should be no more than 255 rows
     uint8_t stopY;   // stop Y coordinate 2D (bottom); there should be no more than 255 rows
+    uint16_t transitionprogress; // current transition progress 0 - 0xFFFF
     char    *name;
 
     // runtime data
@@ -468,6 +469,7 @@ typedef struct Segment {
       check3(false),
       startY(0),
       stopY(1),
+      transitionprogress(0xFFFF),
       name(nullptr),
       next_time(0),
       step(0),
@@ -559,12 +561,13 @@ typedef struct Segment {
     // transition functions
     void     startTransition(uint16_t dur);     // transition has to start before actual segment values change
     void     stopTransition();                  // ends transition mode by destroying transition structure (does nothing if not in transition)
-    inline void handleTransition() { if (progress() == 0xFFFFU) stopTransition(); }
+    inline void handleTransition() { updateTransitionProgress(); if (progress() == 0xFFFFU) stopTransition(); }
     #ifndef WLED_DISABLE_MODE_BLEND
     void     swapSegenv(tmpsegd_t &tmpSegD);    // copies segment data into specifed buffer, if buffer is not a transition buffer, segment data is overwritten from transition buffer
     void     restoreSegenv(tmpsegd_t &tmpSegD); // restores segment data from buffer, if buffer is not transition buffer, changed values are copied to transition buffer
     #endif
-    [[gnu::hot]] uint16_t progress() const;                  // transition progression between 0-65535
+    [[gnu::hot]] void updateTransitionProgress();            // set current progression of transition
+    inline uint16_t progress() const { return transitionprogress; };  // transition progression between 0-65535
     [[gnu::hot]] uint8_t  currentBri(bool useCct = false) const; // current segment brightness/CCT (blended while in transition)
     uint8_t  currentMode() const;                            // currently active effect/mode (while in transition)
     [[gnu::hot]] uint32_t currentColor(uint8_t slot) const;  // currently active segment color (blended while in transition)

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -363,7 +363,7 @@ typedef struct Segment {
     };
     uint8_t startY;  // start Y coodrinate 2D (top); there should be no more than 255 rows
     uint8_t stopY;   // stop Y coordinate 2D (bottom); there should be no more than 255 rows
-    uint16_t transitionprogress; // current transition progress 0 - 0xFFFF
+    // note: two bytes of padding are added here
     char    *name;
 
     // runtime data
@@ -419,6 +419,7 @@ typedef struct Segment {
     static CRGBPalette16 _newRandomPalette;   // target random palette
     static uint16_t _lastPaletteChange;       // last random palette change time in millis()/1000
     static uint16_t _lastPaletteBlend;        // blend palette according to set Transition Delay in millis()%0xFFFF
+    static uint16_t _transitionprogress;      // current transition progress 0 - 0xFFFF
     #ifndef WLED_DISABLE_MODE_BLEND
     static bool          _modeBlend;          // mode/effect blending semaphore
     #endif
@@ -469,7 +470,6 @@ typedef struct Segment {
       check3(false),
       startY(0),
       stopY(1),
-      transitionprogress(0xFFFF),
       name(nullptr),
       next_time(0),
       step(0),
@@ -567,7 +567,7 @@ typedef struct Segment {
     void     restoreSegenv(tmpsegd_t &tmpSegD); // restores segment data from buffer, if buffer is not transition buffer, changed values are copied to transition buffer
     #endif
     [[gnu::hot]] void updateTransitionProgress();            // set current progression of transition
-    inline uint16_t progress() const { return transitionprogress; };  // transition progression between 0-65535
+    inline uint16_t progress() const { return _transitionprogress; };  // transition progression between 0-65535
     [[gnu::hot]] uint8_t  currentBri(bool useCct = false) const; // current segment brightness/CCT (blended while in transition)
     uint8_t  currentMode() const;                            // currently active effect/mode (while in transition)
     [[gnu::hot]] uint32_t currentColor(uint8_t slot) const;  // currently active segment color (blended while in transition)

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -317,12 +317,12 @@ void Segment::stopTransition() {
 }
 
 // transition progression between 0-65535
-uint16_t IRAM_ATTR Segment::progress() const {
+void IRAM_ATTR Segment::updateTransitionProgress() {
+  transitionprogress = 0xFFFFU;
   if (isInTransition()) {
     unsigned diff = millis() - _t->_start;
-    if (_t->_dur > 0 && diff < _t->_dur) return diff * 0xFFFFU / _t->_dur;
+    if (_t->_dur > 0 && diff < _t->_dur) transitionprogress = diff * 0xFFFFU / _t->_dur;
   }
-  return 0xFFFFU;
 }
 
 #ifndef WLED_DISABLE_MODE_BLEND

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -317,7 +317,7 @@ void Segment::stopTransition() {
 }
 
 // transition progression between 0-65535
-void IRAM_ATTR Segment::updateTransitionProgress() {
+void Segment::updateTransitionProgress() {
   transitionprogress = 0xFFFFU;
   if (isInTransition()) {
     unsigned diff = millis() - _t->_start;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -75,6 +75,7 @@ CRGBPalette16 Segment::_randomPalette     = generateRandomPalette();  // was CRG
 CRGBPalette16 Segment::_newRandomPalette  = generateRandomPalette();  // was CRGBPalette16(DEFAULT_COLOR);
 uint16_t      Segment::_lastPaletteChange = 0; // perhaps it should be per segment
 uint16_t      Segment::_lastPaletteBlend  = 0; //in millis (lowest 16 bits only)
+uint16_t      Segment::_transitionprogress  = 0xFFFF;
 
 #ifndef WLED_DISABLE_MODE_BLEND
 bool Segment::_modeBlend = false;
@@ -318,10 +319,10 @@ void Segment::stopTransition() {
 
 // transition progression between 0-65535
 void Segment::updateTransitionProgress() {
-  transitionprogress = 0xFFFFU;
+  _transitionprogress = 0xFFFFU;
   if (isInTransition()) {
     unsigned diff = millis() - _t->_start;
-    if (_t->_dur > 0 && diff < _t->_dur) transitionprogress = diff * 0xFFFFU / _t->_dur;
+    if (_t->_dur > 0 && diff < _t->_dur) _transitionprogress = diff * 0xFFFFU / _t->_dur;
   }
 }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -318,7 +318,7 @@ void Segment::stopTransition() {
 }
 
 // transition progression between 0-65535
-void Segment::updateTransitionProgress() {
+inline void Segment::updateTransitionProgress() {
   _transitionprogress = 0xFFFFU;
   if (isInTransition()) {
     unsigned diff = millis() - _t->_start;


### PR DESCRIPTION
progress() is called in `setPixelColor()` re-calculating the transition progress for each pixel. 
Replaced that call with an inline function to get the new segment variable. The progress is updated in service() when `handleTransition()` is called. The new variable is in a spot where padding is added, so this should not use more RAM. 

Result: over 10% increase in FPS on 16x16 matrix during transitions
