### PR TITLE
fixed ADA light Serial conditions for USB CDC (some ESP32 C3 / S2 / S3 )

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -454,7 +454,7 @@ void WLED::setup()
 
   // all GPIOs are allocated at this point
 #ifdef ARDUINO_USB_CDC_ON_BOOT
-  // USB CDC means USB D+ D- are used .. pin allocator will always return. force it as enabled instead
+  // USB CDC means USB D+ D- are used .. pin allocator will always return false in this case. force it as enabled instead
   serialCanRX = true;
   serialCanTX = true;
 #else 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -453,8 +453,15 @@ void WLED::setup()
   findWiFi(true);      // start scanning for available WiFi-s
 
   // all GPIOs are allocated at this point
+#ifdef ARDUINO_USB_CDC_ON_BOOT
+  // USB CDC means USB D+ D- are used .. pin allocator will always return. force it as enabled instead
+  serialCanRX = true;
+  serialCanTX = true;
+#else 
+ // use RX/TX as set by the framework - these boards do _not_ have RX=3 and TX=1
   serialCanRX = !PinManager::isPinAllocated(hardwareRX); // Serial RX pin (GPIO 3 on ESP32 and ESP8266)
   serialCanTX = !PinManager::isPinAllocated(hardwareTX) || PinManager::getPinOwner(hardwareTX) == PinOwner::DebugOut; // Serial TX pin (GPIO 1 on ESP32 and ESP8266)
+#endif  // ARDUINO_USB_CDC_ON_BOOT
 
   #ifdef WLED_ENABLE_ADALIGHT
   //Serial RX (Adalight, Improv, Serial JSON) only possible if GPIO3 unused

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -69,11 +69,7 @@ void sendBytes(){
 
 void handleSerial()
 {
-  #if ARDUINO_USB_CDC_ON_BOOT
-    if (!Serial) return;// arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
-  #else
-    if (!(serialCanRX)) return; // check via pin manager if UART pin is NOT allocated by other function.
-  #endif 
+  if (!(serialCanRX && Serial)) return; // arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
 
   static auto state = AdaState::Header_A;
   static uint16_t count = 0;

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -69,9 +69,11 @@ void sendBytes(){
 
 void handleSerial()
 {
-  if (serialCanRX == false && Serial) {
-    return;
-  }; // arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
+  #if ARDUINO_USB_CDC_ON_BOOT
+    if (!Serial) return;// arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
+  #else
+    if (!(serialCanRX)) return; // check via pin manager if UART pin is NOT allocated by other function.
+  #endif 
 
   static auto state = AdaState::Header_A;
   static uint16_t count = 0;

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -69,7 +69,9 @@ void sendBytes(){
 
 void handleSerial()
 {
-  if (!(serialCanRX && Serial)) return; // arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
+  if (serialCanRX == false) {
+    return;
+  }; // arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
 
   static auto state = AdaState::Header_A;
   static uint16_t count = 0;

--- a/wled00/wled_serial.cpp
+++ b/wled00/wled_serial.cpp
@@ -69,7 +69,7 @@ void sendBytes(){
 
 void handleSerial()
 {
-  if (serialCanRX == false) {
+  if (serialCanRX == false && Serial) {
     return;
   }; // arduino docs: `if (Serial)` indicates whether or not the USB CDC serial connection is open. For all non-USB CDC ports, this will always return true
 


### PR DESCRIPTION
after a while searching, i found out that USB Serial CDC is not working for ADA light. 
it seems there are incompatibility in isPinOK when checking for pins are used in case of pins of native USB. 
this fixes the issue and now the ada light is working fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced USB CDC serial communication handling to properly detect and enable serial capabilities when using USB CDC boot mode, improving serial communication reliability across different hardware configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->