### PR TITLE
Add correct pin availability for ESP32 Mini modules

### DIFF
--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -214,7 +214,18 @@ bool PinManager::isPinOk(byte gpio, bool output)
     // JTAG: GPIO39-42 are usually used for inline debugging
     // GPIO46 is input only and pulled down
   #else
-    if (gpio > 5 && gpio < 12) return false;      //SPI flash pins
+
+    if (strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) {
+      // this chip has 4 MB of internal Flash and different packaging, so available pins are different!
+      if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio =< 8)) ||
+          (gpio == 11) || (gpio == 16) || (gpio == 17) || (gpio == 20) || 
+          (gpio == 24) || ((gpio >= 28) && (gpio <= 31)))
+        return false;
+    } else {
+      // for classic ESP32 (non-mini) modules, these are the SPI flash pins
+      if (gpio > 5 && gpio < 12) return false;      //SPI flash pins
+    }
+
     if (strncmp_P(PSTR("ESP32-PICO"), ESP.getChipModel(), 10) == 0 && (gpio == 16 || gpio == 17)) return false; // PICO-D4: gpio16+17 are in use for onboard SPI FLASH
     if (gpio == 16 || gpio == 17) return !psramFound(); //PSRAM pins on ESP32 (these are IO)
   #endif

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -215,7 +215,9 @@ bool PinManager::isPinOk(byte gpio, bool output)
     // GPIO46 is input only and pulled down
   #else
 
+    Serial.printf("GPIO TEST %d\n\r", gpio);
     if (strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) {
+      Serial.println("U4WDH");
       // this chip has 4 MB of internal Flash and different packaging, so available pins are different!
       if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio <= 8)) ||
           (gpio == 11) || (gpio == 16) || (gpio == 17) || (gpio == 20) || 

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -215,9 +215,8 @@ bool PinManager::isPinOk(byte gpio, bool output)
     // GPIO46 is input only and pulled down
   #else
 
-    Serial.printf("GPIO TEST %d\n\r", gpio);
-    if (strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) {
-      Serial.println("U4WDH");
+    if ((strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) ||    // this is the correct identifier, but....
+        (strncmp_P(PSTR("ESP32-PICO-D2"), ESP.getChipModel(), 13) == 0)) {  // https://github.com/espressif/arduino-esp32/issues/10683
       // this chip has 4 MB of internal Flash and different packaging, so available pins are different!
       if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio <= 8)) ||
           (gpio == 11) || (gpio == 16) || (gpio == 17) || (gpio == 20) || 

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -218,16 +218,16 @@ bool PinManager::isPinOk(byte gpio, bool output)
     if ((strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) ||    // this is the correct identifier, but....
         (strncmp_P(PSTR("ESP32-PICO-D2"), ESP.getChipModel(), 13) == 0)) {  // https://github.com/espressif/arduino-esp32/issues/10683
       // this chip has 4 MB of internal Flash and different packaging, so available pins are different!
-      if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio <= 8)) ||
-          (gpio == 11) || (gpio == 16) || (gpio == 17) || (gpio == 20) || 
-          (gpio == 24) || ((gpio >= 28) && (gpio <= 31)))
+      if (((gpio > 5) && (gpio < 9)) || (gpio == 11))
         return false;
     } else {
       // for classic ESP32 (non-mini) modules, these are the SPI flash pins
       if (gpio > 5 && gpio < 12) return false;      //SPI flash pins
     }
 
-    if (strncmp_P(PSTR("ESP32-PICO"), ESP.getChipModel(), 10) == 0 && (gpio == 16 || gpio == 17)) return false; // PICO-D4: gpio16+17 are in use for onboard SPI FLASH
+    if (((strncmp_P(PSTR("ESP32-PICO"), ESP.getChipModel(), 10) == 0) ||
+         (strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0))
+        && (gpio == 16 || gpio == 17)) return false; // PICO-D4/U4WDH: gpio16+17 are in use for onboard SPI FLASH
     if (gpio == 16 || gpio == 17) return !psramFound(); //PSRAM pins on ESP32 (these are IO)
   #endif
     if (output) return digitalPinCanOutput(gpio);

--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -217,7 +217,7 @@ bool PinManager::isPinOk(byte gpio, bool output)
 
     if (strncmp_P(PSTR("ESP32-U4WDH"), ESP.getChipModel(), 11) == 0) {
       // this chip has 4 MB of internal Flash and different packaging, so available pins are different!
-      if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio =< 8)) ||
+      if ((gpio == 1) || (gpio == 3) || ((gpio >= 6) && (gpio <= 8)) ||
           (gpio == 11) || (gpio == 16) || (gpio == 17) || (gpio == 20) || 
           (gpio == 24) || ((gpio >= 28) && (gpio <= 31)))
         return false;


### PR DESCRIPTION
ESP32 Mini modules (https://www.espressif.com/en/module/esp32-mini-1-en) from Espressif have /slightly/ different pins available due to having internal SPI flash on different pins than WROVER/WROOMs. this code checks if its part of the "ESP32-U4WDH" family (or, due to https://github.com/espressif/arduino-esp32/issues/10683 may be called "ESP32-PICO-D2")