### PR TITLE
replacement for fastled sqrt16()

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5475,15 +5475,15 @@ uint16_t mode_2Dmetaballs(void) {   // Metaballs by Stefan Petrick. Cannot have 
       // and add them together with weightening
       unsigned dx = abs(x - x1);
       unsigned dy = abs(y - y1);
-      unsigned dist = 2 * sqrt16((dx * dx) + (dy * dy));
+      unsigned dist = 2 * sqrt16_bw((dx * dx) + (dy * dy));
 
       dx = abs(x - x2);
       dy = abs(y - y2);
-      dist += sqrt16((dx * dx) + (dy * dy));
+      dist += sqrt16_bw((dx * dx) + (dy * dy));
 
       dx = abs(x - x3);
       dy = abs(y - y3);
-      dist += sqrt16((dx * dx) + (dy * dy));
+      dist += sqrt16_bw((dx * dx) + (dy * dy));
 
       // inverse result
       int color = dist ? 1000 / dist : 255;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5475,15 +5475,15 @@ uint16_t mode_2Dmetaballs(void) {   // Metaballs by Stefan Petrick. Cannot have 
       // and add them together with weightening
       unsigned dx = abs(x - x1);
       unsigned dy = abs(y - y1);
-      unsigned dist = 2 * sqrt16_bw((dx * dx) + (dy * dy));
+      unsigned dist = 2 * sqrt32_bw((dx * dx) + (dy * dy));
 
       dx = abs(x - x2);
       dy = abs(y - y2);
-      dist += sqrt16_bw((dx * dx) + (dy * dy));
+      dist += sqrt32_bw((dx * dx) + (dy * dy));
 
       dx = abs(x - x3);
       dy = abs(y - y3);
-      dist += sqrt16_bw((dx * dx) + (dy * dy));
+      dist += sqrt32_bw((dx * dx) + (dy * dy));
 
       // inverse result
       int color = dist ? 1000 / dist : 255;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -678,7 +678,7 @@ uint16_t Segment::virtualLength() const {
         vLen = max(vW,vH); // get the longest dimension
         break;
       case M12_pArc:
-        vLen = sqrt16_bw(vH*vH + vW*vW); // use diagonal
+        vLen = sqrt32_bw(vH*vH + vW*vW); // use diagonal
         break;
       case M12_sPinwheel:
         vLen = getPinwheelLength(vW, vH);
@@ -921,7 +921,7 @@ uint32_t IRAM_ATTR_YN Segment::getPixelColor(int i) const
         break; }
       case M12_pArc:
         if (i >= vW && i >= vH) {
-          unsigned vI = sqrt16_bw(i*i/2);
+          unsigned vI = sqrt32_bw(i*i/2);
           return getPixelColorXY(vI,vI); // use diagonal
         }
       case M12_pCorner:

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -678,7 +678,7 @@ uint16_t Segment::virtualLength() const {
         vLen = max(vW,vH); // get the longest dimension
         break;
       case M12_pArc:
-        vLen = sqrt16(vH*vH + vW*vW); // use diagonal
+        vLen = sqrt16_bw(vH*vH + vW*vW); // use diagonal
         break;
       case M12_sPinwheel:
         vLen = getPinwheelLength(vW, vH);
@@ -921,7 +921,7 @@ uint32_t IRAM_ATTR_YN Segment::getPixelColor(int i) const
         break; }
       case M12_pArc:
         if (i >= vW && i >= vH) {
-          unsigned vI = sqrt16(i*i/2);
+          unsigned vI = sqrt16_bw(i*i/2);
           return getPixelColorXY(vI,vI); // use diagonal
         }
       case M12_pCorner:

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -549,6 +549,7 @@ float asin_t(float x);
 template <typename T> T atan_t(T x);
 float floor_t(float x);
 float fmod_t(float num, float denom);
+uint8_t sqrt16_bw(uint16_t x);
 #define sin_t sin_approx
 #define cos_t cos_approx
 #define tan_t tan_approx

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -549,7 +549,7 @@ float asin_t(float x);
 template <typename T> T atan_t(T x);
 float floor_t(float x);
 float fmod_t(float num, float denom);
-uint8_t sqrt16_bw(uint16_t x);
+uint32_t sqrt32_bw(uint32_t x);
 #define sin_t sin_approx
 #define cos_t cos_approx
 #define tan_t tan_approx

--- a/wled00/wled_math.cpp
+++ b/wled00/wled_math.cpp
@@ -222,13 +222,14 @@ float fmod_t(float num, float denom) {
 }
 
 // bit-wise integer square root calculation (exact)
-uint8_t sqrt16_bw(uint16_t x) {
+uint32_t sqrt32_bw(uint32_t x) {
   uint32_t res = 0;
   uint32_t bit;
   uint32_t num = x; // use 32bit for faster calculation
 
-  if(num < 0x40)  bit = 1 << 6; // speed optimization for small numbers < 64 (mostly used)
-  else bit = 1 << 14; // start with highest power of 4 <= 2^16
+  if(num < 1 << 10)  bit = 1 << 10; // speed optimization for small numbers < 32^2
+  else if (num < 1 << 20) bit = 1 << 20; // speed optimization for medium numbers < 1024^2
+  else bit = 1 << 30; // start with highest power of 4 <= 2^32
 
   while (bit > num) bit >>= 2; // reduce iterations
 

--- a/wled00/wled_math.cpp
+++ b/wled00/wled_math.cpp
@@ -220,3 +220,26 @@ float fmod_t(float num, float denom) {
   #endif
   return res;
 }
+
+// bit-wise integer square root calculation (exact)
+uint8_t sqrt16_bw(uint16_t x) {
+  uint32_t res = 0;
+  uint32_t bit;
+  uint32_t num = x; // use 32bit for faster calculation
+
+  if(num < 0x40)  bit = 1 << 6; // speed optimization for small numbers < 64 (mostly used)
+  else bit = 1 << 14; // start with highest power of 4 <= 2^16
+
+  while (bit > num) bit >>= 2; // reduce iterations
+
+  while (bit != 0) {
+    if (num >= res + bit) {
+      num -= res + bit;
+      res = (res >> 1) + bit;
+    } else {
+      res >>= 1;
+    }
+    bit >>= 2;
+  }
+  return res;
+}


### PR DESCRIPTION
replacing yet another fastled function: it is about 10% slower for numbers smaller 128 but faster for larger numbers. Speed difference is irrelevant to WLED (we are talking 30ns slower per call on a C3) but it saves some flash and takes us one step closer to ditching fastled.