### PR TITLE
Swap to tasmota/platform-espressif32

### DIFF
--- a/boards/lolin_s3_mini.json
+++ b/boards/lolin_s3_mini.json
@@ -1,0 +1,47 @@
+{
+    "build": {
+      "arduino": {
+        "ldscript": "esp32s3_out.ld",
+        "memory_type": "qio_qspi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DBOARD_HAS_PSRAM",
+        "-DARDUINO_LOLIN_S3_MINI",
+        "-DARDUINO_USB_MODE=1"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "hwids": [
+        [
+          "0x303A",
+          "0x8167"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "lolin_s3_mini"
+    },
+    "connectivity": [
+      "bluetooth",
+      "wifi"
+    ],
+    "debug": {
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "name": "WEMOS LOLIN S3 Mini",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 460800
+    },
+    "url": "https://www.wemos.cc/en/latest/s3/index.html",
+    "vendor": "WEMOS"
+}
+  

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
+default_envs = nodemcuv2, esp8266_2m, esp8266_2m_tasmota, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
@@ -379,6 +379,14 @@ platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02\"
+lib_deps = ${esp8266.lib_deps}
+
+[env:esp8266_2m_tasmota]
+board = esp_wroom_02
+platform = https://github.com/tasmota/platform-espressif8266#2024.09.00 ;; TODO: not sure this is the correct version
+board_build.ldscript = ${common.ldscript_2m512k}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02_Tasmota\"
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp8266_2m_compat]

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp8266_2m_tasmota, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
@@ -379,14 +379,6 @@ platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02\"
-lib_deps = ${esp8266.lib_deps}
-
-[env:esp8266_2m_tasmota]
-board = esp_wroom_02
-platform = https://github.com/tasmota/platform-espressif8266#2024.09.00 ;; TODO: not sure this is the correct version
-board_build.ldscript = ${common.ldscript_2m512k}
-build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02_Tasmota\"
 lib_deps = ${esp8266.lib_deps}
 
 [env:esp8266_2m_compat]

--- a/platformio.ini
+++ b/platformio.ini
@@ -528,6 +528,7 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 lib_deps = ${esp32c3.lib_deps}
+board_build.flash_mode = dio
 
 [env:esp32s3dev_16MB_opi]
 ;; ESP32-S3 development board, with 16MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
 
 src_dir  = ./wled00
 data_dir = ./wled00/data
@@ -428,6 +428,18 @@ build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32\" #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
 lib_deps = ${esp32.lib_deps}
+  ${esp32.AR_lib_deps}
+monitor_filters = esp32_exception_decoder
+board_build.partitions = ${esp32.default_partitions}
+
+[env:esp32dev_V4]
+board = esp32dev
+platform = ${esp32_idf_V4.platform}
+platform_packages = ${esp32_idf_V4.platform_packages}
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_V4\" #-D WLED_DISABLE_BROWNOUT_DET
+  ${esp32.AR_build_flags}
+lib_deps = ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}

--- a/platformio.ini
+++ b/platformio.ini
@@ -273,8 +273,9 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
+
+;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.02/platform-espressif32.zip ;; Tasmota Arduino Core 2.0.9 with IPv6 support, based on IDF 4.4.4
-platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
@@ -289,7 +290,6 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 [esp32s2]
 ;; generic definitions for all ESP32-S2 boards
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -309,7 +309,6 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DARDUINO_ARCH_ESP32
@@ -328,7 +327,6 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -DESP32
@@ -435,7 +433,6 @@ board_build.partitions = ${esp32.default_partitions}
 [env:esp32dev_V4]
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
-; platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_V4\" #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
@@ -447,7 +444,6 @@ board_build.partitions = ${esp32.default_partitions}
 [env:esp32dev_8M]
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_8M\" #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
@@ -463,7 +459,6 @@ board_upload.maximum_size = 8388608
 [env:esp32dev_16M]
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_16M\" #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}
@@ -506,7 +501,6 @@ board_build.partitions = ${esp32.default_partitions}
 [env:esp32_wrover]
 extends = esp32_idf_V4
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio

--- a/platformio.ini
+++ b/platformio.ini
@@ -275,7 +275,7 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
 
 ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
-platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.02/platform-espressif32.zip ;; Tasmota Arduino Core 2.0.9 with IPv6 support, based on IDF 4.4.4
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.00/platform-espressif32.zip ;; Tasmota Arduino Core 2.0.18 with IPv6 support, based on IDF 4.4.8 
 build_unflags = ${common.build_unflags}
 build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one

--- a/platformio.ini
+++ b/platformio.ini
@@ -273,7 +273,7 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 ;;
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
-platform = espressif32@ ~6.3.2
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2023.06.02/platform-espressif32.zip ;; Tasmota Arduino Core 2.0.9 with IPv6 support, based on IDF 4.4.4
 platform_packages = platformio/framework-arduinoespressif32 @ 3.20009.0    ;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
 build_unflags = ${common.build_unflags}
 build_flags = -g
@@ -435,7 +435,7 @@ board_build.partitions = ${esp32.default_partitions}
 [env:esp32dev_V4]
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
+; platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_V4\" #-D WLED_DISABLE_BROWNOUT_DET
   ${esp32.AR_build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -448,7 +448,7 @@ lib_deps = ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
-board_build.flash_mode = qio ;; TODO: is this the correct flash mode?
+board_build.flash_mode = dio
 
 [env:esp32dev_8M]
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -440,6 +440,7 @@ lib_deps = ${esp32_idf_V4.lib_deps}
   ${esp32.AR_lib_deps}
 monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
+board_build.flash_mode = qio ;; TODO: is this the correct flash mode?
 
 [env:esp32dev_8M]
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -528,7 +528,7 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 lib_deps = ${esp32c3.lib_deps}
-board_build.flash_mode = dio
+board_build.flash_mode = qio
 
 [env:esp32s3dev_16MB_opi]
 ;; ESP32-S3 development board, with 16MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)

--- a/platformio.ini
+++ b/platformio.ini
@@ -274,7 +274,7 @@ board_build.partitions = ${esp32.default_partitions}   ;; default partioning for
 ;; please note that you can NOT update existing ESP32 installs with a "V4" build. Also updating by OTA will not work properly.
 ;; You need to completely erase your device (esptool erase_flash) first, then install the "V4" build from VSCode+platformio.
 
-;; select arduino-esp32 v2.0.9 (arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them)
+;; arduino-esp32 2.0.10 thru 2.0.14 are buggy so avoid them
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2024.06.00/platform-espressif32.zip ;; Tasmota Arduino Core 2.0.18 with IPv6 support, based on IDF 4.4.8 
 build_unflags = ${common.build_unflags}
 build_flags = -g

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp8266_2m_tasmota, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
+default_envs = nodemcuv2, esp8266_2m, esp8266_2m_tasmota, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover
 
 src_dir  = ./wled00
 data_dir = ./wled00/data

--- a/platformio.ini
+++ b/platformio.ini
@@ -516,7 +516,6 @@ lib_deps = ${esp32_idf_V4.lib_deps}
 [env:esp32c3dev]
 extends = esp32c3
 platform = ${esp32c3.platform}
-platform_packages = ${esp32c3.platform_packages}
 framework = arduino
 board = esp32-c3-devkitm-1
 board_build.partitions = ${esp32.default_partitions}
@@ -534,7 +533,6 @@ lib_deps = ${esp32c3.lib_deps}
 board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
 board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
 platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_16MB_opi\"
@@ -557,7 +555,6 @@ monitor_filters = esp32_exception_decoder
 board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
 board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
 platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_8MB_opi\"
@@ -577,7 +574,6 @@ monitor_filters = esp32_exception_decoder
 ;; For ESP32-S3 WROOM-2, a.k.a. ESP32-S3 DevKitC-1 v1.1
 ;; with >= 16MB FLASH and >= 8MB PSRAM (memory_type: opi_opi)
 platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
 board = esp32s3camlcd ;; this is the only standard board with "opi_opi"
 board_build.arduino.memory_type = opi_opi
 upload_speed = 921600
@@ -604,7 +600,6 @@ monitor_filters = esp32_exception_decoder
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
 board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM 
 platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_4M_qspi\"
@@ -622,7 +617,6 @@ monitor_filters = esp32_exception_decoder
 
 [env:lolin_s2_mini]
 platform = ${esp32s2.platform}
-platform_packages = ${esp32s2.platform_packages}
 board = lolin_s2_mini
 board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = qio


### PR DESCRIPTION
Reduce the image size by swapping to tasmota's version of platform-espressif32

Motivation is that otherwise the move to IDF V4 means we run out of space