### PR TITLE
Add UDP protocol for same-color range updates

### DIFF
--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -511,7 +511,7 @@ void handleNotifications()
   }
 
   //UDP realtime: 1 warls 2 drgb 3 drgbw
-  if (udpIn[0] > 0 && udpIn[0] < 5)
+  if (udpIn[0] > 0 && udpIn[0] < 7)
   {
     realtimeIP = (isSupp) ? notifier2Udp.remoteIP() : notifierUdp.remoteIP();
     DEBUG_PRINTLN(realtimeIP);
@@ -569,7 +569,17 @@ void handleNotifications()
         setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
         id++;
       }
+    } else if (udpIn[0] == 6) //scrgbw
+    {
+      uint8_t start = udpIn[2];
+      uint8_t count = udpIn[3];
+      for (size_t id = start; id<start+count; id++)
+      {
+        if (id >= totalLen) break;
+        setRealtimePixel(id, udpIn[4], udpIn[5], udpIn[6], udpIn[7]);
+      }
     }
+
     strip.show();
     return;
   }


### PR DESCRIPTION
Allows easily changing a number of leds to the same color at once, without having to send individual colors.

Especially useful to easily change the color of the whole strip or large parts of it to the same color. i.e. custom fade in animations

---

I added this as I couldn't find a protocol implementation that could easily flash the entire strip / control custom whole-strip fade animations.
Update entire ranges to a specific color should save bandwidth as the amount of bytes sent is kept at a minimum.

|Byte|Description|
|---|---|
|0 |Protocol = 6 |
| 1 | Timeout |
| 2 | Strip starting index |
| 3 | Number of LEDs to update from the starting index |
| 4 | Red value |
| 5 | Green value |
| 6 | Blue value |
| 7 | White value |

*Note*: The white value exists, because I own a strip that supports the white channel, and I thought that whilst the idea of this protocol is keeping the byte count at a minimum, adding the single white byte would be OK.

Example transmissions:
- `{ 6, 255, 0, 30, 255, 0, 0, 0 }` - Changes the first 30 leds to red
- `{ 6, 255, 30, 10, 0, 255, 0, 0 }` - Changes leds 31 to 40 to green