### PR TITLE
Update settings_sec.htm for buttons placment and warning text  ( Cosmetic change ) 

### DIFF
--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -60,8 +60,8 @@
 		<hr>
 		<h3>Backup & Restore</h3>
 		<div class="warn">&#9888; Restoring presets/configuration will OVERWRITE your current presets/configuration.<br>
-		Incorrect upload or configuration may require a factory reset or re-flashing of your ESP.</div>
-		For security reasons, passwords are not backed up.
+		Incorrect upload or configuration may require a factory reset or re-flashing of your ESP.<br>
+		For security reasons, passwords are not backed up.</div>
 		<a class="btn lnk" id="bckcfg" href="/presets.json" download="presets">Backup presets</a><br>
 		<div>Restore presets<br><input type="file" name="data" accept=".json"> <button type="button" onclick="uploadFile(d.Sf.data,'/presets.json');">Upload</button><br></div><br>
 		<a class="btn lnk" id="bckpresets" href="/cfg.json" download="cfg">Backup configuration</a><br>


### PR DESCRIPTION
Fix the  warning text and Backup presets button misalignment  in  settings_sec.htm .
Before and after view  below . PC browser tested are   firefox , chrome and edge . Phone tested are  Iphone7 and   Iphone10

![image](https://github.com/user-attachments/assets/88a8a883-4def-4b74-8ba9-fc81ce5b412e)

This is  a cosmetic change but may lead to confusion  otherwise 
