### PR TITLE
Prevent UI from cutting off on mobile devices

### DIFF
--- a/wled00/data/index.css
+++ b/wled00/data/index.css
@@ -277,6 +277,7 @@ button {
 .tab {
 	background-color: transparent;
 	color: var(--c-d);
+	padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
 .bot {

--- a/wled00/data/index.htm
+++ b/wled00/data/index.htm
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
 	<meta charset="utf-8">
 	<meta name="theme-color" content="#222222">
 	<meta content="yes" name="apple-mobile-web-app-capable">


### PR DESCRIPTION
When the web UI is added to the iOS home screen (via the "Add to Home Screen" option) the navigation tabs are cut off.

This PR adds some padding so they aren't cut off anymore.

| Before | After |
|-----------|----|
| ![image](https://github.com/user-attachments/assets/daa6d314-793a-41be-94b2-1756fd44ec9f) | ![image](https://github.com/user-attachments/assets/c66d3091-24f6-428c-b7b7-fa5d1b0026c7) |

Notice the buttons on the bottom are no longer cut off. *Please ignore the error that appears, it is unrelated.*

Side note: if there is interest in adding more "PWA" functionality to the UI (e.g. change the icon on the home screen, add a message when it's disconnected, let me know and I will open another PR :smile:  ).
