### PR TITLE
Pixel-Based Effect Classes

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -13,8 +13,9 @@
 #include "wled.h"
 #include "FX.h"
 #include "fcn_declare.h"
-#include "effects/StaticEffect.h"
+#include "effects/BouncingBallsEffect.h"
 #include "effects/PaletteEffect.h"
+#include "effects/StaticEffect.h"
 #include <memory>
 
 #if !(defined(WLED_DISABLE_PARTICLESYSTEM2D) && defined(WLED_DISABLE_PARTICLESYSTEM1D))
@@ -10154,6 +10155,7 @@ void WS2812FX::setupEffectData(size_t modeCount) {
   // Solid must be first! (assuming vector is empty upon call to setup)
   addEffect(std::make_unique<EffectFactory>(StaticEffect::effectInformation));
   addEffect(std::make_unique<EffectFactory>(PaletteEffect::effectInformation));
+  addEffect(std::make_unique<EffectFactory>(BouncingBallsEffect::effectInformation));
   // fill reserved word in case there will be any gaps in the array
   for (size_t i=1; i<modeCount; i++) {
     _effectFactories.push_back(nullptr);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -16,6 +16,7 @@
 #include "effects/BouncingBallsEffect.h"
 #include "effects/PaletteEffect.h"
 #include "effects/StaticEffect.h"
+#include "effects/TetrixEffect.h"
 #include <memory>
 
 #if !(defined(WLED_DISABLE_PARTICLESYSTEM2D) && defined(WLED_DISABLE_PARTICLESYSTEM1D))
@@ -10155,6 +10156,7 @@ void WS2812FX::setupEffectData(size_t modeCount) {
   // Solid must be first! (assuming vector is empty upon call to setup)
   addEffect(std::make_unique<EffectFactory>(StaticEffect::effectInformation));
   addEffect(std::make_unique<EffectFactory>(PaletteEffect::effectInformation));
+  addEffect(std::make_unique<EffectFactory>(TetrixEffect::effectInformation));
   addEffect(std::make_unique<EffectFactory>(BouncingBallsEffect::effectInformation));
   // fill reserved word in case there will be any gaps in the array
   for (size_t i=1; i<modeCount; i++) {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -628,7 +628,6 @@ typedef struct Segment {
     Segment &setMode(uint8_t fx, bool loadDefaults = false);
     Segment &setPalette(uint8_t pal);
     Segment &setName(const char* name);
-    uint8_t differs(const Segment& b) const;
     void    refreshLightCapabilities();
 
     // runtime data functions

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -882,7 +882,7 @@ class WS2812FX {  // 96 bytes
     inline void trigger()                                     { _triggered = true; }  // Forces the next frame to be computed on all active segments.
     inline void setShowCallback(show_callback cb)             { _callback = cb; }
     inline void setTransition(uint16_t t)                     { _transitionDur = t; } // sets transition time (in ms)
-    inline void appendSegment(const Segment &seg = Segment()) { if (_segments.size() < getMaxSegments()) _segments.push_back(seg); }
+    inline void appendSegment(Segment &&seg = Segment())      { if (_segments.size() < getMaxSegments()) _segments.push_back(std::move(seg)); }
     inline void suspend()                                     { _suspend = true; }    // will suspend (and canacel) strip.service() execution
     inline void resume()                                      { _suspend = false; }   // will resume strip.service() execution
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -578,6 +578,7 @@ typedef struct Segment {
       if (name) { free(name); name = nullptr; }
       stopTransition();
       deallocateData();
+      effect = nullptr;
     }
 
     Segment& operator= (const Segment &orig); // copy assignment

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -1036,4 +1036,29 @@ class WS2812FX {  // 96 bytes
 extern const char JSON_mode_names[];
 extern const char JSON_palette_names[];
 
+class LazyColor {
+  public:
+      explicit constexpr LazyColor(Segment& seg, int x, int y)
+          : seg(seg),
+            x(x),
+            y(y)
+      {
+      }
+
+      uint32_t getColor(int x, int y) const {
+          if (!loaded) {
+              color = seg.getPixelColorXY(x, y);
+              loaded = true;
+          }
+          return color;
+      }
+
+  private:
+      Segment& seg;
+      int x = 0;
+      int y = 0;
+      mutable bool loaded = false;
+      mutable uint32_t color = 0;
+  };
+
 #endif

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -1038,28 +1038,29 @@ extern const char JSON_mode_names[];
 extern const char JSON_palette_names[];
 
 class LazyColor {
-  public:
-      explicit constexpr LazyColor(Segment& seg, int x, int y)
-          : seg(seg),
-            x(x),
-            y(y)
-      {
-      }
+public:
+    explicit constexpr LazyColor(Segment& seg, int x, int y)
+        : seg(seg),
+          x(x),
+          y(y)
+    {
+    }
 
-      uint32_t getColor(int x, int y) const {
-          if (!loaded) {
-              color = seg.getPixelColorXY(x, y);
-              loaded = true;
-          }
-          return color;
-      }
+    uint32_t getColor(int x, int y) const {
+        if (!loaded) {
+            color = seg.getPixelColorXY(x, y);
+            loaded = true;
+        }
+        return color;
+    }
 
-  private:
-      Segment& seg;
-      int x = 0;
-      int y = 0;
-      mutable bool loaded = false;
-      mutable uint32_t color = 0;
-  };
+private:
+    Segment& seg;
+    int x = 0;
+    int y = 0;
+    mutable bool loaded = false;
+    mutable uint32_t color = 0;
+};
+
 
 #endif

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -100,6 +100,7 @@ Segment::Segment(const Segment &orig) {
   name = nullptr;
   data = nullptr;
   _dataLen = 0;
+  effect.release(); // The ownership still lies with orig, but unique_ptr was memcpy'd, so remove the pointer here without destroying the effect.
   if (orig.name) { name = static_cast<char*>(malloc(strlen(orig.name)+1)); if (name) strcpy(name, orig.name); }
   if (orig.data) { if (allocateData(orig._dataLen)) memcpy(data, orig.data, orig._dataLen); }
 }
@@ -112,6 +113,7 @@ Segment::Segment(Segment &&orig) noexcept {
   orig.name = nullptr;
   orig.data = nullptr;
   orig._dataLen = 0;
+  orig.effect.release(); // The ownership lies with this, but unique_ptr was memcpy'd, so remove the pointer in orig without destroying the effect.
 }
 
 // copy assignment
@@ -127,6 +129,7 @@ Segment& Segment::operator= (const Segment &orig) {
     // erase pointers to allocated data
     data = nullptr;
     _dataLen = 0;
+    effect.release(); // The ownership still lies with orig, but unique_ptr was memcpy'd, so remove the pointer here without destroying the effect.
     // copy source data
     if (orig.name) { name = static_cast<char*>(malloc(strlen(orig.name)+1)); if (name) strcpy(name, orig.name); }
     if (orig.data) { if (allocateData(orig._dataLen)) memcpy(data, orig.data, orig._dataLen); }
@@ -146,6 +149,7 @@ Segment& Segment::operator= (Segment &&orig) noexcept {
     orig.data = nullptr;
     orig._dataLen = 0;
     orig._t   = nullptr; // old segment cannot be in transition
+    orig.effect.release(); // The ownership lies with this, but unique_ptr was memcpy'd, so remove the pointer in orig without destroying the effect.
   }
   return *this;
 }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1638,7 +1638,9 @@ void WS2812FX::service() {
     }
     _segment_index++;
   }
+  #ifndef WLED_DISABLE_MODE_BLEND
   Segment::setClippingRect(0, 0);             // disable clipping for overlays
+  #endif
   #if !(defined(WLED_DISABLE_PARTICLESYSTEM2D) && defined(WLED_DISABLE_PARTICLESYSTEM1D))
   servicePSmem(); // handle segment particle system memory
   #endif

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1621,7 +1621,7 @@ void WS2812FX::service() {
           for (int y = 0; y < h; y++) {
             effect->nextRow(y);
             for (int x = 0; x < w; x++) {
-              const uint32_t oldColor = seg.getPixelColorXY(x, y);
+              const LazyColor oldColor(seg, x, y);
               const uint32_t newColor = effect->getPixelColor(x, y, oldColor);
               seg.setPixelColorXY(x, y, newColor);
             }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -13,6 +13,7 @@
 #include "FX.h"
 #include "FXparticleSystem.h"  // TODO: better define the required function (mem service) in FX.h?
 #include "palettes.h"
+#include "effects/Effect.h"
 
 /*
   Custom per-LED mapping has moved!
@@ -209,7 +210,9 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
   if (pal < 245 && pal > GRADIENT_PALETTE_COUNT+13) pal = 0;
   if (pal > 245 && (strip.customPalettes.size() == 0 || 255U-pal > strip.customPalettes.size()-1)) pal = 0; // TODO remove strip dependency by moving customPalettes out of strip
   //default palette. Differs depending on effect
-  if (pal == 0) pal = _default_palette; //load default palette set in FX _data, party colors as default
+  if (pal == 0 && effect != nullptr) {
+    pal = effect->getDefaultPaletteId();
+  }
   switch (pal) {
     case 0: //default palette. Exceptions for specific effects above
       targetPalette = PartyColors_p; break;
@@ -253,7 +256,7 @@ CRGBPalette16 &Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
   return targetPalette;
 }
 
-void Segment::startTransition(uint16_t dur) {
+void Segment::startTransition(uint16_t dur, std::unique_ptr<Effect>&& oldEffect) {
   if (dur == 0) {
     if (isInTransition()) _t->_dur = dur; // this will stop transition in next handleTransition()
     return;
@@ -261,7 +264,7 @@ void Segment::startTransition(uint16_t dur) {
   if (isInTransition()) return; // already in transition no need to store anything
 
   // starting a transition has to occur before change so we get current values 1st
-  _t = new(std::nothrow) Transition(dur); // no previous transition running
+  _t = std::make_unique<Transition>(dur); // no previous transition running
   if (!_t) return; // failed to allocate data
 
   //DEBUG_PRINTF_P(PSTR("-- Started transition: %p (%p)\n"), this, _t);
@@ -270,38 +273,14 @@ void Segment::startTransition(uint16_t dur) {
   _t->_briT           = on ? opacity : 0;
   _t->_cctT           = cct;
 #ifndef WLED_DISABLE_MODE_BLEND
-  swapSegenv(_t->_segT);
-  _t->_modeT          = mode;
-  _t->_segT._dataLenT = 0;
-  _t->_segT._dataT    = nullptr;
-  if (_dataLen > 0 && data) {
-    _t->_segT._dataT = (byte *)malloc(_dataLen);
-    if (_t->_segT._dataT) {
-      //DEBUG_PRINTF_P(PSTR("--  Allocated duplicate data (%d) for %p: %p\n"), _dataLen, this, _t->_segT._dataT);
-      memcpy(_t->_segT._dataT, data, _dataLen);
-      _t->_segT._dataLenT = _dataLen;
-    }
-  }
+  _t->_effectT      = std::move(oldEffect);
 #else
   for (size_t i=0; i<NUM_COLORS; i++) _t->_colorT[i] = colors[i];
 #endif
 }
 
 void Segment::stopTransition() {
-  if (isInTransition()) {
-    //DEBUG_PRINTF_P(PSTR("-- Stopping transition: %p\n"), this);
-    #ifndef WLED_DISABLE_MODE_BLEND
-    if (_t->_segT._dataT && _t->_segT._dataLenT > 0) {
-      //DEBUG_PRINTF_P(PSTR("--  Released duplicate data (%d) for %p: %p\n"), _t->_segT._dataLenT, this, _t->_segT._dataT);
-      free(_t->_segT._dataT);
-      _t->_segT._dataT = nullptr;
-      _t->_segT._dataLenT = 0;
-    }
-    #endif
-    delete _t;
-    _t = nullptr;
-  }
-  _transitionprogress = 0xFFFFU; // stop means stop - transition has ended
+  _t = nullptr;
 }
 
 // transition progression between 0-65535
@@ -402,20 +381,25 @@ uint8_t Segment::currentBri(bool useCct) const {
   return curBri;
 }
 
-uint8_t Segment::currentMode() const {
+Effect* Segment::getTransitionEffect() const {
 #ifndef WLED_DISABLE_MODE_BLEND
-  unsigned prog = isInTransition() ? progress() : 0xFFFFU;
-  if (prog == 0xFFFFU) return mode;
+  if (isInTransition()) return _t->_effectT.get();
+  //TODO?
+  /*
   if (blendingStyle != BLEND_STYLE_FADE) {
     // workaround for on/off transition to respect blending style
-    uint8_t modeT = (bri != briT) &&  bri ? FX_MODE_STATIC : _t->_modeT;   // On/Off transition active (bri!=briT) and final bri>0 : old mode is STATIC
+    uint8_t modeT = (bri != briT) &&  bri ? FX_MODE_STATIC : _t->_effectT.get();   // On/Off transition active (bri!=briT) and final bri>0 : old mode is STATIC
     uint8_t modeS = (bri != briT) && !bri ? FX_MODE_STATIC : mode;         // On/Off transition active (bri!=briT) and final bri==0 : new mode is STATIC
-    return _modeBlend ? modeT : modeS;    // _modeBlend==true -> old effect
+    return isInTransition() ? modeT : modeS;    // isInTransition()==true -> old effect
   }
-  return _modeBlend ? _t->_modeT : mode;  // _modeBlend==true -> old effect
-#else
-  return mode;
+  return isInTransition() ? _t->_modeT : nullptr;  // isInTransition()==true -> old effect
+  */
 #endif
+  return nullptr;
+}
+
+Effect* Segment::getCurrentEffect() const {
+  return effect.get();
 }
 
 uint32_t Segment::currentColor(uint8_t slot) const {
@@ -605,42 +589,45 @@ Segment &Segment::setOption(uint8_t n, bool val) {
   return *this;
 }
 
-Segment &Segment::setMode(uint8_t fx, bool loadDefaults) {
+Segment &Segment::setMode(uint8_t effectId, bool loadDefaults) {
+  EffectFactory* effectFactory = nullptr;
   // skip reserved
-  while (fx < strip.getModeCount() && strncmp_P("RSVD", strip.getModeData(fx), 4) == 0) fx++;
-  if (fx >= strip.getModeCount()) fx = 0; // set solid mode
-  // if we have a valid mode & is not reserved
-  if (fx != mode) {
-#ifndef WLED_DISABLE_MODE_BLEND
-    //DEBUG_PRINTF_P(PSTR("- Starting effect transition: %d\n"), fx);
-    startTransition(strip.getTransition()); // set effect transitions
-#endif
-    mode = fx;
-    int sOpt;
-    // load default values from effect string
-    if (loadDefaults) {
-      sOpt = extractModeDefaults(fx, "sx");  speed     = (sOpt >= 0) ? sOpt : DEFAULT_SPEED;
-      sOpt = extractModeDefaults(fx, "ix");  intensity = (sOpt >= 0) ? sOpt : DEFAULT_INTENSITY;
-      sOpt = extractModeDefaults(fx, "c1");  custom1   = (sOpt >= 0) ? sOpt : DEFAULT_C1;
-      sOpt = extractModeDefaults(fx, "c2");  custom2   = (sOpt >= 0) ? sOpt : DEFAULT_C2;
-      sOpt = extractModeDefaults(fx, "c3");  custom3   = (sOpt >= 0) ? sOpt : DEFAULT_C3;
-      sOpt = extractModeDefaults(fx, "o1");  check1    = (sOpt >= 0) ? (bool)sOpt : false;
-      sOpt = extractModeDefaults(fx, "o2");  check2    = (sOpt >= 0) ? (bool)sOpt : false;
-      sOpt = extractModeDefaults(fx, "o3");  check3    = (sOpt >= 0) ? (bool)sOpt : false;
-      sOpt = extractModeDefaults(fx, "m12"); if (sOpt >= 0) map1D2D   = constrain(sOpt, 0, 7); else map1D2D = M12_Pixels;  // reset mapping if not defined (2D FX may not work)
-      sOpt = extractModeDefaults(fx, "si");  if (sOpt >= 0) soundSim  = constrain(sOpt, 0, 3);
-      sOpt = extractModeDefaults(fx, "rev"); if (sOpt >= 0) reverse   = (bool)sOpt;
-      sOpt = extractModeDefaults(fx, "mi");  if (sOpt >= 0) mirror    = (bool)sOpt; // NOTE: setting this option is a risky business
-      sOpt = extractModeDefaults(fx, "rY");  if (sOpt >= 0) reverse_y = (bool)sOpt;
-      sOpt = extractModeDefaults(fx, "mY");  if (sOpt >= 0) mirror_y  = (bool)sOpt; // NOTE: setting this option is a risky business
-      sOpt = extractModeDefaults(fx, "pal"); if (sOpt >= 0) setPalette(sOpt); //else setPalette(0);
-    }
-    sOpt = extractModeDefaults(fx, "pal"); // always extract 'pal' to set _default_palette
-    if(sOpt <= 0) sOpt = 6; // partycolors if zero or not set
-    _default_palette = sOpt; // _deault_palette is loaded into pal0 in loadPalette() (if selected)
-    markForReset();
-    stateChanged = true; // send UDP/WS broadcast
+  while (effectId < strip.getModeCount() && (effectFactory = strip.getEffectFactory(effectId)) == nullptr) effectId++;
+  if (effectFactory == nullptr) {
+    effectId = 0; // set solid mode
+    effectFactory = strip.getEffectFactory(0);
   }
+  if ((effect != nullptr) && (effectId == effect->getEffectId())) return *this;
+#ifndef WLED_DISABLE_MODE_BLEND
+  //DEBUG_PRINTF_P(PSTR("- Starting effect transition: %d\n"), effectId);
+  startTransition(strip.getTransition(), std::move(effect)); // set effect transitions
+#endif
+  effect = effectFactory->makeEffect();
+  const char* metaData = effectFactory->getMetaData();
+  int sOpt;
+  // load default values from effect string
+  if (loadDefaults) {
+    sOpt = extractModeDefaults(metaData, "sx");  speed     = (sOpt >= 0) ? sOpt : DEFAULT_SPEED;
+    sOpt = extractModeDefaults(metaData, "ix");  intensity = (sOpt >= 0) ? sOpt : DEFAULT_INTENSITY;
+    sOpt = extractModeDefaults(metaData, "c1");  custom1   = (sOpt >= 0) ? sOpt : DEFAULT_C1;
+    sOpt = extractModeDefaults(metaData, "c2");  custom2   = (sOpt >= 0) ? sOpt : DEFAULT_C2;
+    sOpt = extractModeDefaults(metaData, "c3");  custom3   = (sOpt >= 0) ? sOpt : DEFAULT_C3;
+    sOpt = extractModeDefaults(metaData, "o1");  check1    = (sOpt >= 0) ? (bool)sOpt : false;
+    sOpt = extractModeDefaults(metaData, "o2");  check2    = (sOpt >= 0) ? (bool)sOpt : false;
+    sOpt = extractModeDefaults(metaData, "o3");  check3    = (sOpt >= 0) ? (bool)sOpt : false;
+    sOpt = extractModeDefaults(metaData, "m12"); if (sOpt >= 0) map1D2D   = constrain(sOpt, 0, 7); else map1D2D = M12_Pixels;  // reset mapping if not defined (2D FX may not work)
+    sOpt = extractModeDefaults(metaData, "si");  if (sOpt >= 0) soundSim  = constrain(sOpt, 0, 3);
+    sOpt = extractModeDefaults(metaData, "rev"); if (sOpt >= 0) reverse   = (bool)sOpt;
+    sOpt = extractModeDefaults(metaData, "mi");  if (sOpt >= 0) mirror    = (bool)sOpt; // NOTE: setting this option is a risky business
+    sOpt = extractModeDefaults(metaData, "rY");  if (sOpt >= 0) reverse_y = (bool)sOpt;
+    sOpt = extractModeDefaults(metaData, "mY");  if (sOpt >= 0) mirror_y  = (bool)sOpt; // NOTE: setting this option is a risky business
+    sOpt = extractModeDefaults(metaData, "pal"); if (sOpt >= 0) setPalette(sOpt); //else setPalette(0);
+  }
+  sOpt = extractModeDefaults(metaData, "pal"); // always extract 'pal' to set _default_palette
+  if(sOpt <= 0) sOpt = 6; // partycolors if zero or not set
+  _default_palette = sOpt; // _deault_palette is loaded into pal0 in loadPalette() (if selected)
+  markForReset();
+  stateChanged = true; // send UDP/WS broadcast
   return *this;
 }
 
@@ -1092,7 +1079,7 @@ uint8_t Segment::differs(const Segment& b) const {
   if (grouping != b.grouping)   d |= SEG_DIFFERS_GSO;
   if (spacing != b.spacing)     d |= SEG_DIFFERS_GSO;
   if (opacity != b.opacity)     d |= SEG_DIFFERS_BRI;
-  if (mode != b.mode)           d |= SEG_DIFFERS_FX;
+  if (getEffectId() != b.getEffectId()) d |= SEG_DIFFERS_FX;
   if (speed != b.speed)         d |= SEG_DIFFERS_FX;
   if (intensity != b.intensity) d |= SEG_DIFFERS_FX;
   if (palette != b.palette)     d |= SEG_DIFFERS_FX;
@@ -1473,6 +1460,8 @@ void WS2812FX::finalizeInit() {
   deserializeMap();     // (re)load default ledmap (will also setUpMatrix() if ledmap does not exist)
 }
 
+#pragma GCC push_options
+#pragma GCC optimize ("O3")
 void WS2812FX::service() {
   unsigned long nowUp = millis(); // Be aware, millis() rolls over every 49 days
   now = nowUp + timebase;
@@ -1500,7 +1489,7 @@ void WS2812FX::service() {
     if (!seg.isActive()) continue;
 
     // last condition ensures all solid segments are updated at the same time
-    if (nowUp >= seg.next_time || _triggered || (doShow && seg.mode == FX_MODE_STATIC))
+    if (nowUp >= seg.next_time || _triggered || (doShow && seg.getEffectId() == FX_MODE_STATIC))
     {
       doShow = true;
       unsigned frameDelay = FRAMETIME;
@@ -1575,20 +1564,71 @@ void WS2812FX::service() {
               Segment::setClippingRect(0, dw, h - dh, h);
               break;
           }
-          frameDelay = (*_mode[seg.currentMode()])();  // run new/current mode
+
+          // run new/current effect
+          {
+            Effect* const effect = seg.getCurrentEffect();
+            effect->nextFrame();
+            for (int y = 0; y < h; y++) {
+              effect->nextRow(y);
+              for (int x = 0; x < w; x++) {
+                const uint32_t oldColor = seg.getPixelColorXY(x, y);
+                const uint32_t newColor = effect->getPixelColor(x, y, oldColor);
+                seg.setPixelColorXY(x, y, newColor);
+              }
+            }
+            frameDelay = 0;
+          }
+
+          //TODO
+          /*
           // now run old/previous mode
           Segment::tmpsegd_t _tmpSegData;
           Segment::modeBlend(true);           // set semaphore
           seg.swapSegenv(_tmpSegData);        // temporarily store new mode state (and swap it with transitional state)
           seg.beginDraw();                    // set up parameters for get/setPixelColor()
-          frameDelay = min(frameDelay, (unsigned)(*_mode[seg.currentMode()])());  // run old mode
+
+          // run old mode
+          {
+            Effect* const oldEffect = seg.getTransitionEffect();  // this will return old mode while in transition
+            if (oldEffect != nullptr) {
+              oldEffect->nextFrame();
+              for (int y = 0; y < h; y++) {
+                oldEffect->nextRow(y);
+                for (int x = 0; x < w; x++) {
+                  const uint32_t oldColor = seg.getPixelColorXY(x, y);
+                  uint32_t newColor = oldEffect->getPixelColor(x, y, oldColor);
+                }
+              }
+              frameDelay = 0;
+            }
+          }
+
           seg.call++;                         // increment old mode run counter
           seg.restoreSegenv(_tmpSegData);     // restore mode state (will also update transitional state)
           Segment::modeBlend(false);          // unset semaphore
           blendingStyle = orgBS;              // restore blending style if it was modified for single pixel segment
+          */
         } else
 #endif
-        frameDelay = (*_mode[seg.mode])();         // run effect mode (not in transition)
+        // run effect mode (not in transition)
+        {
+          unsigned w = seg.is2D() ? Segment::vWidth() : Segment::vLength();
+          unsigned h = Segment::vHeight();
+
+          Effect* const effect = seg.getCurrentEffect(); // new/current effect
+          effect->nextFrame();
+          for (int y = 0; y < h; y++) {
+            effect->nextRow(y);
+            for (int x = 0; x < w; x++) {
+              const uint32_t oldColor = seg.getPixelColorXY(x, y);
+              const uint32_t newColor = effect->getPixelColor(x, y, oldColor);
+              seg.setPixelColorXY(x, y, newColor);
+            }
+          }
+          frameDelay = 0;
+        }
+
         seg.call++;
         if (seg.isInTransition() && frameDelay > FRAMETIME) frameDelay = FRAMETIME; // force faster updates during transition
         BusManager::setSegmentCCT(oldCCT); // restore old CCT for ABL adjustments
@@ -1618,6 +1658,7 @@ void WS2812FX::service() {
   if ((_targetFps != FPS_UNLIMITED) && (millis() - nowUp > _frametime)) DEBUG_PRINTF_P(PSTR("Slow strip %u/%d.\n"), (unsigned)(millis()-nowUp), (int)_frametime);
   #endif
 }
+#pragma GCC pop_options
 
 void IRAM_ATTR WS2812FX::setPixelColor(unsigned i, uint32_t col) const {
   i = getMappedPixelIndex(i);
@@ -1925,8 +1966,7 @@ void WS2812FX::printSize() {
   for (const Segment &seg : _segments) size += seg.getSize();
   DEBUG_PRINTF_P(PSTR("Segments: %d -> %u/%dB\n"), _segments.size(), size, Segment::getUsedSegmentData());
   for (const Segment &seg : _segments) DEBUG_PRINTF_P(PSTR("  Seg: %d,%d [A=%d, 2D=%d, RGB=%d, W=%d, CCT=%d]\n"), seg.width(), seg.height(), seg.isActive(), seg.is2D(), seg.hasRGB(), seg.hasWhite(), seg.isCCT());
-  DEBUG_PRINTF_P(PSTR("Modes: %d*%d=%uB\n"), sizeof(mode_ptr), _mode.size(), (_mode.capacity()*sizeof(mode_ptr)));
-  DEBUG_PRINTF_P(PSTR("Data: %d*%d=%uB\n"), sizeof(const char *), _modeData.size(), (_modeData.capacity()*sizeof(const char *)));
+  DEBUG_PRINTF_P(PSTR("Modes: %d*%d=%uB\n"), sizeof(mode_ptr), _effectFactories.size(), (_effectFactories.capacity()*sizeof(mode_ptr)));
   DEBUG_PRINTF_P(PSTR("Map: %d*%d=%uB\n"), sizeof(uint16_t), (int)customMappingSize, customMappingSize*sizeof(uint16_t));
 }
 #endif

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1075,33 +1075,6 @@ uint32_t IRAM_ATTR_YN Segment::getPixelColor(int i) const
   return strip.getPixelColor(i);
 }
 
-uint8_t Segment::differs(const Segment& b) const {
-  uint8_t d = 0;
-  if (start != b.start)         d |= SEG_DIFFERS_BOUNDS;
-  if (stop != b.stop)           d |= SEG_DIFFERS_BOUNDS;
-  if (offset != b.offset)       d |= SEG_DIFFERS_GSO;
-  if (grouping != b.grouping)   d |= SEG_DIFFERS_GSO;
-  if (spacing != b.spacing)     d |= SEG_DIFFERS_GSO;
-  if (opacity != b.opacity)     d |= SEG_DIFFERS_BRI;
-  if (getEffectId() != b.getEffectId()) d |= SEG_DIFFERS_FX;
-  if (speed != b.speed)         d |= SEG_DIFFERS_FX;
-  if (intensity != b.intensity) d |= SEG_DIFFERS_FX;
-  if (palette != b.palette)     d |= SEG_DIFFERS_FX;
-  if (custom1 != b.custom1)     d |= SEG_DIFFERS_FX;
-  if (custom2 != b.custom2)     d |= SEG_DIFFERS_FX;
-  if (custom3 != b.custom3)     d |= SEG_DIFFERS_FX;
-  if (startY != b.startY)       d |= SEG_DIFFERS_BOUNDS;
-  if (stopY != b.stopY)         d |= SEG_DIFFERS_BOUNDS;
-
-  //bit pattern: (msb first)
-  // set:2, sound:2, mapping:3, transposed, mirrorY, reverseY, [reset,] paused, mirrored, on, reverse, [selected]
-  if ((options & 0b1111111111011110U) != (b.options & 0b1111111111011110U)) d |= SEG_DIFFERS_OPT;
-  if ((options & 0x0001U) != (b.options & 0x0001U))                         d |= SEG_DIFFERS_SEL;
-  for (unsigned i = 0; i < NUM_COLORS; i++) if (colors[i] != b.colors[i])   d |= SEG_DIFFERS_COL;
-
-  return d;
-}
-
 void Segment::refreshLightCapabilities() {
   unsigned capabilities = 0;
   unsigned segStartIdx = 0xFFFFU;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -223,7 +223,7 @@ void handleDMXData(uint16_t uni, uint16_t dmxChannels, uint8_t* e131_data, uint8
             return;
 
           if (e131_data[dataOffset+1] < strip.getModeCount())
-            if (e131_data[dataOffset+1] != seg.mode)      seg.setMode(   e131_data[dataOffset+1]);
+            if (e131_data[dataOffset+1] != seg.getEffectId()) seg.setMode(e131_data[dataOffset+1]);
           if (e131_data[dataOffset+2]   != seg.speed)     seg.speed     = e131_data[dataOffset+2];      
           if (e131_data[dataOffset+3]   != seg.intensity) seg.intensity = e131_data[dataOffset+3];
           if (e131_data[dataOffset+4]   != seg.palette)   seg.setPalette(e131_data[dataOffset+4]);

--- a/wled00/effects/BouncingBallsEffect.h
+++ b/wled00/effects/BouncingBallsEffect.h
@@ -3,7 +3,7 @@
 #include "../FX.h"
 #include "Effect.h"
 
-class BouncingBallsEffect : public Effect {
+class BouncingBallsEffect : public BaseEffect<BouncingBallsEffect> {
     struct Ball {
         unsigned long lastBounceTime{strip.now};
         float impactVelocity{};
@@ -13,30 +13,12 @@ class BouncingBallsEffect : public Effect {
     };
 
 private:
-    using Base = Effect;
+    using Base = BaseEffect<BouncingBallsEffect>;
     using Self = BouncingBallsEffect;
     static constexpr unsigned maxNumBalls = 16;
 
 public:
     using Base::Base;
-
-    static std::unique_ptr<Effect> makeEffect() {
-        Effect * ptr = new Self(effectInformation);
-        std::unique_ptr<Effect> effect(ptr);
-        return std::move(effect);
-    }
-
-    static void nextFrame(Effect* effect) {
-        static_cast<Self*>(effect)->nextFrameImpl();
-    }
-
-    static void nextRow(Effect* effect, int y) {
-        static_cast<Self*>(effect)->nextRowImpl(y);
-    }
-
-    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
-        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
-    }
 
     static constexpr EffectInformation effectInformation {
         "Bouncing Balls@Gravity,balls per line,,,lines,,Overlay;!,!,!;!;1;m12=1",
@@ -48,7 +30,6 @@ public:
         &Self::getPixelColor,
     };
 
-private:
     void nextFrameImpl() {
         numBalls = (SEGMENT.intensity * (maxNumBalls - 1)) / 255 + 1; // minimum 1 ball
         strips = SEGMENT.custom3;
@@ -87,6 +68,7 @@ private:
             return currentColor.getColor(x, y);
     }
 
+private:
     // virtualStrip idea by @ewowi (Ewoud Wijma)
     // requires virtual strip # to be embedded into upper 16 bits of index in setPixelColor()
     // the following functions will not work on virtual strips: fill(), fade_out(), fadeToBlack(), blur()

--- a/wled00/effects/BouncingBallsEffect.h
+++ b/wled00/effects/BouncingBallsEffect.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "../FX.h"
+#include "Effect.h"
+
+class BouncingBallsEffect : public Effect {
+    struct Ball {
+        unsigned long lastBounceTime{strip.now};
+        float impactVelocity{};
+        float height{};
+        float pixelHeight{};
+        uint32_t color{};
+    };
+
+private:
+    using Base = Effect;
+    using Self = BouncingBallsEffect;
+    static constexpr unsigned maxNumBalls = 16;
+
+public:
+    using Base::Base;
+
+    static std::unique_ptr<Effect> makeEffect() {
+        Effect * ptr = new Self(effectInformation);
+        std::unique_ptr<Effect> effect(ptr);
+        return std::move(effect);
+    }
+
+    static void nextFrame(Effect* effect) {
+        static_cast<Self*>(effect)->nextFrameImpl();
+    }
+
+    static void nextRow(Effect* effect, int y) {
+        static_cast<Self*>(effect)->nextRowImpl(y);
+    }
+
+    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
+        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
+    }
+
+    static constexpr EffectInformation effectInformation {
+        "Bouncing Balls@Gravity,balls per line,,,lines,,Overlay;!,!,!;!;1;m12=1",
+        FX_MODE_BOUNCINGBALLS,
+        0u,
+        &Self::makeEffect,
+        &Self::nextFrame,
+        &Self::nextRow,
+        &Self::getPixelColor,
+    };
+
+private:
+    void nextFrameImpl() {
+        numBalls = (SEGMENT.intensity * (maxNumBalls - 1)) / 255 + 1; // minimum 1 ball
+        strips = SEGMENT.custom3;
+        useBackgroundColor = !SEGMENT.check2;
+
+        if (useBackgroundColor)
+            backgroundColor = (SEGCOLOR(2) ? BLACK : SEGCOLOR(1));
+        ballSize = std::max(1u, SEG_H / strips);
+
+        const size_t ballsVectorSize = maxNumBalls * strips; //TODO reduce to actual ball count instead of max ball count?
+        balls.resize(ballsVectorSize);
+        if (balls.size() != ballsVectorSize) {
+            balls.clear();
+            return;
+        }
+        balls.shrink_to_fit();
+
+        for (unsigned stripNr = 0; stripNr < strips; ++stripNr)
+            runVirtualStrip(stripNr, &balls[stripNr * maxNumBalls]);
+    }
+
+    void nextRowImpl(int y) {
+        stripIndex = (y * strips) / SEG_W;
+    }
+
+    uint32_t getPixelColorImpl(int x, int y, const LazyColor& currentColor) {
+        for (size_t ballIndex = 0; ballIndex < numBalls; ballIndex++) {
+            const Ball& ball = balls[stripIndex * maxNumBalls + ballIndex];
+            if (ball.pixelHeight - (ballSize / 2) <= x && x < ball.pixelHeight + ((ballSize + 1) / 2))
+                return ball.color;
+        }
+
+        if (useBackgroundColor)
+            return backgroundColor;
+        else
+            return currentColor.getColor(x, y);
+    }
+
+    // virtualStrip idea by @ewowi (Ewoud Wijma)
+    // requires virtual strip # to be embedded into upper 16 bits of index in setPixelColor()
+    // the following functions will not work on virtual strips: fill(), fade_out(), fadeToBlack(), blur()
+    void runVirtualStrip(size_t stripNr, Ball* balls) {
+        constexpr float gravity = -9.81f; // standard value of gravity
+        constexpr float initialVelocityFactor = 4.4294469f; // sqrtf(-2.0f * gravity);
+        // number of balls based on intensity setting to max of 7 (cycles colors)
+        // non-chosen color is a random color
+        const unsigned long time = strip.now;
+
+        const float bounceTimeFactor = 0.001f / ((255-SEGMENT.speed)/64 +1);
+        for (size_t i = 0; i < numBalls; i++) {
+            // time since last bounce in seconds
+            const float timeSec = (time - balls[i].lastBounceTime) * bounceTimeFactor;
+            balls[i].height = ((0.5f * gravity) * timeSec + balls[i].impactVelocity) * timeSec; // avoid use pow(x, 2) - its extremely slow !
+
+            if (balls[i].height <= 0.0f) {
+                balls[i].height = 0.0f;
+                //damping for better effect using multiple balls
+                const float dampening = 0.9f - float(i)/float(numBalls * numBalls); // avoid use pow(x, 2) - its extremely slow !
+                balls[i].impactVelocity = dampening * balls[i].impactVelocity;
+                balls[i].lastBounceTime = time;
+
+                if (balls[i].impactVelocity < 0.015f) {
+                    float impactVelocityStart = initialVelocityFactor * hw_random8(5,11)/10.0f; // randomize impact velocity
+                    balls[i].impactVelocity = impactVelocityStart;
+                }
+            } else if (balls[i].height > 1.0f) {
+                continue; // do not draw OOB ball
+            }
+            balls[i].pixelHeight = balls[i].height * (SEGLEN - 1);
+
+            //TODO currently evaluated once per virtual strip, but the result is the same for all strips
+            if (SEGMENT.palette) {
+                balls[i].color = SEGMENT.color_wheel(i*(256/MAX(numBalls, 8)));
+            } else if (SEGCOLOR(2)) {
+                balls[i].color = SEGCOLOR(i % NUM_COLORS);
+            } else {
+                balls[i].color = SEGCOLOR(0);
+            }
+        }
+    }
+
+private:
+    unsigned numBalls;
+    unsigned strips;
+    std::vector<Ball> balls;
+    uint32_t backgroundColor;
+    bool useBackgroundColor;
+    int stripIndex;
+    int ballSize;
+};

--- a/wled00/effects/BufferedEffect.h
+++ b/wled00/effects/BufferedEffect.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "../FX.h"
+#include "Effect.h"
+
+class BufferedEffect : public Effect {
+protected:
+    class PixelBuffer {
+        friend class BufferedEffect;
+    public:
+        uint32_t getPixelColor(int i) const {
+            if (i < 0) [[unlikely]] {
+                Serial.printf("BufferedEffect::PixelBuffer::getPixelColor: %d < 0\n", i);
+                std::terminate();
+            }
+            if (static_cast<size_t>(i) >= pixels.size()) [[unlikely]] {
+                Serial.printf("BufferedEffect::PixelBuffer::getPixelColor: %d >= %u\n", i, pixels.size());
+                std::terminate();
+            }
+            return pixels[static_cast<size_t>(i)];
+        }
+        inline uint32_t getPixelColorXY(int x, int y) const {
+            return getPixelColor(y * SEG_W + x);
+        }
+        void setPixelColor(int i, uint32_t c) {
+            if (i < 0) [[unlikely]] {
+                std::terminate();
+            }
+            if (static_cast<size_t>(i) >= pixels.size()) [[unlikely]] {
+                std::terminate();
+            }
+            pixels[static_cast<size_t>(i)] = c;
+        }
+        void blendPixelColor(int n, uint32_t color, uint8_t blend) {
+            setPixelColor(n, color_blend(getPixelColor(n), color, blend));
+        }
+
+    private:
+        std::vector<uint32_t> pixels;
+    };
+
+private:
+    using Self = BufferedEffect;
+    using Base = Effect;
+
+protected:
+    explicit BufferedEffect(const EffectInformation& ei, bool initBufferWithCurrentState)
+        : Base{ei}
+    {
+        if (!initBufferWithCurrentState) {
+            return;
+        }
+        const unsigned strips = SEGMENT.nrOfVStrips();
+        const unsigned stripLength = SEGLEN;
+        const size_t length = SEGMENT.nrOfVStrips() * stripLength;
+        buffer.pixels.resize(length); // don't initialize the buffer with specific values
+        if (buffer.pixels.size() != length) {
+            buffer.pixels.clear();
+            return;
+        }
+        for (unsigned stripIndex = 0; stripIndex < strips; stripIndex++) {
+            for (unsigned i = 0; i < stripLength; i++) {
+                unsigned encodedIndex = ((i) | (int((stripIndex) + 1) << 16)); // original indexToVStrip
+                buffer.pixels[(i * strips + stripIndex)] = SEGMENT.getPixelColor(encodedIndex);
+            }
+        }
+    }
+
+    static inline unsigned indexToVStrip(unsigned index, size_t stripNr) {
+        return (SEGLEN - index - 1u) * SEGMENT.nrOfVStrips() + stripNr;
+    }
+
+public:
+    void nextFrameImpl() {
+        const size_t length = SEGMENT.nrOfVStrips() * SEGLEN;
+        buffer.pixels.resize(length, 0u);
+        if (buffer.pixels.size() != length) {
+            buffer.pixels.clear();
+            return;
+        }
+    }
+
+    constexpr void nextRowImpl(int y) {
+    }
+
+    uint32_t getPixelColorImpl(int x, int y, const LazyColor& currentColor) {
+        return buffer.getPixelColorXY(x, y);
+    }
+
+protected:
+    PixelBuffer buffer{};
+};

--- a/wled00/effects/Effect.h
+++ b/wled00/effects/Effect.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "../wled.h" // for debug prints
+
+class Effect;
+
+// Kinda emulates a v-table without needing an actual v-table.
+struct EffectInformation {
+    const char* metaData;
+    uint8_t effectId;
+    uint8_t defaultPaletteId;
+    std::unique_ptr<Effect> (*makeEffect)();
+};
+static_assert(std::is_pod_v<EffectInformation>);
+
+class Effect {
+public:
+    explicit constexpr Effect(const EffectInformation& ei) : info(ei) {}
+    constexpr uint8_t getEffectId() const {
+        return info.effectId;
+    }
+    uint8_t getDefaultPaletteId() const {
+        return info.defaultPaletteId;
+    }
+    virtual void nextFrame() {}
+    virtual void nextRow(int y) {}
+    virtual uint32_t getPixelColor(int x, int y, uint32_t currentColor) {
+        return 0;
+    }
+private:
+    const EffectInformation& info;
+};
+
+class EffectFactory {
+public:
+    explicit constexpr EffectFactory(const EffectInformation& ei) : info(ei) {}
+    constexpr uint8_t getEffectId() const {
+        return info.effectId;
+    }
+    constexpr const char* getMetaData() const {
+        return info.metaData;
+    }
+    std::unique_ptr<Effect> makeEffect() const {
+        return info.makeEffect();
+    }
+private:
+    const EffectInformation& info;
+};

--- a/wled00/effects/Effect.h
+++ b/wled00/effects/Effect.h
@@ -42,16 +42,31 @@ public:
         return info.getPixelColor(this, x, y, currentColor);
     }
 
-    constexpr static void nextFrameNoop(Effect* effect) {
-    }
-    constexpr static void nextRowNoop(Effect* effect, int y) {
-    }
-    constexpr static uint32_t getPixelColorNoop(Effect* effect, int x, int y, const LazyColor& currentColor) {
-        return 0;
-    }
-
 private:
     const EffectInformation& info;
+};
+
+template<typename T>
+class BaseEffect : public Effect {
+    using Base = Effect;
+public:
+    using Base::Base;
+
+    static std::unique_ptr<Effect> makeEffect() {
+        return std::make_unique<T>(T::effectInformation);
+    }
+
+    static void nextFrame(Effect* effect) {
+        static_cast<T*>(effect)->nextFrameImpl();
+    }
+
+    static void nextRow(Effect* effect, int y) {
+        static_cast<T*>(effect)->nextRowImpl(y);
+    }
+
+    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
+        return static_cast<T*>(effect)->getPixelColorImpl(x, y, currentColor);
+    }
 };
 
 class EffectFactory {

--- a/wled00/effects/Effect.h
+++ b/wled00/effects/Effect.h
@@ -46,9 +46,8 @@ private:
     const EffectInformation& info;
 };
 
-template<typename T>
-class BaseEffect : public Effect {
-    using Base = Effect;
+template<typename T, typename Base = Effect>
+class BaseEffect : public Base {
 public:
     using Base::Base;
 

--- a/wled00/effects/Effect.h
+++ b/wled00/effects/Effect.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "../wled.h" // for debug prints
+#include <memory>
 
 class Effect;
+class LazyColor;
 
 // Kinda emulates a v-table without needing an actual v-table.
 struct EffectInformation {
     using MakeEffectFunction    = std::unique_ptr<Effect> (*)();
     using NextFrameFunction     = void (*)(Effect* effect);
     using NextRowFunction       = void (*)(Effect* effect, int y);
-    using GetPixelColorFunction = uint32_t (*)(Effect* effect, int x, int y, uint32_t currentColor);
+    using GetPixelColorFunction = uint32_t (*)(Effect* effect, int x, int y, const LazyColor& currentColor);
 
     const char* metaData;
     const uint8_t effectId;
@@ -37,7 +38,7 @@ public:
     constexpr void nextRow(int y) {
         info.nextRow(this, y);
     }
-    constexpr uint32_t getPixelColor(int x, int y, uint32_t currentColor) {
+    constexpr uint32_t getPixelColor(int x, int y, const LazyColor& currentColor) {
         return info.getPixelColor(this, x, y, currentColor);
     }
 
@@ -45,7 +46,7 @@ public:
     }
     constexpr static void nextRowNoop(Effect* effect, int y) {
     }
-    constexpr static uint32_t getPixelColorNoop(Effect* effect, int x, int y, uint32_t currentColor) {
+    constexpr static uint32_t getPixelColorNoop(Effect* effect, int x, int y, const LazyColor& currentColor) {
         return 0;
     }
 

--- a/wled00/effects/Effect.h
+++ b/wled00/effects/Effect.h
@@ -6,10 +6,18 @@ class Effect;
 
 // Kinda emulates a v-table without needing an actual v-table.
 struct EffectInformation {
+    using MakeEffectFunction    = std::unique_ptr<Effect> (*)();
+    using NextFrameFunction     = void (*)(Effect* effect);
+    using NextRowFunction       = void (*)(Effect* effect, int y);
+    using GetPixelColorFunction = uint32_t (*)(Effect* effect, int x, int y, uint32_t currentColor);
+
     const char* metaData;
-    uint8_t effectId;
-    uint8_t defaultPaletteId;
-    std::unique_ptr<Effect> (*makeEffect)();
+    const uint8_t effectId;
+    const uint8_t defaultPaletteId;
+    const MakeEffectFunction makeEffect;
+    const NextFrameFunction nextFrame;
+    const NextRowFunction nextRow;
+    const GetPixelColorFunction getPixelColor;
 };
 static_assert(std::is_pod_v<EffectInformation>);
 
@@ -19,14 +27,28 @@ public:
     constexpr uint8_t getEffectId() const {
         return info.effectId;
     }
-    uint8_t getDefaultPaletteId() const {
+    constexpr uint8_t getDefaultPaletteId() const {
         return info.defaultPaletteId;
     }
-    virtual void nextFrame() {}
-    virtual void nextRow(int y) {}
-    virtual uint32_t getPixelColor(int x, int y, uint32_t currentColor) {
+
+    constexpr void nextFrame() {
+        info.nextFrame(this);
+    }
+    constexpr void nextRow(int y) {
+        info.nextRow(this, y);
+    }
+    constexpr uint32_t getPixelColor(int x, int y, uint32_t currentColor) {
+        return info.getPixelColor(this, x, y, currentColor);
+    }
+
+    constexpr static void nextFrameNoop(Effect* effect) {
+    }
+    constexpr static void nextRowNoop(Effect* effect, int y) {
+    }
+    constexpr static uint32_t getPixelColorNoop(Effect* effect, int x, int y, uint32_t currentColor) {
         return 0;
     }
+
 private:
     const EffectInformation& info;
 };

--- a/wled00/effects/PaletteEffect.h
+++ b/wled00/effects/PaletteEffect.h
@@ -4,9 +4,11 @@
 #include "Effect.h"
 #include <algorithm>
 
-class PaletteEffect : public Effect {
+class PaletteEffect : public BaseEffect<PaletteEffect> {
 private:
     using Self = PaletteEffect;
+    using Base = BaseEffect<PaletteEffect>;
+
     // Set up some compile time constants so that we can handle integer and float based modes using the same code base.
     #ifdef ESP8266
     using mathType = int32_t;
@@ -29,24 +31,9 @@ private:
     static constexpr float (*sinFunction)(float)    = &sin_t;
     static constexpr float (*cosFunction)(float)    = &cos_t;
     #endif
+
 public:
-    using Effect::Effect;
-
-    static std::unique_ptr<Effect> makeEffect() {
-        return std::make_unique<Self>(effectInformation);
-    }
-
-    static void nextFrame(Effect* effect) {
-        static_cast<Self*>(effect)->nextFrameImpl();
-    }
-
-    static constexpr void nextRow(Effect* effect, int y) {
-        static_cast<Self*>(effect)->nextRowImpl(y);
-    }
-
-    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
-        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
-    }
+    using Base::Base;
 
     static constexpr EffectInformation effectInformation {
         "Palette@Shift,Size,Rotation,,,Animate Shift,Animate Rotation,Anamorphic;;!;12;ix=112,c1=0,o1=1,o2=0,o3=1",
@@ -58,7 +45,6 @@ public:
         &Self::getPixelColor,
     };
 
-private:
     void nextFrameImpl() {
         const bool isMatrix = strip.isMatrix;
         const int cols = SEG_W;

--- a/wled00/effects/PaletteEffect.h
+++ b/wled00/effects/PaletteEffect.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "../FX.h"
+#include "Effect.h"
+#include <algorithm>
+
+class PaletteEffect : public Effect {
+private:
+    using Self = PaletteEffect;
+    // Set up some compile time constants so that we can handle integer and float based modes using the same code base.
+    #ifdef ESP8266
+    using mathType = int32_t;
+    using wideMathType = int64_t;
+    using angleType = unsigned;
+    static constexpr mathType sInt16Scale             = 0x7FFF;
+    static constexpr mathType maxAngle                = 0x8000;
+    static constexpr mathType staticRotationScale     = 256;
+    static constexpr mathType animatedRotationScale   = 1;
+    static constexpr int16_t (*sinFunction)(uint16_t) = &sin16_t;
+    static constexpr int16_t (*cosFunction)(uint16_t) = &cos16_t;
+    #else
+    using mathType = float;
+    using wideMathType = float;
+    using angleType = float;
+    static constexpr mathType sInt16Scale           = 1.0f;
+    static constexpr mathType maxAngle              = M_PI / 256.0;
+    static constexpr mathType staticRotationScale   = 1.0f;
+    static constexpr mathType animatedRotationScale = M_TWOPI / double(0xFFFF);
+    static constexpr float (*sinFunction)(float)    = &sin_t;
+    static constexpr float (*cosFunction)(float)    = &cos_t;
+    #endif
+public:
+    using Effect::Effect;
+
+    static std::unique_ptr<Effect> makeEffect() {
+        return std::make_unique<Self>(effectInformation);
+    }
+
+    static constexpr EffectInformation effectInformation {
+        "Palette@Shift,Size,Rotation,,,Animate Shift,Animate Rotation,Anamorphic;;!;12;ix=112,c1=0,o1=1,o2=0,o3=1",
+        FX_MODE_PALETTE,
+        0u,
+        &Self::makeEffect,
+    };
+
+    void nextFrame() override {
+        const bool isMatrix = strip.isMatrix;
+        const int cols = SEG_W;
+        const int rows = isMatrix ? SEG_H : strip.getActiveSegmentsNum();
+
+        const int  inputRotation        = SEGMENT.custom1;
+        const bool inputAnimateRotation = SEGMENT.check2;
+        const bool inputAssumeSquare    = SEGMENT.check3;
+
+        const angleType theta = (!inputAnimateRotation) ? ((inputRotation + 128) * maxAngle / staticRotationScale) : (((strip.now * ((inputRotation >> 4) +1)) & 0xFFFF) * animatedRotationScale);
+        sinTheta = sinFunction(theta);
+        cosTheta = cosFunction(theta);
+
+        const mathType maxX    = std::max(1, cols-1);
+        const mathType maxY    = std::max(1, rows-1);
+        // Set up some parameters according to inputAssumeSquare, so that we can handle anamorphic mode using the same code base.
+        maxXIn  =  inputAssumeSquare ? maxX : mathType(1);
+        maxYIn  =  inputAssumeSquare ? maxY : mathType(1);
+        maxXOut = !inputAssumeSquare ? maxX : mathType(1);
+        const mathType maxYOut = !inputAssumeSquare ? maxY : mathType(1);
+        centerX = sInt16Scale * maxXOut / mathType(2);
+        centerY = sInt16Scale * maxYOut / mathType(2);
+        // The basic idea for this effect is to rotate a rectangle that is filled with the palette along one axis, then map our
+        // display to it, to find what color a pixel should have.
+        // However, we want a) no areas of solid color (in front of or behind the palette), and b) we want to make use of the full palette.
+        // So the rectangle needs to have exactly the right size. That size depends on the rotation.
+        // This scale computation here only considers one dimension. You can think of it like the rectangle is always scaled so that
+        // the left and right most points always match the left and right side of the display.
+        scale = std::abs(sinTheta) + (std::abs(cosTheta) * maxYOut / maxXOut);
+    }
+
+    void nextRow(int y) override {
+        // translate, scale, rotate
+        ytCosTheta = mathType((wideMathType(cosTheta) * wideMathType(y * sInt16Scale - centerY * maxYIn))/wideMathType(maxYIn * scale));
+    }
+
+    uint32_t getPixelColor(int x, int y, uint32_t currentColor) override {
+        const int  inputSize            = SEGMENT.intensity;
+        const bool inputAnimateShift    = SEGMENT.check1;
+        const int  inputShift           = SEGMENT.speed;
+
+        const mathType xtSinTheta = mathType((wideMathType(sinTheta) * wideMathType(x * sInt16Scale - centerX * maxXIn))/wideMathType(maxXIn * scale));
+        // Map the pixel coordinate to an imaginary-rectangle-coordinate.
+        // The y coordinate doesn't actually matter, as our imaginary rectangle is filled with the palette from left to right,
+        // so all points at a given x-coordinate have the same color.
+        const mathType sourceX = xtSinTheta + ytCosTheta + centerX;
+        // The computation was scaled just right so that the result should always be in range [0, maxXOut], but enforce this anyway
+        // to account for imprecision. Then scale it so that the range is [0, 255], which we can use with the palette.
+        int colorIndex = (std::min(std::max(sourceX, mathType(0)), maxXOut * sInt16Scale) * wideMathType(255)) / (sInt16Scale * maxXOut);
+        // inputSize determines by how much we want to scale the palette:
+        // values < 128 display a fraction of a palette,
+        // values > 128 display multiple palettes.
+        if (inputSize <= 128) {
+            colorIndex = (colorIndex * inputSize) / 128;
+        } else {
+            // Linear function that maps colorIndex 128=>1, 256=>9.
+            // With this function every full palette repetition is exactly 16 configuration steps wide.
+            // That allows displaying exactly 2 repetitions for example.
+            colorIndex = ((inputSize - 112) * colorIndex) / 16;
+        }
+        // Finally, shift the palette a bit.
+        const int paletteOffset = (!inputAnimateShift) ? (inputShift) : (((strip.now * ((inputShift >> 3) +1)) & 0xFFFF) >> 8);
+        colorIndex -= paletteOffset;
+        const uint32_t color = SEGMENT.color_wheel((uint8_t)colorIndex);
+        return color;
+    }
+
+private:
+    mathType sinTheta;
+    mathType cosTheta;
+    mathType maxXIn;
+    mathType maxYIn;
+    mathType maxXOut;
+    mathType centerX;
+    mathType centerY;
+    mathType scale;
+    mathType ytCosTheta;
+};

--- a/wled00/effects/PaletteEffect.h
+++ b/wled00/effects/PaletteEffect.h
@@ -36,14 +36,30 @@ public:
         return std::make_unique<Self>(effectInformation);
     }
 
+    static void nextFrame(Effect* effect) {
+        static_cast<Self*>(effect)->nextFrameImpl();
+    }
+
+    static constexpr void nextRow(Effect* effect, int y) {
+        static_cast<Self*>(effect)->nextRowImpl(y);
+    }
+
+    static uint32_t getPixelColor(Effect* effect, int x, int y, uint32_t currentColor) {
+        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
+    }
+
     static constexpr EffectInformation effectInformation {
         "Palette@Shift,Size,Rotation,,,Animate Shift,Animate Rotation,Anamorphic;;!;12;ix=112,c1=0,o1=1,o2=0,o3=1",
         FX_MODE_PALETTE,
         0u,
         &Self::makeEffect,
+        &Self::nextFrame,
+        &Self::nextRow,
+        &Self::getPixelColor,
     };
 
-    void nextFrame() override {
+private:
+    void nextFrameImpl() {
         const bool isMatrix = strip.isMatrix;
         const int cols = SEG_W;
         const int rows = isMatrix ? SEG_H : strip.getActiveSegmentsNum();
@@ -74,12 +90,12 @@ public:
         scale = std::abs(sinTheta) + (std::abs(cosTheta) * maxYOut / maxXOut);
     }
 
-    void nextRow(int y) override {
+    constexpr void nextRowImpl(int y) {
         // translate, scale, rotate
         ytCosTheta = mathType((wideMathType(cosTheta) * wideMathType(y * sInt16Scale - centerY * maxYIn))/wideMathType(maxYIn * scale));
     }
 
-    uint32_t getPixelColor(int x, int y, uint32_t currentColor) override {
+    uint32_t getPixelColorImpl(int x, int y, uint32_t currentColor) {
         const int  inputSize            = SEGMENT.intensity;
         const bool inputAnimateShift    = SEGMENT.check1;
         const int  inputShift           = SEGMENT.speed;

--- a/wled00/effects/PaletteEffect.h
+++ b/wled00/effects/PaletteEffect.h
@@ -44,7 +44,7 @@ public:
         static_cast<Self*>(effect)->nextRowImpl(y);
     }
 
-    static uint32_t getPixelColor(Effect* effect, int x, int y, uint32_t currentColor) {
+    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
         return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
     }
 
@@ -95,7 +95,7 @@ private:
         ytCosTheta = mathType((wideMathType(cosTheta) * wideMathType(y * sInt16Scale - centerY * maxYIn))/wideMathType(maxYIn * scale));
     }
 
-    uint32_t getPixelColorImpl(int x, int y, uint32_t currentColor) {
+    uint32_t getPixelColorImpl(int x, int y, const LazyColor& currentColor) {
         const int  inputSize            = SEGMENT.intensity;
         const bool inputAnimateShift    = SEGMENT.check1;
         const int  inputShift           = SEGMENT.speed;

--- a/wled00/effects/StaticEffect.h
+++ b/wled00/effects/StaticEffect.h
@@ -12,7 +12,7 @@ public:
         return std::make_unique<StaticEffect>(effectInformation);
     }
 
-    static uint32_t getPixelColor(Effect* effect, int x, int y, uint32_t currentColor) {
+    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
         return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
     }
 
@@ -27,7 +27,7 @@ public:
     };
 
 private:
-    uint32_t getPixelColorImpl(int x, int y, uint32_t currentColor) {
+    uint32_t getPixelColorImpl(int x, int y, const LazyColor& currentColor) {
         return SEGCOLOR(0);
     }
 };

--- a/wled00/effects/StaticEffect.h
+++ b/wled00/effects/StaticEffect.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../FX.h"
+#include "Effect.h"
+
+class StaticEffect : public Effect {
+public:
+    using Effect::Effect;
+    static std::unique_ptr<Effect> makeEffect() {
+        return std::make_unique<StaticEffect>(effectInformation);
+    }
+
+    uint32_t getPixelColor(int x, int y, uint32_t currentColor) override {
+        return SEGCOLOR(0);
+    }
+
+    static constexpr EffectInformation effectInformation {
+        "Solid",
+        FX_MODE_STATIC,
+        0u,
+        &StaticEffect::makeEffect,
+    };
+};

--- a/wled00/effects/StaticEffect.h
+++ b/wled00/effects/StaticEffect.h
@@ -3,30 +3,30 @@
 #include "../FX.h"
 #include "Effect.h"
 
-class StaticEffect : public Effect {
+class StaticEffect : public BaseEffect<StaticEffect> {
 private:
     using Self = StaticEffect;
-public:
-    using Effect::Effect;
-    static std::unique_ptr<Effect> makeEffect() {
-        return std::make_unique<StaticEffect>(effectInformation);
-    }
+    using Base = BaseEffect<StaticEffect>;
 
-    static uint32_t getPixelColor(Effect* effect, int x, int y, const LazyColor& currentColor) {
-        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
-    }
+public:
+    using Base::Base;
 
     static constexpr EffectInformation effectInformation {
         "Solid",
         FX_MODE_STATIC,
         0u,
         &Self::makeEffect,
-        &Effect::nextFrameNoop,
-        &Effect::nextRowNoop,
+        &Self::nextFrame,
+        &Self::nextRow,
         &Self::getPixelColor,
     };
 
-private:
+    constexpr void nextFrameImpl() {
+    }
+
+    constexpr void nextRowImpl(int y) {
+    }
+
     uint32_t getPixelColorImpl(int x, int y, const LazyColor& currentColor) {
         return SEGCOLOR(0);
     }

--- a/wled00/effects/StaticEffect.h
+++ b/wled00/effects/StaticEffect.h
@@ -4,20 +4,30 @@
 #include "Effect.h"
 
 class StaticEffect : public Effect {
+private:
+    using Self = StaticEffect;
 public:
     using Effect::Effect;
     static std::unique_ptr<Effect> makeEffect() {
         return std::make_unique<StaticEffect>(effectInformation);
     }
 
-    uint32_t getPixelColor(int x, int y, uint32_t currentColor) override {
-        return SEGCOLOR(0);
+    static uint32_t getPixelColor(Effect* effect, int x, int y, uint32_t currentColor) {
+        return static_cast<Self*>(effect)->getPixelColorImpl(x, y, currentColor);
     }
 
     static constexpr EffectInformation effectInformation {
         "Solid",
         FX_MODE_STATIC,
         0u,
-        &StaticEffect::makeEffect,
+        &Self::makeEffect,
+        &Effect::nextFrameNoop,
+        &Effect::nextRowNoop,
+        &Self::getPixelColor,
     };
+
+private:
+    uint32_t getPixelColorImpl(int x, int y, uint32_t currentColor) {
+        return SEGCOLOR(0);
+    }
 };

--- a/wled00/effects/TetrixEffect.h
+++ b/wled00/effects/TetrixEffect.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "../FX.h"
+#include "Effect.h"
+#include "BufferedEffect.h"
+
+#include <type_traits> //TODO remove
+
+class TetrixEffect : public BaseEffect<TetrixEffect, BufferedEffect> {
+private:
+    struct Tetris {
+        float    pos{};
+        float    speed{};
+        uint8_t  col{};   // color index
+        uint16_t brick{}; // brick size in pixels
+        uint16_t stack{0u}; // stack size in pixels
+        uint32_t step{}; // 2D-fication of SEGENV.step (state)
+    };
+
+    using Self = TetrixEffect;
+    using Base = BaseEffect<TetrixEffect, BufferedEffect>;
+
+public:
+    explicit TetrixEffect(const EffectInformation& ei) : Base{ei, true} {}
+
+    static constexpr EffectInformation effectInformation {
+        "Tetrix@!,Width,,,,One color;!,!;!;;sx=0,ix=0,pal=11,m12=1",
+        FX_MODE_TETRIX,
+        0u,
+        &Self::makeEffect,
+        &Self::nextFrame,
+        &Self::nextRow,
+        &Self::getPixelColor,
+    };
+
+    void nextFrameImpl() {
+      Base::nextFrameImpl();
+
+      unsigned strips = SEGMENT.nrOfVStrips(); // allow running on virtual strips (columns in 2D segment)
+      drops.resize(strips);
+      if (drops.size() != strips) {
+        drops.clear();
+        return;
+      }
+
+      for (unsigned stripNr=0; stripNr<strips; stripNr++)
+        runStrip(stripNr, &drops[stripNr]);
+    }
+
+private:
+    // virtualStrip idea by @ewowi (Ewoud Wijma)
+    // requires virtual strip # to be embedded into upper 16 bits of index in setPixelcolor()
+    // the following functions will not work on virtual strips: fill(), fade_out(), fadeToBlack(), blur()
+    void runStrip(size_t stripNr, Tetris *drop) {
+      // initialize dropping on first call or segment full
+      if (SEGENV.call == 0) {
+        drop->stack = 0;                  // reset brick stack size
+        drop->step = strip.now + 2000;     // start by fading out strip
+        if (SEGMENT.check1) drop->col = 0;// use only one color from palette
+      }
+
+      if (drop->step == 0) {              // init brick
+        // speed calculation: a single brick should reach bottom of strip in X seconds
+        // if the speed is set to 1 this should take 5s and at 255 it should take 0.25s
+        // as this is dependant on SEGLEN it should be taken into account and the fact that effect runs every FRAMETIME s
+        int speed = SEGMENT.speed ? SEGMENT.speed : hw_random8(1,255);
+        speed = map(speed, 1, 255, 5000, 250); // time taken for full (SEGLEN) drop
+        drop->speed = float(SEGLEN * FRAMETIME) / float(speed); // set speed
+        drop->pos   = SEGLEN;             // start at end of segment (no need to subtract 1)
+        if (!SEGMENT.check1) drop->col = hw_random8(0,15)<<4;   // limit color choices so there is enough HUE gap
+        drop->step  = 1;                  // drop state (0 init, 1 forming, 2 falling)
+        drop->brick = (SEGMENT.intensity ? (SEGMENT.intensity>>5)+1 : hw_random8(1,5)) * (1+(SEGLEN>>6));  // size of brick
+      }
+
+      if (drop->step == 1) {              // forming
+        if (hw_random8()>>6) {               // random drop
+          drop->step = 2;                 // fall
+        }
+      }
+      if (drop->step == 2) {              // falling
+        if (drop->pos > drop->stack) {    // fall until top of stack
+          drop->pos -= drop->speed;       // may add gravity as: speed += gravity
+          if (int(drop->pos) < int(drop->stack)) drop->pos = drop->stack;
+          for (unsigned i = unsigned(drop->pos); i < SEGLEN; i++) {
+            uint32_t col = i < unsigned(drop->pos)+drop->brick ? SEGMENT.color_from_palette(drop->col, false, false, 0) : SEGCOLOR(1);
+            buffer.setPixelColor(indexToVStrip(i, stripNr), col);
+          }
+        } else {                          // we hit bottom
+          drop->step = 0;                 // proceed with next brick, go back to init
+          drop->stack += drop->brick;     // increase the stack size
+          if (drop->stack >= SEGLEN) drop->step = strip.now + 2000; // fade out stack
+        }
+      }
+
+      if (drop->step > 2) {               // fade strip
+        drop->brick = 0;                  // reset brick size (no more growing)
+        if (drop->step > strip.now) {
+          // allow fading of virtual strip
+          for (unsigned i = 0; i < SEGLEN; i++) buffer.blendPixelColor(indexToVStrip(i, stripNr), SEGCOLOR(1), 25); // 10% blend
+        } else {
+          drop->stack = 0;                // reset brick stack size
+          drop->step = 0;                 // proceed with next brick
+          if (SEGMENT.check1) drop->col += 8;   // gradually increase palette index
+        }
+      }
+    }
+
+private:
+    std::vector<Tetris> drops;
+};

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -505,7 +505,7 @@ bool requestJSONBufferLock(uint8_t moduleID=255);
 void releaseJSONBufferLock();
 uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLen);
 uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxLen, uint8_t *var = nullptr);
-int16_t extractModeDefaults(uint8_t mode, const char *segVar);
+int16_t extractModeDefaults(const char *metaData, const char *segVar);
 void checkSettingsPIN(const char *pin);
 uint16_t crc16(const unsigned char* data_p, size_t length);
 uint16_t beatsin88_t(accum88 beats_per_minute_88, uint16_t lowest = 0, uint16_t highest = 65535, uint32_t timebase = 0, uint16_t phase_offset = 0);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -179,7 +179,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
         if (!colValid) continue;
 
         seg.setColor(i, RGBW32(rgbw[0],rgbw[1],rgbw[2],rgbw[3]));
-        if (seg.mode == FX_MODE_STATIC) strip.trigger(); //instant refresh
+        if (seg.getEffectId() == FX_MODE_STATIC) strip.trigger(); //instant refresh
       }
     } else {
       // non RGB & non White segment (usually On/Off bus)
@@ -216,10 +216,10 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   if (seg.is2D() && seg.map1D2D == M12_pArc && (reverse != seg.reverse || reverse_y != seg.reverse_y || mirror != seg.mirror || mirror_y != seg.mirror_y)) seg.fill(BLACK); // clear entire segment (in case of Arc 1D to 2D expansion)
   #endif
 
-  byte fx = seg.mode;
+  byte fx = seg.getEffectId();
   if (getVal(elem["fx"], &fx, 0, strip.getModeCount())) {
     if (!presetId && currentPlaylist>=0) unloadPlaylist();
-    if (fx != seg.mode) seg.setMode(fx, elem[F("fxdef")]);
+    seg.setMode(fx, elem[F("fxdef")]);
   }
 
   getVal(elem["sx"], &seg.speed);
@@ -543,7 +543,7 @@ void serializeSegment(const JsonObject& root, const Segment& seg, byte id, bool 
   strcat(colstr, "]");
   root["col"] = serialized(colstr);
 
-  root["fx"]  = seg.mode;
+  root["fx"]  = seg.getEffectId();
   root["sx"]  = seg.speed;
   root["ix"]  = seg.intensity;
   root["pal"] = seg.palette;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -15,6 +15,36 @@
  * JSON API (De)serialization
  */
 
+namespace {
+bool differs(const Segment& segment, const std::array<std::byte, sizeof(Segment)>& backup) {
+  const Segment& segmentBackup = *reinterpret_cast<const Segment*>(backup.data());
+  Serial.println("differs 00");
+  Serial.printf("differs 01 %p %p\n", (void*)segment.getCurrentEffect(), (void*)segmentBackup.getCurrentEffect());
+  if (segment.start != segmentBackup.start)         return true;
+  if (segment.stop != segmentBackup.stop)           return true;
+  if (segment.offset != segmentBackup.offset)       return true;
+  if (segment.grouping != segmentBackup.grouping)   return true;
+  if (segment.spacing != segmentBackup.spacing)     return true;
+  if (segment.opacity != segmentBackup.opacity)     return true;
+  if (segment.getCurrentEffect() != segmentBackup.getCurrentEffect()) return true;
+  if (segment.speed != segmentBackup.speed)         return true;
+  if (segment.intensity != segmentBackup.intensity) return true;
+  if (segment.palette != segmentBackup.palette)     return true;
+  if (segment.custom1 != segmentBackup.custom1)     return true;
+  if (segment.custom2 != segmentBackup.custom2)     return true;
+  if (segment.custom3 != segmentBackup.custom3)     return true;
+  if (segment.startY != segmentBackup.startY)       return true;
+  if (segment.stopY != segmentBackup.stopY)         return true;
+
+  //bit pattern: (msb first)
+  // set:2, sound:2, mapping:3, transposed, mirrorY, reverseY, [reset,] paused, mirrored, on, reverse, [selected]
+  if ((segment.options & 0b1111111111011110U) != (segmentBackup.options & 0b1111111111011110U)) return true;
+  for (unsigned i = 0; i < NUM_COLORS; i++) if (segment.colors[i] != segmentBackup.colors[i])   return true;
+
+  return false;
+}
+}
+
 bool deserializeSegment(JsonObject elem, byte it, byte presetId)
 {
   byte id = elem["id"] | it;
@@ -34,7 +64,8 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
   //DEBUG_PRINTLN(F("-- JSON deserialize segment."));
   Segment& seg = strip.getSegment(id);
   //DEBUG_PRINTF_P(PSTR("--  Original segment: %p (%p)\n"), &seg, seg.data);
-  const Segment prev = seg; //make a backup so we can tell if something changed (calling copy constructor)
+  alignas(Segment) std::array<std::byte, sizeof(Segment)> segmentBackup; //make a backup so we can tell if something changed (voiding copy constructor)
+  std::memcpy(segmentBackup.data(), &seg, sizeof(Segment));
   //DEBUG_PRINTF_P(PSTR("--  Duplicate segment: %p (%p)\n"), &prev, prev.data);
 
   int start = elem["start"] | seg.start;
@@ -293,7 +324,7 @@ bool deserializeSegment(JsonObject elem, byte it, byte presetId)
     strip.trigger(); // force segment update
   }
   // send UDP/WS if segment options changed (except selection; will also deselect current preset)
-  if (seg.differs(prev) & 0x7F) stateChanged = true;
+  stateChanged = stateChanged || differs(seg, segmentBackup);
 
   return true;
 }

--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -17,7 +17,7 @@ void setValuesFromSegment(uint8_t s)
   colSec[1] = G(seg.colors[1]);
   colSec[2] = B(seg.colors[1]);
   colSec[3] = W(seg.colors[1]);
-  effectCurrent   = seg.mode;
+  effectCurrent   = seg.getEffectId();
   effectSpeed     = seg.speed;
   effectIntensity = seg.intensity;
   effectPalette   = seg.palette;
@@ -38,7 +38,7 @@ void applyValuesToSelectedSegs()
     if (effectSpeed     != selsegPrev.speed)     {seg.speed     = effectSpeed;     stateChanged = true;}
     if (effectIntensity != selsegPrev.intensity) {seg.intensity = effectIntensity; stateChanged = true;}
     if (effectPalette   != selsegPrev.palette)   {seg.setPalette(effectPalette);}
-    if (effectCurrent   != selsegPrev.mode)      {seg.setMode(effectCurrent);}
+    if (effectCurrent   != selsegPrev.getEffectId()) {seg.setMode(effectCurrent);}
     uint32_t col0 = RGBW32(   col[0],    col[1],    col[2],    col[3]);
     uint32_t col1 = RGBW32(colSec[0], colSec[1], colSec[2], colSec[3]);
     if (col0 != selsegPrev.colors[0])            {seg.setColor(0, col0);}

--- a/wled00/overlay.cpp
+++ b/wled00/overlay.cpp
@@ -94,7 +94,7 @@ void handleOverlayDraw() {
     for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
       const Segment& segment = segments[i];
       if (!segment.isActive()) continue;
-      if (segment.mode > 0 || segment.colors[0] > 0) {
+      if (segment.getEffectId() > 0 || segment.colors[0] > 0) {
         return;
       }
     }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -854,7 +854,7 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   uint32_t col2    = selseg.colors[2];
   byte colIn[4]    = {R(col0), G(col0), B(col0), W(col0)};
   byte colInSec[4] = {R(col1), G(col1), B(col1), W(col1)};
-  byte effectIn    = selseg.mode;
+  byte effectIn    = selseg.getEffectId();
   byte speedIn     = selseg.speed;
   byte intensityIn = selseg.intensity;
   byte paletteIn   = selseg.palette;

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -48,7 +48,7 @@ void notify(byte callMode, bool followUp)
   udpOut[5] = B(col);
   udpOut[6] = nightlightActive;
   udpOut[7] = nightlightDelayMins;
-  udpOut[8] = mainseg.mode;
+  udpOut[8] = mainseg.getEffectId();
   udpOut[9] = mainseg.speed;
   udpOut[10] = W(col);
   //compatibilityVersionByte:
@@ -118,7 +118,7 @@ void notify(byte callMode, bool followUp)
     udpOut[8 +ofs] = selseg.offset & 0xFF;
     udpOut[9 +ofs] = selseg.options & 0x8F; //only take into account selected, mirrored, on, reversed, reverse_y (for 2D); ignore freeze, reset, transitional
     udpOut[10+ofs] = selseg.opacity;
-    udpOut[11+ofs] = selseg.mode;
+    udpOut[11+ofs] = selseg.getEffectId();
     udpOut[12+ofs] = selseg.speed;
     udpOut[13+ofs] = selseg.intensity;
     udpOut[14+ofs] = selseg.palette;

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -333,11 +333,12 @@ uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxL
 
 
 // extracts mode parameter defaults from last section of mode data (e.g. "Juggle@!,Trail;!,!,;!;012;sx=16,ix=240")
-int16_t extractModeDefaults(uint8_t mode, const char *segVar)
+int16_t extractModeDefaults(const char *metaData, const char *segVar)
 {
-  if (mode < strip.getModeCount()) {
+  //TODO this function doesn't need any string copies
+  if (metaData != nullptr) {
     char lineBuffer[256];
-    strncpy_P(lineBuffer, strip.getModeData(mode), sizeof(lineBuffer)/sizeof(char)-1);
+    strncpy_P(lineBuffer, metaData, sizeof(lineBuffer)/sizeof(char)-1);
     lineBuffer[sizeof(lineBuffer)/sizeof(char)-1] = '\0'; // terminate string
     if (lineBuffer[0] != 0) {
       char* startPtr = strrchr(lineBuffer, ';'); // last ";" in FX data


### PR DESCRIPTION
Ignore some of the changes of this PR...

What I am trying to figure out with this PR is if you'd be interested in on overhaul of how effects work. I created a virtual base Effect class, and implemented 2 effects as implementations of that:

[wled00/effects/Effect.h](https://github.com/wled-dev/WLED/pull/4549/files#diff-50deaad265c6f363e2e19fea29e8e0b49edfece29cd6f00fcdfbafe9d4dac60b)
[wled00/effects/StaticEffect.h](https://github.com/wled-dev/WLED/pull/4549/files#diff-1c7a35da2e134021ba759990d60150321ccf0074ae3d9357d7dc38663d1a50d3)
[wled00/effects/PaletteEffect.h](https://github.com/wled-dev/WLED/pull/4549/files#diff-4df54429aaaa37469cde72e0db4514bd4a9e1aab4c0921fb42c13eae139c56ba)

Note that this effect class does not handle a segment as a whole like current effects do, but instead handles one pixel at a time. See how this is called in [wled00/FX_fcn.cpp](https://github.com/wled-dev/WLED/pull/4549/files#diff-f109c5828073461346e40af85d68967e51a37b8353f8f228ae720dc54fa64550R1536) `WS2812FX::service()`.

Advantages of this approach: 

- not every effect needs to understand the inner workings of how segments work
- when using sparse setups, such as matrices where not all pixels map to physical LEDs, this could potentially safe some work. (Or at least implementing this kind of saving would require one change to `service` rather than requiring changing of all effects.)
- theoretically, this design should work will with potential future sparse 3D setups (where instead of implementing dense LED cubes, you throw a bunch of LEDs into space, then map their 3D positions)
- things like the 2D expansion that is currently used in the palette effect only could/would have to be implemented globally for all effects rather than once per effect
- EDIT: Another potential advantage might be that this design would allow effects being layered on top of each other without losing information due to brightness being applied immediately (however I don't think this would work for effects that use color values from previous frames)

Disadvantages:

- theoretically one virtual function call per pixel. (A good compiler should be able to resolve the virtual function once per `service()` call instead of per pixel iteration, but c++ provides no way of enforcing that.)
- currently, this code relies on c++17 and therefore only compiles on esp 8266

Outlook: currently, I only implemented fading transitions (untested). Theoretically, it would be possible to use an extended version of this Effect class to handle transitions, so that there would only have to be one code base for effects and transitions.


What do you think? Are you interested in this kind of work? Should I invest some time into advancing it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reimplemented effect system architecture with enhanced state management and rendering pipeline.
  * Improved effect-to-effect transition handling and ownership mechanics.
  * Updated Solid, Palette, Bouncing Balls, and Tetrix effects with revised implementations featuring improved processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->