### PR TITLE
Add a setting to create custom quick color buttons

### DIFF
--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -113,6 +113,7 @@
 			<div class="qcs" onclick="pC('#00ffc8');" style="background-color:#00ffc8;"></div>
 			<div class="qcs" onclick="pC('#08ff00');" style="background-color:#08ff00;"></div>
 			<div class="qcs" onclick="pC('rnd');" title="Random" style="background:linear-gradient(to right, red, orange, yellow, green, blue, purple);transform: translateY(-11px);">R</div>
+			<div id="qcs-c"></div>
 		</div>
 		<div id="csl">
 			<button id="csl0" title="Select slot" class="btn" onclick="selectSlot(0);" data-r="0" data-g="0" data-b="0" data-w="0">1</button>

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -28,7 +28,7 @@ var isM = false, mw = 0, mh=0;
 var ws, wsRpt=0;
 var cfg = {
 	theme:{base:"dark", bg:{url:"", rnd: false, rndGrayscale: false, rndBlur: false}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
-	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
+	comp :{colors:{picker: true, rgb: false, quick: true, hex: false, cqcs: ""},
 		  labels:true, pcmbot:false, pid:true, seglen:false, segpwr:false, segexp:false,
 		  css:true, hdays:false, fxdef:true, on:0, off:0, idsort: false}
 };
@@ -1279,6 +1279,20 @@ function updateUI()
 	gId('kwrap').style.display   = (hasRGB && !hasCCT) ? "block":"none";      // Kelvin slider
 	gId('rgbwrap').style.display = (hasRGB && ccfg.rgb) ? "block":"none";     // RGB sliders
 	gId('qcs-w').style.display   = (hasRGB && ccfg.quick) ? "block":"none";   // quick selection
+
+	if (hasRGB && ccfg.quick && ccfg.cqcs) {                                  // custom quick selectors
+		var clist = ccfg.cqcs.split(",");
+		var str = "", ct = 0;
+		for (let i = 0; i < clist.length; i++) {
+			var col = clist[i].trim();
+			if (!col.match(/^#(?:[0-9a-fA-F]{3}){1,2}$/g)) continue;
+			if (ct !== 0 && (ct % 11 === 6 || ct % 11 === 0)) str += ` <br>`;
+			str += ` <div class="qcs" onclick="pC('${col}');" style="background-color:${col};"></div>`;
+			ct++;
+		}
+		gId('qcs-c').innerHTML = str;
+	}
+
 	//gId('csl').style.display     = (hasRGB || hasWhite) ? "block":"none";     // color selectors (hide for On/Off bus)
 	//gId('palw').style.display    = (hasRGB) ? "inline-block":"none";          // palettes are shown/hidden in setEffectParameters()
 

--- a/wled00/data/settings_ui.htm
+++ b/wled00/data/settings_ui.htm
@@ -16,6 +16,7 @@
 				"picker": "Color Wheel",
 				"rgb": "RGB sliders",
 				"quick": "Quick color selectors",
+				"cqcs": "Custom quick color selectors",
 				"hex": "HEX color input"
 				},
 			"pcmbot": "Show bottom tab bar in PC mode",
@@ -91,7 +92,7 @@
 						str += `${lb}: <input class="agi" type="number" id=${fk} value=${s[i]}><br>`;
 					} else if (t === 'string')
 					{
-						str += `${lb}:<br><input class="agi" id=${fk} value=${s[i]}><br>`;
+						str += `${lb}:<br><input class="agi" id=${fk} value="${s[i]}"><br>`;
 					}
 				}
 			}


### PR DESCRIPTION
This feature allows custom quick colors to be added from the User Interface settings page.

A string setting holds comma-separated hex values in local storage. When the UI is updated, each color is added as a button underneath the existing colors. With lots of colors, the number of colors per row matches the existing alternating row pattern.

Testing:
- Invalid hex codes are not added as buttons
- Extra spaces around the commas have no effect

Limitations:
- The user must edit the string to change the colors
- There is no color picker UI available