### PR TITLE
constexpr is invalid on is2D()

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -711,7 +711,6 @@ typedef struct Segment {
     inline void fill_solid(CRGB c) { fill(RGBW32(c.r,c.g,c.b,0)); }
   #else
     inline bool is2D() const                                                      { return false; }
-    inline int  XY(int x, int y) const                                            { return x; }
     inline void setPixelColorXY(int x, int y, uint32_t c)                         { setPixelColor(x, c); }
     inline void setPixelColorXY(unsigned x, unsigned y, uint32_t c)               { setPixelColor(int(x), c); }
     inline void setPixelColorXY(int x, int y, byte r, byte g, byte b, byte w = 0) { setPixelColor(x, RGBW32(r,g,b,w)); }

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -710,7 +710,8 @@ typedef struct Segment {
     void wu_pixel(uint32_t x, uint32_t y, CRGB c);
     inline void fill_solid(CRGB c) { fill(RGBW32(c.r,c.g,c.b,0)); }
   #else
-    inline constexpr bool is2D() const                                            { return false; }
+    inline bool is2D() const                                                      { return false; }
+    inline int  XY(int x, int y) const                                            { return x; }
     inline void setPixelColorXY(int x, int y, uint32_t c)                         { setPixelColor(x, c); }
     inline void setPixelColorXY(unsigned x, unsigned y, uint32_t c)               { setPixelColor(int(x), c); }
     inline void setPixelColorXY(int x, int y, byte r, byte g, byte b, byte w = 0) { setPixelColor(x, RGBW32(r,g,b,w)); }


### PR DESCRIPTION
The WLED_DISABLE_2D build flag fails to compile, because the is2D() member of the Segment is not a literal type: 


```
In file included from wled00/fcn_declare.h:222:0,
    from wled00/wled.h:189,
    from wled00/FX.cpp:13:
     wled00/FX.h:714:27: error: 
     enclosing class of constexpr non-static member function 'bool Segment::is2D() const' is not a literal type
             inline constexpr bool is2D() const                                            { return false; }
                                  ^
In file included from wled00/fcn_declare.h:222:0,
    from wled00/wled.h:189,
    from wled00/FX.cpp:13:
        wled00/FX.h:361:16: note: 'Segment' is not literal because:
                 typedef struct Segment {
                                ^
wled00/FX.h:361:16: note:   'Segment' has a non-trivial destructor
```

Removing the `constexpr` allows it to compile