### PR TITLE
Defer calling begin() on buses

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1286,14 +1286,9 @@ void WS2812FX::finalizeInit() {
     _isOffRefreshRequired |= bus->isOffRefreshRequired() && !bus->isPWM(); // use refresh bit for phase shift with analog
     unsigned busEnd = bus->getStart() + bus->getLength();
     if (busEnd > _length) _length = busEnd;
-    #ifdef ESP8266
-    // why do we need to reinitialise GPIO3???
-    //if (!bus->isDigital() || bus->is2Pin()) continue;
-    //uint8_t pins[5];
-    //if (!bus->getPins(pins)) continue;
-    //BusDigital* bd = static_cast<BusDigital*>(bus);
-    //if (pins[0] == 3) bd->reinit();
-    #endif
+
+    // This must be done after all buses have been created, as some kinds (parallel I2S) interact
+    bus->begin();
   }
 
   Segment::maxWidth  = _length;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -410,7 +410,7 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
   };
 }
 
-void BusDigital::reinit() {
+void BusDigital::begin() {
   if (!_valid) return;
   PolyBus::begin(_busPtr, _iType, _pins);
 }
@@ -910,7 +910,7 @@ void BusManager::on() {
       if (busses[i]->isDigital() && busses[i]->getPins(pins)) {
         if (pins[0] == LED_BUILTIN || pins[1] == LED_BUILTIN) {
           BusDigital *bus = static_cast<BusDigital*>(busses[i]);
-          bus->reinit();
+          bus->begin();
           break;
         }
       }

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -79,6 +79,7 @@ class Bus {
 
     virtual ~Bus() {} //throw the bus under the bus
 
+    virtual void     begin() {};
     virtual void     show() = 0;
     virtual bool     canShow() const                          { return true; }
     virtual void     setStatusPixel(uint32_t c)                {}
@@ -213,7 +214,7 @@ class BusDigital : public Bus {
     uint16_t getLEDCurrent() const override  { return _milliAmpsPerLed; }
     uint16_t getUsedCurrent() const override { return _milliAmpsTotal; }
     uint16_t getMaxCurrent() const override  { return _milliAmpsMax; }
-    void reinit();
+    void begin() override;
     void cleanup();
 
     static std::vector<LEDType> getLEDTypes();

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -597,7 +597,7 @@ class PolyBus {
       case I_HS_P98_3: busPtr = new B_HS_P98_3(len, pins[1], pins[0]); break;
       case I_SS_P98_3: busPtr = new B_SS_P98_3(len, pins[1], pins[0]); break;
     }
-    begin(busPtr, busType, pins, clock_kHz);
+
     return busPtr;
   }
 


### PR DESCRIPTION
NeoPixelBus requires that all parallel I2S bus members be constructed before any of them call Begin().  Implement this by deferring the Begin() call to the end of the bus initialization process.  This replaces the "reinit" logic previously used to work around a similar initialization ordering issue for ESP8266 pins.

Fixes #4301.

This PR introduces a new virtual begin() call on Bus types, although it's only currently used on digital buses.  This seemed like a cleaner abstraction than requiring a bunch of type-checking logic at the point of use, and maps more closely to the NeoPixelBus expected call sequence.  It also leaves a hook behind for future bus types that might need separate initialization phases.