### PR TITLE
add example demonstrating advanced PlatformIO environment inheritance

### DIFF
--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -538,9 +538,19 @@ lib_deps = ${env:esp32dev.lib_deps}
   sui77/rc-switch @ 2.6.4
 
 # ------------------------------------------------------------------------------
-# Advanced example: Inheriting all settings from an upstream "base" config, and
-# adding/overriding specific build flags, which is useful if you want to base
-# your environment on a stable core env but just override certain WLED defaults.
+# Advanced example: Inheriting all settings from an upstream WLED "release" config,
+# and adding/overriding specific build flags, which is useful if you want to base
+# your environment on a stable WLED release env but easily override some of its
+# defaults, such as the output pin numbers, the default ethernet board ID, etc.
+#
+# WARNING: The WLED project does NOT guarantee that your chosen "upstream" config
+# will exist or be maintained in the future. Environments can sometimes change
+# radically. The compiler will warn you if the upstream configuration doesn't
+# exist anymore, but it won't warn you if it's no longer maintained or has added
+# new flags that may impact your use-case. It is YOUR responsibility to periodically
+# check the status and any new defaults for your chosen upstream configuration.
+# However, it's *generally* safe to pick a well-known, popular release configuration
+# and tweak a few commonly used defaults such as its pin numbers and modes!
 # ------------------------------------------------------------------------------
 
 [env:esp32_eth_custom]
@@ -550,9 +560,10 @@ lib_deps = ${env:esp32dev.lib_deps}
 extends = env:esp32_eth
 
 ;; Remove conflicting upstream flags to fix compiler "variable redefined" warnings.
-;; WARNING: Must specify the EXACT upstream "build_flags" flag VALUES to unset;
-;; because if we don't specify any value then it unsets ALL instances of the
-;; flag, meaning that it would erase our new values too.
+;; WARNING: Must specify the EXACT upstream "build_flags" flag VALUES to unset.
+;; If no value is specified, then ALL values for that flag will be removed, which
+;; also deletes any new values you're trying to set. Also be aware that the
+;; compiler deletes ALL instances of the EXACT VALUES you specify below.
 ;; NOTE: If the upstream values are ever changed, the compiler will encounter
 ;; duplicate values and complain about "variable redefined" again, meaning that
 ;; these values will simply need to be revised. So maintenance is safe and easy.
@@ -567,5 +578,7 @@ build_unflags = ${env:esp32_eth.build_unflags}
 build_flags = ${env:esp32_eth.build_flags}
   ;; Set/add your new flag values:
   -D WLED_RELEASE_NAME=\"ESP32_Ethernet_Custom\"
-  -D RLYPIN=24
+  -D RLYPIN=15           ;; Relay pin.
+  -D WLED_ETH_DEFAULT=4  ;; "QuinLed-ESP32-Ethernet"
+  -D DATA_PINS=16,3,1,4  ;; LED output channels.
 

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -536,3 +536,36 @@ extends = env:esp32dev
 build_flags = ${env:esp32dev.build_flags} -D USERMOD_RF433
 lib_deps = ${env:esp32dev.lib_deps}
   sui77/rc-switch @ 2.6.4
+
+# ------------------------------------------------------------------------------
+# Advanced example: Inheriting all settings from an upstream "base" config, and
+# adding/overriding specific build flags, which is useful if you want to base
+# your environment on a stable core env but just override certain WLED defaults.
+# ------------------------------------------------------------------------------
+
+[env:esp32_eth_custom]
+;; Inherit all settings from upstream config. We can then override specific settings.
+;; WARNING: The upstream environment's name, such as "esp32_eth" in this example,
+;; must also be specified in the other inherited settings (see example below).
+extends = env:esp32_eth
+
+;; Remove conflicting upstream flags to fix compiler "variable redefined" warnings.
+;; WARNING: Must specify the EXACT upstream "build_flags" flag VALUES to unset;
+;; because if we don't specify any value then it unsets ALL instances of the
+;; flag, meaning that it would erase our new values too.
+;; NOTE: If the upstream values are ever changed, the compiler will encounter
+;; duplicate values and complain about "variable redefined" again, meaning that
+;; these values will simply need to be revised. So maintenance is safe and easy.
+build_unflags = ${env:esp32_eth.build_unflags}
+  ;; Unset the old, conflicting flag values:
+  -D WLED_RELEASE_NAME=\"ESP32_Ethernet\"
+  -D RLYPIN=-1
+
+;; Inherit all upstream flags and then overwrite/append with some custom values.
+;; NOTE: You can add/modify ANY of the WLED build-time variables here (it doesn't
+;; have to be values that were in the original upstream config).
+build_flags = ${env:esp32_eth.build_flags}
+  ;; Set/add your new flag values:
+  -D WLED_RELEASE_NAME=\"ESP32_Ethernet_Custom\"
+  -D RLYPIN=24
+


### PR DESCRIPTION
Adds a self-documented example demonstrating how a user can inherit from a core WLED configuration and add their own values without needing to copy all of the upstream values manually. This new method simplifies configuration maintenance for the users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configurable environment for ESP32 Ethernet devices that inherits settings from the default configuration.
  - Updated build settings now allow the customization of the release name and relay pin, ensuring optimal configuration without conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->