### PR TITLE
Swap AnimARTrix to be platformio library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -167,7 +167,7 @@ lib_deps =
     ;electroniccats/MPU6050 @1.0.1
   # For -D USERMOD_ANIMARTRIX
   # CC BY-NC 3.0 licensed effects by Stefan Petrick, include this usermod only if you accept the terms!
-    ;https://github.com/netmindz/animartrix.git#18bf17389e57c69f11bc8d04ebe1d215422c7fb7
+    ; AnimartrixUsermod=symlink://./usermods/usermod_v2_animartrix/
   # SHT85
     ;robtillaart/SHT85@~0.3.3
   # Audioreactive usermod

--- a/usermods/usermod_v2_animartrix/library.json
+++ b/usermods/usermod_v2_animartrix/library.json
@@ -1,0 +1,6 @@
+{
+  "name": "AnimartrixUsermod",
+  "dependencies": {
+    "Animartrix": "https://github.com/netmindz/animartrix.git#b172586"
+  }
+}

--- a/usermods/usermod_v2_animartrix/readme.md
+++ b/usermods/usermod_v2_animartrix/readme.md
@@ -1,6 +1,6 @@
 # ANIMartRIX
 
-Addes the effects from ANIMartRIX to WLED
+Adds the effects from ANIMartRIX to WLED
 
 CC BY-NC 3.0 licensed effects by Stefan Petrick, include this usermod only if you accept the terms!
 
@@ -8,7 +8,7 @@ CC BY-NC 3.0 licensed effects by Stefan Petrick, include this usermod only if yo
 
 Please uncomment the two references to ANIMartRIX in your platform.ini 
 
-lib_dep to a version of https://github.com/netmindz/animartrix.git
+lib_dep needs to include AnimartrixUsermod=symlink://./usermods/usermod_v2_animartrix/
 and the build_flags  -D USERMOD_ANIMARTRIX
 
 


### PR DESCRIPTION
Change the usermod to be proper platformIO library. 

It would be nicer if we could just reference the usermod by name in the dependencies, but I can't see how to treat a local directory like a registry where you only include what you need. It seems you either just pull in every file or ignored.

Using the symlink approach at least means we can still selectively include what we need and take advantage of defining the dependencies of the usermod in the library.json file rather than listing dependencies in the readme to be added to lib_deps