### PR TITLE
settings_leds: Initialize current limiter field

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -6,7 +6,7 @@
 	<title>LED Settings</title>
 	<script src="common.js" async type="text/javascript"></script>
 	<script>
-		var laprev=55,maxB=1,maxD=1,maxA=1,maxV=0,maxM=4000,maxPB=2048,maxL=1664,maxCO=5,maxLbquot=0; //maximum bytes for LED allocation: 4kB for 8266, 32kB for 32
+		var maxB=1,maxD=1,maxA=1,maxV=0,maxM=4000,maxPB=2048,maxL=1664,maxCO=5; //maximum bytes for LED allocation: 4kB for 8266, 32kB for 32
 		var oMaxB=1;
 		var customStarts=false,startsDirty=[];
 		function off(n)    { gN(n).value = -1;}

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -422,7 +422,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <option value="15">15mA (seed/fairy pixels)</option>
 <option value="0">Custom</option>
 </select><br>
-<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()" value="55"> mA<br></div>
+<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()"> mA<br></div>
 <div id="PSU${s}">PSU: <input name="MA${s}" type="number" class="xl" min="250" max="65000" oninput="UI()" value="250"> mA<br></div>
 </div>
 <div id="co${s}" style="display:inline">Color Order:
@@ -471,6 +471,8 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 				if (i >= maxB || twopinB >= 1)     disable(sel,'option[data-type="2P"]'); // NOTE: see isD2P()
 				disable(sel,`option[data-type^="${'A'.repeat(maxA-analogB+1)}"]`); // NOTE: see isPWM()
 				sel.selectedIndex = sel.querySelector('option:not(:disabled)').index;
+			    // initialize current limiter
+				enLA(d.Sf["LAsel"+s],s);
 			}
 			if (n==-1) {
 				o[--i].remove();--i;

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -422,7 +422,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <option value="15">15mA (seed/fairy pixels)</option>
 <option value="0">Custom</option>
 </select><br>
-<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()"> mA<br></div>
+<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()" value=55> mA<br></div>
 <div id="PSU${s}">PSU: <input name="MA${s}" type="number" class="xl" min="250" max="65000" oninput="UI()" value="250"> mA<br></div>
 </div>
 <div id="co${s}" style="display:inline">Color Order:

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -422,7 +422,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <option value="15">15mA (seed/fairy pixels)</option>
 <option value="0">Custom</option>
 </select><br>
-<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()" value=55> mA<br></div>
+<div id="LAdis${s}" style="display: none;">max. mA/LED: <input name="LA${s}" type="number" min="1" max="255" oninput="UI()" value="55"> mA<br></div>
 <div id="PSU${s}">PSU: <input name="MA${s}" type="number" class="xl" min="250" max="65000" oninput="UI()" value="250"> mA<br></div>
 </div>
 <div id="co${s}" style="display:inline">Color Order:


### PR DESCRIPTION
When adding a new bus, the numeric current limit field was not being initialized; this was causing it to send an empty value (interpreted as 0) when saved if the current limiter drop-down was never touched.

This is a fix for one of the issues reported in #4280.

------------

While this fix technically works, I'm not really satisfied with it -- it replicates the initialization value, so it has to be kept in sync with `LAsel` should that ever change.  I couldn't see an easy alternative, though.  Suggestions welcome!