### PR TITLE
Replaced single palette cases with an array to consolidate code

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -236,23 +236,11 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
         targetPalette = CRGBPalette16(prim,prim,prim,prim,prim,prim,prim,prim,sec,sec,sec,sec,sec,sec,sec,sec);
       }
       break;}
-    case 6: //Party colors
-      targetPalette = PartyColors_p; break;
-    case 7: //Cloud colors
-      targetPalette = CloudColors_p; break;
-    case 8: //Lava colors
-      targetPalette = LavaColors_p; break;
-    case 9: //Ocean colors
-      targetPalette = OceanColors_p; break;
-    case 10: //Forest colors
-      targetPalette = ForestColors_p; break;
-    case 11: //Rainbow colors
-      targetPalette = RainbowColors_p; break;
-    case 12: //Rainbow stripe colors
-      targetPalette = RainbowStripeColors_p; break;
     default: //progmem palettes
       if (pal>245) {
         targetPalette = strip.customPalettes[255-pal]; // we checked bounds above
+      } else if (pal < 13) { // palette 6 - 12, fastled palettes
+        targetPalette = *fastledPalettes[pal-6];
       } else {
         byte tcp[72];
         memcpy_P(tcp, (byte*)pgm_read_dword(&(gGradientPalettes[pal-13])), 72);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -902,10 +902,7 @@ void serializePalettes(JsonObject root, int page)
         setPaletteColors(curPalette, PartyColors_p);
         break;
       case 1: //random
-          curPalette.add("r");
-          curPalette.add("r");
-          curPalette.add("r");
-          curPalette.add("r");
+           for (int j = 0; j < 4; j++) curPalette.add("r");
         break;
       case 2: //primary color only
         curPalette.add("c1");
@@ -922,52 +919,19 @@ void serializePalettes(JsonObject root, int page)
         curPalette.add("c1");
         break;
       case 5: //primary + secondary (+tertiary if not off), more distinct
+        for (int j = 0; j < 5; j++) curPalette.add("c1");
+        for (int j = 0; j < 5; j++) curPalette.add("c2");
+        for (int j = 0; j < 5; j++) curPalette.add("c3");
         curPalette.add("c1");
-        curPalette.add("c1");
-        curPalette.add("c1");
-        curPalette.add("c1");
-        curPalette.add("c1");
-        curPalette.add("c2");
-        curPalette.add("c2");
-        curPalette.add("c2");
-        curPalette.add("c2");
-        curPalette.add("c2");
-        curPalette.add("c3");
-        curPalette.add("c3");
-        curPalette.add("c3");
-        curPalette.add("c3");
-        curPalette.add("c3");
-        curPalette.add("c1");
-        break;
-      case 6: //Party colors
-        setPaletteColors(curPalette, PartyColors_p);
-        break;
-      case 7: //Cloud colors
-        setPaletteColors(curPalette, CloudColors_p);
-        break;
-      case 8: //Lava colors
-        setPaletteColors(curPalette, LavaColors_p);
-        break;
-      case 9: //Ocean colors
-        setPaletteColors(curPalette, OceanColors_p);
-        break;
-      case 10: //Forest colors
-        setPaletteColors(curPalette, ForestColors_p);
-        break;
-      case 11: //Rainbow colors
-        setPaletteColors(curPalette, RainbowColors_p);
-        break;
-      case 12: //Rainbow stripe colors
-        setPaletteColors(curPalette, RainbowStripeColors_p);
         break;
       default:
-        {
-        if (i>=palettesCount) {
+        if (i >= palettesCount)
           setPaletteColors(curPalette, strip.customPalettes[i - palettesCount]);
-        } else {
+        else if (i < 13) // palette 6 - 12, fastled palettes
+          setPaletteColors(curPalette, *fastledPalettes[i-6]);
+        else {
           memcpy_P(tcp, (byte*)pgm_read_dword(&(gGradientPalettes[i - 13])), 72);
           setPaletteColors(curPalette, tcp);
-        }
         }
         break;
     }

--- a/wled00/palettes.h
+++ b/wled00/palettes.h
@@ -844,6 +844,17 @@ const byte candy2_gp[] PROGMEM = {
   211,  39, 33, 34,
   255,   1,  1,  1};
 
+// array of fastled palettes (palette 6 - 12)
+const TProgmemRGBPalette16 *const fastledPalettes[] PROGMEM = {
+  &PartyColors_p,               //06-00 Party
+  &CloudColors_p,               //07-01 Cloud
+  &LavaColors_p,                //08-02 Lava
+  &OceanColors_p,               //09-03 Ocean
+  &ForestColors_p,              //10-04 Forest
+  &RainbowColors_p,             //11-05 Rainbow
+  &RainbowStripeColors_p        //12-06 Rainbow Bands
+};
+
 // Single array of defined cpt-city color palettes.
 // This will let us programmatically choose one based on
 // a number, rather than having to activate each explicitly


### PR DESCRIPTION
- all palettes are now defined in palettes.h
- access to fastled palettes as an array to remove the switch cases
- palette creation in json.cpp in a loop instead of repeated calls to save some flash (about 300 bytes)