### PR TITLE
FIX: "magic numbers" for MQTT topic buffer length in mqtt.cpp and button.cpp (use already defined MQTT_MAX_TOPIC_LEN)

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -29,7 +29,7 @@ void shortPressAction(uint8_t b)
 #ifndef WLED_DISABLE_MQTT
   // publish MQTT message
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
-    char subuf[64];
+    char subuf[MQTT_MAX_TOPIC_LEN + 32];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "short");
   }
@@ -62,7 +62,7 @@ void longPressAction(uint8_t b)
 #ifndef WLED_DISABLE_MQTT
   // publish MQTT message
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
-    char subuf[64];
+    char subuf[MQTT_MAX_TOPIC_LEN + 32];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "long");
   }
@@ -83,7 +83,7 @@ void doublePressAction(uint8_t b)
 #ifndef WLED_DISABLE_MQTT
   // publish MQTT message
   if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
-    char subuf[64];
+    char subuf[MQTT_MAX_TOPIC_LEN + 32];
     sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
     mqtt->publish(subuf, 0, false, "double");
   }
@@ -151,7 +151,7 @@ void handleSwitch(uint8_t b)
 #ifndef WLED_DISABLE_MQTT
     // publish MQTT message
     if (buttonPublishMqtt && WLED_MQTT_CONNECTED) {
-      char subuf[64];
+      char subuf[MQTT_MAX_TOPIC_LEN + 32];
       if (buttonType[b] == BTN_TYPE_PIR_SENSOR) sprintf_P(subuf, PSTR("%s/motion/%d"), mqttDeviceTopic, (int)b);
       else sprintf_P(subuf, _mqtt_topic_button, mqttDeviceTopic, (int)b);
       mqtt->publish(subuf, 0, false, !buttonPressedBefore[b] ? "off" : "on");

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -7,6 +7,10 @@
 #ifndef WLED_DISABLE_MQTT
 #define MQTT_KEEP_ALIVE_TIME 60    // contact the MQTT broker every 60 seconds
 
+#if MQTT_MAX_TOPIC_LEN > 32
+#warning "MQTT topics length > 32 is not recommended for compatibility with usermods!"
+#endif
+
 static void parseMQTTBriPayload(char* payload)
 {
   if      (strstr(payload, "ON") || strstr(payload, "on") || strstr(payload, "true")) {bri = briLast; stateUpdated(CALL_MODE_DIRECT_CHANGE);}

--- a/wled00/mqtt.cpp
+++ b/wled00/mqtt.cpp
@@ -23,24 +23,24 @@ static void parseMQTTBriPayload(char* payload)
 static void onMqttConnect(bool sessionPresent)
 {
   //(re)subscribe to required topics
-  char subuf[38];
+  char subuf[MQTT_MAX_TOPIC_LEN + 6];
 
   if (mqttDeviceTopic[0] != 0) {
-    strlcpy(subuf, mqttDeviceTopic, 33);
+    strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
     mqtt->subscribe(subuf, 0);
     strcat_P(subuf, PSTR("/col"));
     mqtt->subscribe(subuf, 0);
-    strlcpy(subuf, mqttDeviceTopic, 33);
+    strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
     strcat_P(subuf, PSTR("/api"));
     mqtt->subscribe(subuf, 0);
   }
 
   if (mqttGroupTopic[0] != 0) {
-    strlcpy(subuf, mqttGroupTopic, 33);
+    strlcpy(subuf, mqttGroupTopic, MQTT_MAX_TOPIC_LEN + 1);
     mqtt->subscribe(subuf, 0);
     strcat_P(subuf, PSTR("/col"));
     mqtt->subscribe(subuf, 0);
-    strlcpy(subuf, mqttGroupTopic, 33);
+    strlcpy(subuf, mqttGroupTopic, MQTT_MAX_TOPIC_LEN + 1);
     strcat_P(subuf, PSTR("/api"));
     mqtt->subscribe(subuf, 0);
   }
@@ -158,19 +158,19 @@ void publishMqtt()
 
   #ifndef USERMOD_SMARTNEST
   char s[10];
-  char subuf[48];
+  char subuf[MQTT_MAX_TOPIC_LEN + 16];
 
   sprintf_P(s, PSTR("%u"), bri);
-  strlcpy(subuf, mqttDeviceTopic, 33);
+  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(subuf, PSTR("/g"));
   mqtt->publish(subuf, 0, retainMqttMsg, s);         // optionally retain message (#2263)
 
   sprintf_P(s, PSTR("#%06X"), (col[3] << 24) | (col[0] << 16) | (col[1] << 8) | (col[2]));
-  strlcpy(subuf, mqttDeviceTopic, 33);
+  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(subuf, PSTR("/c"));
   mqtt->publish(subuf, 0, retainMqttMsg, s);         // optionally retain message (#2263)
 
-  strlcpy(subuf, mqttDeviceTopic, 33);
+  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(subuf, PSTR("/status"));
   mqtt->publish(subuf, 0, true, "online");          // retain message for a LWT
 
@@ -178,7 +178,7 @@ void publishMqtt()
   DynamicBuffer buf(1024);
   bufferPrint pbuf(buf.data(), buf.size());
   XML_response(pbuf);
-  strlcpy(subuf, mqttDeviceTopic, 33);
+  strlcpy(subuf, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(subuf, PSTR("/v"));
   mqtt->publish(subuf, 0, retainMqttMsg, buf.data(), pbuf.size());   // optionally retain message (#2263)
   #endif
@@ -211,7 +211,7 @@ bool initMqtt()
   if (mqttUser[0] && mqttPass[0]) mqtt->setCredentials(mqttUser, mqttPass);
 
   #ifndef USERMOD_SMARTNEST
-  strlcpy(mqttStatusTopic, mqttDeviceTopic, 33);
+  strlcpy(mqttStatusTopic, mqttDeviceTopic, MQTT_MAX_TOPIC_LEN + 1);
   strcat_P(mqttStatusTopic, PSTR("/status"));
   mqtt->setWill(mqttStatusTopic, 0, true, "offline"); // LWT message
   #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -483,7 +483,7 @@ WLED_GLOBAL unsigned long lastMqttReconnectAttempt _INIT(0);  // used for other 
   #endif
 WLED_GLOBAL AsyncMqttClient *mqtt _INIT(NULL);
 WLED_GLOBAL bool mqttEnabled _INIT(false);
-WLED_GLOBAL char mqttStatusTopic[MQTT_MAX_TOPIC_LEN + 8] _INIT("");            // this must be global because of async handlers
+WLED_GLOBAL char mqttStatusTopic[MQTT_MAX_TOPIC_LEN + 8] _INIT("");         // this must be global because of async handlers
 WLED_GLOBAL char mqttDeviceTopic[MQTT_MAX_TOPIC_LEN + 1] _INIT("");         // main MQTT topic (individual per device, default is wled/mac)
 WLED_GLOBAL char mqttGroupTopic[MQTT_MAX_TOPIC_LEN + 1]  _INIT("wled/all"); // second MQTT topic (for example to group devices)
 WLED_GLOBAL char mqttServer[MQTT_MAX_SERVER_LEN + 1]     _INIT("");         // both domains and IPs should work (no SSL)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -476,7 +476,7 @@ WLED_GLOBAL uint16_t pollReplyCount _INIT(0);                     // count numbe
 WLED_GLOBAL unsigned long lastMqttReconnectAttempt _INIT(0);  // used for other periodic tasks too
 #ifndef WLED_DISABLE_MQTT
   #ifndef MQTT_MAX_TOPIC_LEN
-    #define MQTT_MAX_TOPIC_LEN 32  // should not be less than 32. might cause trouble when increased with usermods active that do not handle this correctly.
+    #define MQTT_MAX_TOPIC_LEN 32
   #endif
   #ifndef MQTT_MAX_SERVER_LEN
     #define MQTT_MAX_SERVER_LEN 32

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -476,7 +476,7 @@ WLED_GLOBAL uint16_t pollReplyCount _INIT(0);                     // count numbe
 WLED_GLOBAL unsigned long lastMqttReconnectAttempt _INIT(0);  // used for other periodic tasks too
 #ifndef WLED_DISABLE_MQTT
   #ifndef MQTT_MAX_TOPIC_LEN
-    #define MQTT_MAX_TOPIC_LEN 32
+    #define MQTT_MAX_TOPIC_LEN 32  // should not be less than 32. might cause trouble when increased with usermods active that do not handle this correctly.
   #endif
   #ifndef MQTT_MAX_SERVER_LEN
     #define MQTT_MAX_SERVER_LEN 32

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -483,10 +483,10 @@ WLED_GLOBAL unsigned long lastMqttReconnectAttempt _INIT(0);  // used for other 
   #endif
 WLED_GLOBAL AsyncMqttClient *mqtt _INIT(NULL);
 WLED_GLOBAL bool mqttEnabled _INIT(false);
-WLED_GLOBAL char mqttStatusTopic[40] _INIT("");            // this must be global because of async handlers
-WLED_GLOBAL char mqttDeviceTopic[MQTT_MAX_TOPIC_LEN+1] _INIT("");         // main MQTT topic (individual per device, default is wled/mac)
-WLED_GLOBAL char mqttGroupTopic[MQTT_MAX_TOPIC_LEN+1]  _INIT("wled/all"); // second MQTT topic (for example to group devices)
-WLED_GLOBAL char mqttServer[MQTT_MAX_SERVER_LEN+1]     _INIT("");         // both domains and IPs should work (no SSL)
+WLED_GLOBAL char mqttStatusTopic[MQTT_MAX_TOPIC_LEN + 8] _INIT("");            // this must be global because of async handlers
+WLED_GLOBAL char mqttDeviceTopic[MQTT_MAX_TOPIC_LEN + 1] _INIT("");         // main MQTT topic (individual per device, default is wled/mac)
+WLED_GLOBAL char mqttGroupTopic[MQTT_MAX_TOPIC_LEN + 1]  _INIT("wled/all"); // second MQTT topic (for example to group devices)
+WLED_GLOBAL char mqttServer[MQTT_MAX_SERVER_LEN + 1]     _INIT("");         // both domains and IPs should work (no SSL)
 WLED_GLOBAL char mqttUser[41] _INIT("");                   // optional: username for MQTT auth
 WLED_GLOBAL char mqttPass[65] _INIT("");                   // optional: password for MQTT auth
 WLED_GLOBAL char mqttClientID[41] _INIT("");               // override the client ID

--- a/wled00/wled_eeprom.cpp
+++ b/wled00/wled_eeprom.cpp
@@ -2,6 +2,10 @@
 #include <EEPROM.h>
 #include "wled.h"
 
+#if defined(WLED_ENABLE_MQTT) && MQTT_MAX_TOPIC_LEN < 32
+#error "MQTT topics length < 32 is not supported by the EEPROM module!"
+#endif
+
 /*
  * DEPRECATED, do not use for new settings
  * Only used to restore config from pre-0.11 installations using the deEEP() methods


### PR DESCRIPTION
See issue #4293.

As seen in `wled.h`, `MQTT_MAX_TOPIC_LEN` is currently defined to be `32`. All modified lines of code result in the same value by adding a number to `MQTT_MAX_TOPIC_LEN`, allowing this variable to be increased without the risk of buffer overflows at a later date or by someone compiling the project with the modification themselves.