### PR TITLE
Introduce printSetInputMaxlength to properly set an inputs maxlength …

### DIFF
--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -465,7 +465,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormValue(settingsScript,PSTR("MG"),mqttGroupTopic);
     printSetFormCheckbox(settingsScript,PSTR("BM"),buttonPublishMqtt);
     printSetFormCheckbox(settingsScript,PSTR("RT"),retainMqttMsg);
-    settingsScript.printf_P(PSTR("d.Sf.MD.maxlength=%d;d.Sf.MG.maxlength=%d;d.Sf.MS.maxlength=%d;"),
+    settingsScript.printf_P(PSTR("d.Sf.MD.maxLength=%d;d.Sf.MG.maxLength=%d;d.Sf.MS.maxLength=%d;"),
                   MQTT_MAX_TOPIC_LEN, MQTT_MAX_TOPIC_LEN, MQTT_MAX_SERVER_LEN);
     #else
     settingsScript.print(F("toggle('MQTT');"));    // hide MQTT settings


### PR DESCRIPTION
Relates to [!4295](https://github.com/Aircoookie/WLED/pull/4295) by fixing MQTT related code that deals with the `MQTT_MAX_TOPIC_LEN` variable.

Previously, the `maxlength` attribute on the `<input>` fields in `settings_sync.html` were set with `inputElement.maxlength = <length>`, however this did not seem to actually modify the `maxlength` attribute as seen in the screenshot (also I couldn't type any more characters than the previous maxlength setting):
![image](https://github.com/user-attachments/assets/f4b4aded-c5f7-4abb-947f-d1807ae2615e)

As seen, modifying `element.maxlength` does actually modify the variable, but it does not modify the `maxlength` attribute weirdly. Using `element.setAttribute("maxlength", X)` was the fix.

In this PR I've modified the code to implement a function to use this JS line instead of the one previously used.