### PR TITLE
Fix problem with spaces

### DIFF
--- a/tools/cdata.js
+++ b/tools/cdata.js
@@ -101,6 +101,7 @@ function adoptVersionAndRepo(html) {
 async function minify(str, type = "plain") {
   const options = {
     collapseWhitespace: true,
+    conservativeCollapse: true, // preserve spaces in text
     collapseBooleanAttributes: true,
     collapseInlineTagWhitespace: true,
     minifyCSS: true,


### PR DESCRIPTION
Due to the minifying, we had some problems with spaces.

**Before:**
![grafik](https://github.com/user-attachments/assets/a9b36f2f-1590-4aa0-8e4b-79d246b302a0)
```
RAM:   [=         ]  14.8% (used 48472 bytes from 327680 bytes)
Flash: [========= ]  86.8% (used 1365765 bytes from 1572864 bytes)
```

**Now:**
![grafik](https://github.com/user-attachments/assets/8cb0d0f9-181e-4cd5-8768-da6874d51ccc)
```
RAM:   [=         ]  14.8% (used 48472 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1366069 bytes from 1572864 bytes)
```