### PR TITLE
Hotfix for #4335 - solves missed pixel problem in blends effect

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -4497,7 +4497,7 @@ uint16_t mode_blends(void) {
   unsigned offset = 0;
   for (unsigned i = 0; i < SEGLEN; i++) {
     SEGMENT.setPixelColor(i, pixels[offset++]);
-    if (offset > pixelLen) offset = 0;
+    if (offset >= pixelLen) offset = 0;
   }
 
   return FRAMETIME;


### PR DESCRIPTION
fixing an off-by-one error to solve #4335