### PR TITLE
Intermediate color updates while moving around the color wheel

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -276,7 +276,7 @@ function onLoad()
 	handleLocationHash();
 	cpick.on("input:end", () => {setColor(1);});
 	cpick.on("color:change", () => {updatePSliders()});
-	cpick.on("color:change", () => {updateIntermediateColor();
+	cpick.on("color:change", () => {updateIntermediateColor()});
 	pmtLS = localStorage.getItem('wledPmt');
 
 	// Load initial data

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -26,6 +26,7 @@ var pmt = 1, pmtLS = 0, pmtLast = 0;
 var lastinfo = {};
 var isM = false, mw = 0, mh=0;
 var ws, wsRpt=0;
+var lastIntermediateColorUpdate = new Date();
 var cfg = {
 	theme:{base:"dark", bg:{url:"", rnd: false, rndGrayscale: false, rndBlur: false}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
 	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
@@ -275,6 +276,7 @@ function onLoad()
 	handleLocationHash();
 	cpick.on("input:end", () => {setColor(1);});
 	cpick.on("color:change", () => {updatePSliders()});
+	cpick.on("color:change", () => {updateIntermediateColor();
 	pmtLS = localStorage.getItem('wledPmt');
 
 	// Load initial data
@@ -2590,6 +2592,14 @@ function updatePSliders() {
 
 	// update Kelvin slider
 	gId('sliderK').value = cpick.color.kelvin;
+}
+
+function updateIntermediateColor() {
+	const now = new Date();
+	if (now - lastIntermediateColorUpdate > 500) {
+		lastIntermediateColorUpdate = now;
+		setColor(1);
+	}
 }
 
 function hexEnter()


### PR DESCRIPTION
Push color changes when moving your finger/mouse around the color wheel every 500 ms, instead of only when the mouse/finger gets released from the color wheel.

This real-time color changing is similar to how Philips Hue does it in their app, and it makes it feel really nice and responsive.

The implementation almost seems TOO easy, it makes me think someone has tried this before and it did not get merged for some reason. Would love to hear your feedback.

One problem I'm seeing currently is that the C code does not handle it nicely when it gets a new color while it is transition from another color. The transition is smooth for the first update, but for the second update it jumps to the second color. Then for the next update it's smooth again, and it jumps again. Could be fixed by increasing the interval that the JS code sends updates. However it might be better to update the C code.