### PR TITLE
fix reproduction in game of life

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -5137,7 +5137,7 @@ uint16_t mode_2Dgameoflife(void) { // Written by Ewoud Wijma, inspired by https:
         neighbors++;
         bool colorFound = false;
         int k;
-        for (k=0; k<9 && colorsCount[i].count != 0; k++)
+        for (k=0; k<9 && colorsCount[k].count != 0; k++)
           if (colorsCount[k].color == prevLeds[xy]) {
             colorsCount[k].count++;
             colorFound = true;


### PR DESCRIPTION
A typo caused broken counting of the most common color in neighbouring cells and blocked reproduction in some directions.