### PR TITLE
Fix for #4269

### DIFF
--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -1191,7 +1191,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
 
   // internal call, does not send XML response
   pos = req.indexOf(F("IN"));
-  if (pos < 1) {
+  if ((request != nullptr) && (pos < 1)) {
     auto response = request->beginResponseStream("text/xml");
     XML_response(*response);
     request->send(response);


### PR DESCRIPTION
The crash bug in #4269 was introduced by #4152; I inadvertently removed a null check on the 'request' parameter.  Restore the missing check so non-JSON API calls don't crash.