### PR TITLE
fixed typo in LED Preferences

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -761,7 +761,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 		Enable automatic brightness limiter: <input type="checkbox" name="ABL" onchange="enABL()"><br>
 		<div id="abl">
 			<i>Automatically limits brightness to stay close to the limit.<br>
-				Keep at &lt;1A if poweing LEDs directly from the ESP 5V pin!<br>
+				Keep at &lt;1A if powering LEDs directly from the ESP 5V pin!<br>
 				If using multiple outputs it is recommended to use per-output limiter.<br>
 				Analog (PWM) and virtual LEDs cannot use automatic brightness limiter.<br></i>
 			<div id="psuMA">Maximum PSU Current: <input name="MA" type="number" class="xl" min="250" max="65000" oninput="UI()" required> mA<br></div>


### PR DESCRIPTION
Changed "poweing" to "powering" within a text block of LED Preferences.