### PR TITLE
UM animated staircase: fix for AJ-SR04M sensor

### DIFF
--- a/usermods/Animated_Staircase/Animated_Staircase.cpp
+++ b/usermods/Animated_Staircase/Animated_Staircase.cpp
@@ -152,6 +152,7 @@ class Animated_Staircase : public Usermod {
       delayMicroseconds(2);
       digitalWrite(signalPin, HIGH);
       delayMicroseconds(10);
+      digitalWrite(signalPin, LOW);
       unsigned long duration = pulseIn(echoPin, HIGH, 30000);
       return (duration > 0 && duration < maxTimeUs);
     }

--- a/usermods/Animated_Staircase/Animated_Staircase.cpp
+++ b/usermods/Animated_Staircase/Animated_Staircase.cpp
@@ -152,8 +152,8 @@ class Animated_Staircase : public Usermod {
       delayMicroseconds(2);
       digitalWrite(signalPin, HIGH);
       delayMicroseconds(10);
-      digitalWrite(signalPin, LOW);
-      return pulseIn(echoPin, HIGH, maxTimeUs) > 0;
+      unsigned long duration = pulseIn(echoPin, HIGH, 30000);
+      return (duration > 0 && duration < maxTimeUs);
     }
 
     bool checkSensors() {


### PR DESCRIPTION
When using AJ-SR04M sensor, pulseIn function always returns 0 when timeout value is about 5-10 thousands. I don't know why.
With HC-SR04 behavior is different - it returns real value. So to support both sensors, I've added this additional logic:
      unsigned long duration = pulseIn(echoPin, HIGH, 30000);
      return (duration > 0 && duration < maxTimeUs);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved ultrasonic sensor detection for more accurate and reliable measurements.
  
- **Style**
  - Applied minor formatting enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->