### PR TITLE
update platformio override example file (solves #4395)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -176,6 +176,7 @@ lib_deps =
 extra_scripts = ${scripts_defaults.extra_scripts}
 
 [esp8266]
+build_unflags = ${common.build_unflags}
 build_flags =
   -DESP8266
   -DFP_IN_IROM
@@ -242,6 +243,7 @@ lib_deps_compat =
 #platform = https://github.com/tasmota/platform-espressif32/releases/download/v2.0.2.3/platform-espressif32-2.0.2.3.zip
 platform = espressif32@3.5.0
 platform_packages = framework-arduinoespressif32 @ https://github.com/Aircoookie/arduino-esp32.git#1.0.6.4
+build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
   #-DCONFIG_LITTLEFS_FOR_IDF_3_2
@@ -263,6 +265,7 @@ lib_deps =
 AR_build_flags = -D USERMOD_AUDIOREACTIVE 
   -D sqrt_internal=sqrtf ;; -fsingle-precision-constant ;; forces ArduinoFFT to use float math (2x faster)
 AR_lib_deps = kosme/arduinoFFT @ 2.0.1
+board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 
 [esp32_idf_V4]
 ;; experimental build environment for ESP32 using ESP-IDF 4.4.x / arduino-esp32 v2.0.5
@@ -272,6 +275,7 @@ AR_lib_deps = kosme/arduinoFFT @ 2.0.1
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
 platform = espressif32@ ~6.3.2
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
+build_unflags = ${common.build_unflags}
 build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
   -DARDUINO_ARCH_ESP32 -DESP32
@@ -280,11 +284,13 @@ build_flags = -g
 lib_deps =
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
+board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
 platform = espressif32@ ~6.3.2
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
+build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32S2
@@ -298,11 +304,13 @@ build_flags = -g
 lib_deps =
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
+board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
 platform = espressif32@ ~6.3.2
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
+build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
   -DARDUINO_ARCH_ESP32C3
@@ -315,11 +323,13 @@ build_flags = -g
 lib_deps =
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
+board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
 platform = espressif32@ ~6.3.2
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
+build_unflags = ${common.build_unflags}
 build_flags = -g
   -DESP32
   -DARDUINO_ARCH_ESP32
@@ -333,6 +343,7 @@ build_flags = -g
 lib_deps =
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
   ${env.lib_deps}
+board_build.partitions = ${esp32.large_partitions}   ;; default partioning for 8MB flash - can be overridden in build envs
 
 
 # ------------------------------------------------------------------------------

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -241,13 +241,11 @@ lib_deps = ${esp8266.lib_deps}
 [env:esp32dev_qio80]
 extends = env:esp32dev  # we want to extend the existing esp32dev environment (and define only updated options)
 board = esp32dev
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags} ;; optional - includes USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32.lib_deps}
   ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
 monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 
@@ -257,13 +255,12 @@ board_build.flash_mode = qio
 ;; please erase your device before installing.
 extends = esp32_idf_V4  # based on newer "esp-idf V4" platform environment
 board = esp32dev
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}  ${esp32_idf_V4.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags} ;; includes USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
 monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32.default_partitions}
+board_build.partitions = ${esp32.default_partitions}  ;; if you get errors about "out of program space", change this to ${esp32.extended_partitions} or even ${esp32.big_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = dio
 
@@ -273,10 +270,8 @@ board = esp32-s2-saola-1
 platform = ${esp32s2.platform}
 platform_packages = ${esp32s2.platform_packages}
 framework = arduino
-board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 board_build.flash_mode = qio
 upload_speed = 460800
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s2.build_flags}
   ;-DLOLIN_WIFI_FIX ;; try this in case Wifi does not work
   -DARDUINO_USB_CDC_ON_BOOT=1
@@ -371,7 +366,6 @@ board_upload.maximum_size = 2097152
 extends = esp32              ;; use default esp32 platform
 board = esp32dev
 upload_speed = 460800
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags}
   -D WLED_RELEASE_NAME=\"ESP32_wemos_shield\"
   -D DATA_PINS=16
@@ -393,7 +387,6 @@ board_build.partitions = ${esp32.default_partitions}
 extends = esp32              ;; use default esp32 platform
 board = pico32               ;; pico32-D4 is different from the standard esp32dev
                              ;; hardware details from https://github.com/srg74/WLED-ESP32-pico
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags}
   -D WLED_RELEASE_NAME=\"pico32-D4\" -D SERVERNAME='"WLED-pico32"'
   -D WLED_DISABLE_ADALIGHT   ;; no serial-to-USB chip on this board - better to disable serial protocols
@@ -410,13 +403,8 @@ board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 
 [env:m5atom]
-board = esp32dev
-build_unflags = ${common.build_unflags}
+extends = env:esp32dev  # we want to extend the existing esp32dev environment (and define only updated options)
 build_flags = ${common.build_flags} ${esp32.build_flags} -D DATA_PINS=27 -D BTNPIN=39
-lib_deps = ${esp32.lib_deps}
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
-board_build.partitions = ${esp32.default_partitions}
 
 [env:sp501e]
 board = esp_wroom_02
@@ -515,9 +503,8 @@ lib_deps = ${esp8266.lib_deps}
 # EleksTube-IPS
 # ------------------------------------------------------------------------------
 [env:elekstube_ips]
+extends = esp32              ;; use default esp32 platform
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
 upload_speed = 921600
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_DISABLE_BROWNOUT_DET -D WLED_DISABLE_INFRARED
   -D USERMOD_RTC
@@ -542,4 +529,3 @@ monitor_filters = esp32_exception_decoder
 lib_deps =
   ${esp32.lib_deps}
   TFT_eSPI @ ^2.3.70
-board_build.partitions = ${esp32.default_partitions}

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -28,8 +28,8 @@ lib_deps = ${esp8266.lib_deps}
 ;  robtillaart/SHT85@~0.3.3
 ;  ;gmag11/QuickESPNow @ ~0.7.0 # will also load QuickDebug
 ;  https://github.com/blazoncek/QuickESPNow.git#optional-debug  ;; exludes debug library
-;  ${esp32.AR_lib_deps} ;; used for USERMOD_AUDIOREACTIVE
 ;  bitbank2/PNGdec@^1.0.1 ;; used for POV display uncomment following
+;  ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
 
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}
@@ -141,7 +141,8 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ;   -D PIR_SENSOR_MAX_SENSORS=2 # max allowable sensors (uses OR logic for triggering)
 ;
 ; Use Audioreactive usermod and configure I2S microphone
-;   -D USERMOD_AUDIOREACTIVE
+;   ${esp32.AR_build_flags} ;; default flags required to propery configure ArduinoFFT
+;   ;; don't forget to add ArduinoFFT to your libs_deps: ${esp32.AR_lib_deps}
 ;   -D AUDIOPIN=-1
 ;   -D DMTYPE=1     # 0-analog/disabled, 1-I2S generic, 2-ES7243, 3-SPH0645, 4-I2S+mclk, 5-I2S PDM
 ;   -D I2S_SDPIN=36
@@ -157,17 +158,22 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ;   -D USERMOD_POV_DISPLAY
 ; Use built-in or custom LED as a status indicator (assumes LED is connected to GPIO16)
 ;   -D STATUSLED=16
-;   
+;
 ; set the name of the module - make sure there is a quote-backslash-quote before the name and a backslash-quote-quote after the name
 ;   -D SERVERNAME="\"WLED\""
-;   
+;
 ; set the number of LEDs
-;   -D DEFAULT_LED_COUNT=30
+;   -D PIXEL_COUNTS=30
 ; or this for multiple outputs
 ;   -D PIXEL_COUNTS=30,30
 ;
 ; set the default LED type
-;   -D DEFAULT_LED_TYPE=22    # see const.h (TYPE_xxxx)
+;   -D LED_TYPES=22    # see const.h (TYPE_xxxx)
+; or this for multiple outputs
+;   -D LED_TYPES=TYPE_SK6812_RGBW,TYPE_WS2812_RGB
+;
+; set default color order of your led strip
+;   -D DEFAULT_LED_COLOR_ORDER=COL_ORDER_GRB
 ;
 ; set milliampere limit when using ESP power pin (or inadequate PSU) to power LEDs
 ;   -D ABL_MILLIAMPS_DEFAULT=850
@@ -176,9 +182,6 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ; enable IR by setting remote type
 ;   -D IRTYPE=0   # 0 Remote disabled | 1 24-key RGB | 2 24-key with CT | 3 40-key blue | 4 40-key RGB | 5 21-key RGB | 6 6-key black | 7 9-key red | 8 JSON remote
 ;   
-; set default color order of your led strip
-;   -D DEFAULT_LED_COLOR_ORDER=COL_ORDER_GRB
-;
 ; use PSRAM on classic ESP32 rev.1 (rev.3 or above has no issues)
 ;   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue   # needed only for classic ESP32 rev.1
 ;
@@ -241,7 +244,9 @@ platform = ${esp32.platform}
 platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
+  ${esp32.AR_build_flags} ;; optional - includes USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32.lib_deps}
+  ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
@@ -256,7 +261,9 @@ platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}  ${esp32_idf_V4.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
+  ${esp32.AR_build_flags} ;; includes USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32_idf_V4.lib_deps}
+  ${esp32.AR_lib_deps} ;; needed for USERMOD_AUDIOREACTIVE
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
@@ -307,7 +314,7 @@ platform = ${common.platform_wled_default}
 platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_USE_SHOJO_PCB
+build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_USE_SHOJO_PCB ;; NB: WLED_USE_SHOJO_PCB is not used anywhere in the source code. Not sure why its needed.
 lib_deps = ${esp8266.lib_deps}
 
 [env:d1_mini_debug]
@@ -373,7 +380,7 @@ build_flags = ${common.build_flags} ${esp32.build_flags}
   -D RLYPIN=19
   -D BTNPIN=17
   -D IRPIN=18
-  -D UWLED_USE_MY_CONFIG
+  -UWLED_USE_MY_CONFIG
   -D USERMOD_DALLASTEMPERATURE
   -D USERMOD_FOUR_LINE_DISPLAY
   -D TEMPERATURE_PIN=23
@@ -414,7 +421,7 @@ platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=-1 -D RLYPIN=-1 -D DATA_PINS=4,12,14,13,5
-                                            -D DEFAULT_LED_TYPE=TYPE_ANALOG_5CH -D WLED_DISABLE_INFRARED -D WLED_MAX_CCT_BLEND=0
+                                            -D LED_TYPES=TYPE_ANALOG_5CH -D WLED_DISABLE_INFRARED -D WLED_MAX_CCT_BLEND=0
 lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_15w_RGBCW]        ;15w bulb
@@ -424,7 +431,7 @@ platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=-1 -D RLYPIN=-1 -D DATA_PINS=4,12,14,5,13
-                                            -D DEFAULT_LED_TYPE=TYPE_ANALOG_5CH -D WLED_DISABLE_INFRARED -D WLED_MAX_CCT_BLEND=0 -D WLED_USE_IC_CCT
+                                            -D LED_TYPES=TYPE_ANALOG_5CH -D WLED_DISABLE_INFRARED -D WLED_MAX_CCT_BLEND=0 -D WLED_USE_IC_CCT
 lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_3Pin_Controller]        ;small controller with only data
@@ -500,7 +507,7 @@ build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_DISABLE_BROWNOU
   -D DATA_PINS=12
   -D RLYPIN=27
   -D BTNPIN=34
-  -D DEFAULT_LED_COUNT=6
+  -D PIXEL_COUNTS=6
   # Display config
   -D ST7789_DRIVER
   -D TFT_WIDTH=135

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -528,4 +528,4 @@ build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_DISABLE_BROWNOU
 monitor_filters = esp32_exception_decoder
 lib_deps =
   ${esp32.lib_deps}
-  TFT_eSPI @ ^2.3.70
+  TFT_eSPI @ 2.5.33  ;; this is the last version that compiles with the WLED default framework - newer versions require platform = espressif32 @ ^6.3.2

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -5,7 +5,7 @@
 # Please visit documentation: https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = WLED_tasmota_1M  # define as many as you need
+default_envs = WLED_generic8266_1M, esp32dev_V4_dio80  # put the name(s) of your own build environment here. You can define as many as you need
 
 #----------
 # SAMPLE
@@ -258,7 +258,7 @@ build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}  ${esp32_idf_V4.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
 lib_deps = ${esp32_idf_V4.lib_deps}
 monitor_filters = esp32_exception_decoder
-board_build.partitions = ${esp32_idf_V4.default_partitions}
+board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = dio
 
@@ -368,6 +368,7 @@ platform_packages = ${esp32.platform_packages}
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags}
+  -D WLED_RELEASE_NAME=\"ESP32_wemos_shield\"
   -D DATA_PINS=16
   -D RLYPIN=19
   -D BTNPIN=17
@@ -376,11 +377,11 @@ build_flags = ${common.build_flags} ${esp32.build_flags}
   -D USERMOD_DALLASTEMPERATURE
   -D USERMOD_FOUR_LINE_DISPLAY
   -D TEMPERATURE_PIN=23
-  -D USERMOD_AUDIOREACTIVE
+  ${esp32.AR_build_flags} ;; includes USERMOD_AUDIOREACTIVE
 lib_deps = ${esp32.lib_deps}
-  OneWire@~2.3.5
-  olikraus/U8g2 @ ^2.28.8
-  https://github.com/blazoncek/arduinoFFT.git
+  OneWire@~2.3.5          ;; needed for USERMOD_DALLASTEMPERATURE
+  olikraus/U8g2 @ ^2.28.8 ;; needed for USERMOD_FOUR_LINE_DISPLAY
+  ${esp32.AR_lib_deps}    ;; needed for USERMOD_AUDIOREACTIVE
 board_build.partitions = ${esp32.default_partitions}
 
 [env:m5atom]

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -141,7 +141,7 @@ build_flags = ${common.build_flags} ${esp8266.build_flags}
 ;   -D PIR_SENSOR_MAX_SENSORS=2 # max allowable sensors (uses OR logic for triggering)
 ;
 ; Use Audioreactive usermod and configure I2S microphone
-;   ${esp32.AR_build_flags} ;; default flags required to propery configure ArduinoFFT
+;   ${esp32.AR_build_flags} ;; default flags required to properly configure ArduinoFFT
 ;   ;; don't forget to add ArduinoFFT to your libs_deps: ${esp32.AR_lib_deps}
 ;   -D AUDIOPIN=-1
 ;   -D DMTYPE=1     # 0-analog/disabled, 1-I2S generic, 2-ES7243, 3-SPH0645, 4-I2S+mclk, 5-I2S PDM
@@ -239,7 +239,7 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=1 -D WLE
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp32dev_qio80]
-extends = env:esp32dev  # ww want to extend the existing esp32dev environment (and define only updated options)
+extends = env:esp32dev  # we want to extend the existing esp32dev environment (and define only updated options)
 board = esp32dev
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} #-D WLED_DISABLE_BROWNOUT_DET

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -389,6 +389,26 @@ lib_deps = ${esp32.lib_deps}
   ${esp32.AR_lib_deps}    ;; needed for USERMOD_AUDIOREACTIVE
 board_build.partitions = ${esp32.default_partitions}
 
+[env:esp32_pico-D4]
+extends = esp32              ;; use default esp32 platform
+board = pico32               ;; pico32-D4 is different from the standard esp32dev
+                             ;; hardware details from https://github.com/srg74/WLED-ESP32-pico
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp32.build_flags}
+  -D WLED_RELEASE_NAME=\"pico32-D4\" -D SERVERNAME='"WLED-pico32"'
+  -D WLED_DISABLE_ADALIGHT   ;; no serial-to-USB chip on this board - better to disable serial protocols
+  -D DATA_PINS=2,18          ;; LED pins
+  -D RLYPIN=19 -D BTNPIN=0 -D IRPIN=-1 ;; no default pin for IR
+  ${esp32.AR_build_flags}    ;; include USERMOD_AUDIOREACTIVE
+  -D UM_AUDIOREACTIVE_ENABLE ;; enable AR by default
+  ;; Audioreactive settings for on-board microphone (ICS-43432)
+  -D SR_DMTYPE=1 -D I2S_SDPIN=25 -D I2S_WSPIN=15 -D I2S_CKPIN=14
+  -D SR_SQUELCH=5 -D SR_GAIN=30
+lib_deps = ${esp32.lib_deps}
+  ${esp32.AR_lib_deps}       ;; needed for USERMOD_AUDIOREACTIVE
+board_build.partitions = ${esp32.default_partitions}
+board_build.f_flash = 80000000L
+
 [env:m5atom]
 board = esp32dev
 build_unflags = ${common.build_unflags}

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -239,9 +239,8 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=1 -D WLE
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp32dev_qio80]
+extends = env:esp32dev  # ww want to extend the existing esp32dev environment (and define only updated options)
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags} ;; optional - includes USERMOD_AUDIOREACTIVE
@@ -256,9 +255,8 @@ board_build.flash_mode = qio
 ;; experimental ESP32 env using ESP-IDF V4.4.x
 ;; Warning: this build environment is not stable!!
 ;; please erase your device before installing.
+extends = esp32_idf_V4  # based on newer "esp-idf V4" platform environment
 board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags}  ${esp32_idf_V4.build_flags} #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags} ;; includes USERMOD_AUDIOREACTIVE
@@ -270,6 +268,7 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = dio
 
 [env:esp32s2_saola]
+extends = esp32s2
 board = esp32-s2-saola-1
 platform = ${esp32s2.platform}
 platform_packages = ${esp32s2.platform_packages}
@@ -369,9 +368,8 @@ board_upload.flash_size = 2MB
 board_upload.maximum_size = 2097152
 
 [env:wemos_shield_esp32]
+extends = esp32              ;; use default esp32 platform
 board = esp32dev
-platform = ${esp32.platform}
-platform_packages = ${esp32.platform_packages}
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags}


### PR DESCRIPTION
* Solved platformIO errors due to undefined references and undefined environments
* Adjusted description of build_flags to match version 0.15
* Added "extends" to esp32 build environments
* moved default build_unflags and board_build.partitions into the main platformio.ini, so custom builds can inherit them with `extends = `
* Additional example environment for pico32-D4 board (see https://github.com/srg74/WLED-ESP32-pico)

I have successfully built some randomly picked firmware envs, however did not test all of them.