### PR TITLE
Update crude parallel I2S detection

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -353,7 +353,7 @@
 			});
 			const S2 = (oMaxB == 14) && (maxV == 4);
 			const S3 = (oMaxB == 14) && (maxV == 6);
-			if (oMaxB == 19 || S2 || S3) { // TODO: crude ESP32 & S2/S3 detection
+			if (oMaxB == 32 || S2 || S3) { // TODO: crude ESP32 & S2/S3 detection
 				if (maxLC > 300 || dC <= 2) {
 					d.Sf["PR"].checked = false;
 					gId("prl").classList.add("hide");


### PR DESCRIPTION
My ESP32s are reporting a maximum of 32 buses, so the parallel I2s tickbox was missing from the LED settings UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware detection logic for ESP32 boards in the LED settings interface, ensuring more accurate display and configuration options for supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->