### PR TITLE
Add SK9822 to the supported LED list

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -399,7 +399,7 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
     //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
     {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored
     {TYPE_WS2801,        "2P", PSTR("WS2801")},
-    {TYPE_APA102,        "2P", PSTR("APA102")},
+    {TYPE_APA102,        "2P", PSTR("APA102/SK9822")},
     {TYPE_LPD8806,       "2P", PSTR("LPD8806")},
     {TYPE_LPD6803,       "2P", PSTR("LPD6803")},
     {TYPE_P9813,         "2P", PSTR("PP9813")},


### PR DESCRIPTION
As a first time user of SK9822 LEDs, I was confused when I couldn't find the option in the drop-down list of supported LEDs. After a bit of googling I found that people advised to use the APA102 preset because they work in the same way. This pull request simply appends "/SK9822" to the APA102 string to prevent further confusion among new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the LED type description to display "APA102/SK9822" instead of "APA102" for improved clarity in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->