### PR TITLE
Add settings and OTA lock state to info

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -643,6 +643,8 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     CJSON(wifiLock, ota[F("lock-wifi")]);
     CJSON(aOtaEnabled, ota[F("aota")]);
     getStringFromJson(otaPass, pwd, 33); //normally not present due to security
+    interfaceUpdateCallMode = CALL_MODE_WS_SEND;
+    stateChanged = true;
   }
 
   #ifdef WLED_ENABLE_DMX

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -802,6 +802,8 @@ void serializeInfo(JsonObject root)
   os += 0x40;
   #endif
 
+  root[F("settingsLocked")] = !correctPIN;
+
   //os += 0x20; // indicated now removed Blynk support, may be reused to indicate another build-time option
 
   #ifdef USERMOD_CRONIXIE
@@ -818,11 +820,10 @@ void serializeInfo(JsonObject root)
   #endif
   #ifndef WLED_DISABLE_OTA
   os += 0x01;
-  root[F("ota")] = !otaLock;
+  root[F("otaLocked")] = otaLock;
   #endif
   root[F("opt")] = os;
-  root[F("settings")] = correctPIN;
-
+  
   root[F("brand")] = F(WLED_BRAND);
   root[F("product")] = F(WLED_PRODUCT_NAME);
   root["mac"] = escapedMac;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -823,7 +823,7 @@ void serializeInfo(JsonObject root)
   root[F("otaLocked")] = otaLock;
   #endif
   root[F("opt")] = os;
-  
+
   root[F("brand")] = F(WLED_BRAND);
   root[F("product")] = F(WLED_PRODUCT_NAME);
   root["mac"] = escapedMac;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -818,8 +818,10 @@ void serializeInfo(JsonObject root)
   #endif
   #ifndef WLED_DISABLE_OTA
   os += 0x01;
+  root[F("ota")] = !otaLock;
   #endif
   root[F("opt")] = os;
+  root[F("settings")] = correctPIN;
 
   root[F("brand")] = F(WLED_BRAND);
   root[F("product")] = F(WLED_PRODUCT_NAME);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -587,6 +587,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       wifiLock = request->hasArg(F("OW"));
       aOtaEnabled = request->hasArg(F("AO"));
       //createEditHandler(correctPIN && !otaLock);
+      interfaceUpdateCallMode = CALL_MODE_WS_SEND;
     }
   }
 

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -588,6 +588,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       aOtaEnabled = request->hasArg(F("AO"));
       //createEditHandler(correctPIN && !otaLock);
       interfaceUpdateCallMode = CALL_MODE_WS_SEND;
+      stateChanged = true;
     }
   }
 

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -355,7 +355,11 @@ void checkSettingsPIN(const char* pin) {
   if (!correctPIN && millis() - lastEditTime < PIN_RETRY_COOLDOWN) return; // guard against PIN brute force
   bool correctBefore = correctPIN;
   correctPIN = (strlen(settingsPIN) == 0 || strncmp(settingsPIN, pin, 4) == 0);
-  if (correctBefore != correctPIN) createEditHandler(correctPIN);
+  if (correctBefore != correctPIN) {
+    createEditHandler(correctPIN);
+    interfaceUpdateCallMode = CALL_MODE_WS_SEND;
+    stateChanged = true;
+  }
   lastEditTime = millis();
 }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -155,6 +155,7 @@ void WLED::loop()
   if (strlen(settingsPIN)>0 && correctPIN && millis() - lastEditTime > PIN_TIMEOUT) {
     correctPIN = false;
     createEditHandler(false);
+    interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
   }
 
   // reconnect WiFi to clear stale allocations if heap gets too low

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -323,9 +323,9 @@ void initServer()
     releaseJSONBufferLock();
 
     if (verboseResponse) {
-      interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
       if (!isConfig) {
         lastInterfaceUpdate = millis(); // prevent WS update until cooldown        
+        interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
         serveJson(request); return; //if JSON contains "v"
       } else {
         doSerializeConfig = true; //serializeConfig(); //Save new settings to FS

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -323,9 +323,9 @@ void initServer()
     releaseJSONBufferLock();
 
     if (verboseResponse) {
+      interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
       if (!isConfig) {
-        lastInterfaceUpdate = millis(); // prevent WS update until cooldown
-        interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
+        lastInterfaceUpdate = millis(); // prevent WS update until cooldown        
         serveJson(request); return; //if JSON contains "v"
       } else {
         doSerializeConfig = true; //serializeConfig(); //Save new settings to FS

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -324,7 +324,7 @@ void initServer()
 
     if (verboseResponse) {
       if (!isConfig) {
-        lastInterfaceUpdate = millis(); // prevent WS update until cooldown        
+        lastInterfaceUpdate = millis(); // prevent WS update until cooldown
         interfaceUpdateCallMode = CALL_MODE_WS_SEND; // schedule WS update
         serveJson(request); return; //if JSON contains "v"
       } else {


### PR DESCRIPTION
As requested by @Moustachauve on Discord: add the settings and OTA lock states to the info struct, so UIs can direct users to an appropriate workflow for updating their devices.

I'm not 100% confident about the usage of `interfaceUpdateCallMode` in these contexts to induce websocket notifications.  The notification subsystem currently seems a bit tangled to me.  If this stands out as obviously wrong, please let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced real-time synchronization of security and lock status across connected interfaces.
  * Security settings (PIN and OTA lock state) now properly notify all connected clients when changed or expired.
  * Added visibility of current lock status in device information responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->