### PR TITLE
IDF v4 Ethernet/Network Fixes

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -216,7 +216,7 @@ const String ARDUINO_EVENT_LIST[41] = {
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event) {
 
-  #if defined(ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+  #if ESP32 && ESP_IDF_VERSION_MAJOR >= 4
 
   DEBUG_PRINT(F("Network Event: "));
   DEBUG_PRINT(ARDUINO_EVENT_LIST[event]);

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -216,7 +216,7 @@ const String ARDUINO_EVENT_LIST[41] = {
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event) {
 
-  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0) && defined(ESP32)
+  #if defined(ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
 
   DEBUG_PRINT(F("Network Event: "));
   DEBUG_PRINT(ARDUINO_EVENT_LIST[event]);

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -169,10 +169,122 @@ int getSignalQuality(int rssi)
     return quality;
 }
 
+const String ARDUINO_EVENT_LIST[41] = {
+  "WIFI_READY",
+  "WIFI_SCAN_DONE",
+  "WIFI_STA_START",
+  "WIFI_STA_STOP",
+  "WIFI_STA_CONNECTED",
+  "WIFI_STA_DISCONNECTED",
+  "WIFI_STA_AUTHMODE_CHANGE",
+  "WIFI_STA_GOT_IP",
+  "WIFI_STA_GOT_IP6",
+  "WIFI_STA_LOST_IP",
+  "WIFI_AP_START",
+  "WIFI_AP_STOP",
+  "WIFI_AP_STACONNECTED",
+  "WIFI_AP_STADISCONNECTED",
+  "WIFI_AP_STAIPASSIGNED",
+  "WIFI_AP_PROBEREQRECVED",
+  "WIFI_AP_GOT_IP6",
+  "WIFI_FTM_REPORT",
+  "ETH_START",
+  "ETH_STOP",
+  "ETH_CONNECTED",
+  "ETH_DISCONNECTED",
+  "ETH_GOT_IP",
+  "ETH_GOT_IP6",
+  "WPS_ER_SUCCESS",
+  "WPS_ER_FAILED",
+  "WPS_ER_TIMEOUT",
+  "WPS_ER_PIN",
+  "WPS_ER_PBC_OVERLAP",
+  "SC_SCAN_DONE",
+  "SC_FOUND_CHANNEL",
+  "SC_GOT_SSID_PSWD",
+  "SC_SEND_ACK_DONE",
+  "PROV_INIT",
+  "PROV_DEINIT",
+  "PROV_START",
+  "PROV_END",
+  "PROV_CRED_RECV",
+  "PROV_CRED_FAIL",
+  "PROV_CRED_SUCCESS",
+  "ARDUINO_NETWORK_EVENT_MAX"
+};
 
 //handle Ethernet connection event
-void WiFiEvent(WiFiEvent_t event)
-{
+void WiFiEvent(WiFiEvent_t event) {
+
+  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0) && !defined(ESP8266)
+
+  DEBUG_PRINT(F("Network Event: "));
+  DEBUG_PRINT(ARDUINO_EVENT_LIST[event]);
+  DEBUG_PRINT(F(" = "));
+
+  switch (event) {
+    case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+      if (Network.isEthernet()) {
+        if (!apActive) {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Disabling WIFi"));
+          WiFi.disconnect(true);
+        } else {
+          DEBUG_PRINTLN(F("WiFi Connected *and* ETH Connected. Leaving AP WiFi active"));
+        }
+      } else {
+        DEBUG_PRINTLN(F("WiFi Connected. No ETH"));
+      }
+      break;
+
+    #ifdef WLED_USE_ETHERNET
+    case ARDUINO_EVENT_ETH_GOT_IP: {
+        IPAddress localIP = ETH.localIP();
+        DEBUG_PRINTF("Ethernet has IP %d.%d.%d.%d. ", localIP[0], localIP[1], localIP[2], localIP[3]);
+        if (!apActive) {
+          DEBUG_PRINTLN(F("Disabling WIFi."));
+          WiFi.disconnect(true);
+        } else {
+          DEBUG_PRINTLN(F("Leaving AP WiFi Active."));
+        }
+      }
+      break;
+
+    case ARDUINO_EVENT_ETH_CONNECTED: {// was SYSTEM_EVENT_ETH_CONNECTED:
+      DEBUG_PRINTLN(F("ETH connected. Setting up ETH"));
+      if (multiWiFi[0].staticIP != (uint32_t)0x00000000 && multiWiFi[0].staticGW != (uint32_t)0x00000000) {
+        ETH.config(multiWiFi[0].staticIP, multiWiFi[0].staticGW, multiWiFi[0].staticSN, dnsAddress);
+      } else {
+        ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+      }
+      // convert the "serverDescription" into a valid DNS hostname (alphanumeric)
+      char hostname[64];
+      prepareHostname(hostname);
+      ETH.setHostname(hostname);
+      showWelcomePage = false;
+      DEBUG_PRINTF("Ethernet link is up. Speed is %u mbit and link is %sfull duplex! (MAC: ", ETH.linkSpeed(), ETH.fullDuplex()?"":"not ");
+      DEBUG_PRINT(ETH.macAddress());
+      DEBUG_PRINTLN(")");
+      }
+      break;
+
+    case ARDUINO_EVENT_ETH_DISCONNECTED: // was SYSTEM_EVENT_ETH_DISCONNECTED:
+      DEBUG_PRINTLN(F("ETH Disconnected. Forcing reconnect"));
+      // This doesn't really affect ethernet per se,
+      // as it's only configured once.  Rather, it
+      // may be necessary to reconnect the WiFi when
+      // ethernet disconnects, as a way to provide
+      // alternative access to the device.
+      forceReconnect = true;
+      break;
+    #endif
+
+    default:
+      DEBUG_PRINTLN(F("No action"));
+      break;
+
+  }
+  #else
+
   switch (event) {
 #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_USE_ETHERNET)
     case SYSTEM_EVENT_ETH_START:
@@ -210,5 +322,6 @@ void WiFiEvent(WiFiEvent_t event)
       DEBUG_PRINTF_P(PSTR("Network event: %d\n"), (int)event);
       break;
   }
+  #endif
 }
 

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -216,7 +216,7 @@ const String ARDUINO_EVENT_LIST[41] = {
 //handle Ethernet connection event
 void WiFiEvent(WiFiEvent_t event) {
 
-  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0) && !defined(ESP8266)
+  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0) && defined(ESP32)
 
   DEBUG_PRINT(F("Network Event: "));
   DEBUG_PRINT(ARDUINO_EVENT_LIST[event]);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -1010,8 +1010,17 @@ void WLED::handleConnection()
     }
   } else if (!interfacesInited) { //newly connected
     DEBUG_PRINTLN();
-    DEBUG_PRINT(F("Connected! IP address: "));
-    DEBUG_PRINTLN(Network.localIP());
+    DEBUG_PRINTLN("");
+    DEBUG_PRINT(F("Connected! IP address: http://"));
+    DEBUG_PRINT(Network.localIP());
+    if (Network.isEthernet()) {
+     #if ESP32
+     DEBUG_PRINTLN(" via Ethernet (disabling WiFi)");
+     WiFi.disconnect(true);
+     #endif
+    } else {
+     DEBUG_PRINTLN(" via WiFi");
+    }
     if (improvActive) {
       if (improvError == 3) sendImprovStateResponse(0x00, true);
       sendImprovStateResponse(0x04);


### PR DESCRIPTION
IDF v4 moves from SYSTEM_EVENT_WIFI_STA_GOT_IP to ARDUINO_EVENT_WIFI_STA_GOT_IP (for example)

Also some improvements to disable WiFi when Ethernet is connected, which ensures things like Art-Net and DDP use the Ethernet connection when present. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced Ethernet connectivity: The system now manages connections more intelligently by prioritizing Ethernet and automatically adjusting WiFi behavior as needed.
- Refactor
	- Updated connection status displays now clearly indicate whether the device is connected via Ethernet or WiFi, providing improved clarity on network status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->