### PR TITLE
Nightly release - Add bin.gz artifacts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,4 +37,5 @@ jobs:
           prerelease: true
           body: ${{ steps.changelog.outputs.changelog }}
           files: |
-            ./*.bin
+            *.bin
+            *.bin.gz


### PR DESCRIPTION
This adds the bin.gz artifacts to the nightly builds.

I'm affected by #4396 and like to try #4419 as fix. I run this on a Shelly RGBW2 (ESP8266 with 2M) and need the `WLED_0.15.0_ESP02.bin.gz` which is currently not published for the nightly builds.
