### PR TITLE
Swap release name to avoid macro expansion

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -414,7 +414,7 @@ board = esp32dev
 platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=ESP32 #-D WLED_DISABLE_BROWNOUT_DET
+build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=ESP32_Classic #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
 lib_deps = ${esp32.lib_deps}
   ${esp32.AR_lib_deps}


### PR DESCRIPTION
Fix for https://github.com/Aircoookie/WLED/issues/4260 