### PR TITLE
POC implementation for deferred settings

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -508,7 +508,7 @@ size_t printSetFormIndex(Print& settingsScript, const char* key, int index);
 size_t printSetClassElementHTML(Print& settingsScript, const char* key, const int index, const char* val);
 void prepareHostname(char* hostname);
 [[gnu::pure]] bool isAsterisksOnly(const char* str, byte maxLen);
-bool requestJSONBufferLock(uint8_t moduleID=255);
+bool requestJSONBufferLock(uint8_t moduleID=255, bool wait = true);
 void releaseJSONBufferLock();
 uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLen);
 uint8_t extractModeSlider(uint8_t mode, uint8_t slider, char *dest, uint8_t maxLen, uint8_t *var = nullptr);

--- a/wled00/handler_queue.cpp
+++ b/wled00/handler_queue.cpp
@@ -1,0 +1,49 @@
+#include "handler_queue.h"
+#include <deque>
+#include <Arduino.h>
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+static StaticSemaphore_t handlerQueueMutexBuffer;
+static SemaphoreHandle_t handlerQueueMutex = xSemaphoreCreateMutexStatic(&handlerQueueMutexBuffer);
+struct guard_type {
+  SemaphoreHandle_t _mtx;
+  guard_type(SemaphoreHandle_t m) : _mtx(m) {
+    xSemaphoreTake(_mtx, portMAX_DELAY);  // todo: error check
+  }
+  ~guard_type() {    
+    xSemaphoreGive(_mtx);
+  }
+};
+#define guard() const guard_type guard(handlerQueueMutex)
+#else
+#define guard()
+#endif
+
+static std::deque<std::function<void()>> handler_queue;
+
+// Enqueue a function on the main task
+bool HandlerQueue::callOnMainTask(std::function<void()> func) {
+  guard();
+  handler_queue.push_back(std::move(func));
+  return true;  // TODO: queue limit
+}
+
+// Run the next task in the queue, if any
+void HandlerQueue::runNext() {
+  std::function<void()> f;
+  {
+    guard();
+    if (handler_queue.size()) {
+      f = std::move(handler_queue.front());
+      handler_queue.pop_front();
+    }
+  }
+  if (f) {
+    auto t1 = millis();    
+    f();
+    auto t2 = millis();
+    Serial.printf("Handler took: %d\n", t2-t1);
+  } 
+}
+

--- a/wled00/handler_queue.h
+++ b/wled00/handler_queue.h
@@ -1,0 +1,13 @@
+// handler_queue.h
+// deferred execution handler queue.  Used for making access to WLED globals safe.
+
+#include <functional>
+
+namespace HandlerQueue {
+  
+  // Enqueue a function on the main task
+  bool callOnMainTask(std::function<void()> func);
+
+  // Run the next task in the queue, if any
+  void runNext();
+}

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -1123,7 +1123,7 @@ void serveJson(AsyncWebServerRequest* request)
     return;
   }
 
-  if (!requestJSONBufferLock(17)) {
+  if (!requestJSONBufferLock(17, false)) {
     request->deferResponse();    
     return;
   }

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -652,7 +652,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
   //USERMODS
   if (subPage == SUBPAGE_UM)
   {
-    if (!requestJSONBufferLock(5)) {
+    if (!requestJSONBufferLock(5, false)) {
       request->deferResponse();
       return;
     }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -151,7 +151,7 @@ bool isAsterisksOnly(const char* str, byte maxLen)
 
 
 //threading/network callback details: https://github.com/wled-dev/WLED/pull/2336#discussion_r762276994
-bool requestJSONBufferLock(uint8_t moduleID)
+bool requestJSONBufferLock(uint8_t moduleID, bool wait)
 {
   if (pDoc == nullptr) {
     DEBUG_PRINTLN(F("ERROR: JSON buffer not allocated!"));
@@ -159,10 +159,11 @@ bool requestJSONBufferLock(uint8_t moduleID)
   }
 
 #if defined(ARDUINO_ARCH_ESP32)
-  // Use a recursive mutex type in case our task is the one holding the JSON buffer.
-  // This can happen during large JSON web transactions.  In this case, we continue immediately
-  // and then will return out below if the lock is still held.
-  if (xSemaphoreTakeRecursive(jsonBufferLockMutex, 250) == pdFALSE) return false;  // timed out waiting
+  if (xSemaphoreTake(jsonBufferLockMutex, wait ? 250 : 0) == pdFALSE) {
+    // TODO, coaelesce with below
+    DEBUG_PRINTF_P(PSTR("ERROR: Locking JSON buffer mutex (%d) failed! (locked by %d??)\n"), moduleID, jsonBufferLock);
+    return false;  // timed out waiting
+  }
 #elif defined(ARDUINO_ARCH_ESP8266)
   // If we're in system context, delay() won't return control to the user context, so there's
   // no point in waiting.
@@ -176,9 +177,6 @@ bool requestJSONBufferLock(uint8_t moduleID)
   // If the lock is still held - by us, or by another task
   if (jsonBufferLock) {
     DEBUG_PRINTF_P(PSTR("ERROR: Locking JSON buffer (%d) failed! (still locked by %d)\n"), moduleID, jsonBufferLock);
-#ifdef ARDUINO_ARCH_ESP32
-    xSemaphoreGiveRecursive(jsonBufferLockMutex);
-#endif
     return false;
   }
 
@@ -194,7 +192,7 @@ void releaseJSONBufferLock()
   DEBUG_PRINTF_P(PSTR("JSON buffer released. (%d)\n"), jsonBufferLock);
   jsonBufferLock = 0;
 #ifdef ARDUINO_ARCH_ESP32
-  xSemaphoreGiveRecursive(jsonBufferLockMutex);
+  xSemaphoreGive(jsonBufferLockMutex);
 #endif  
 }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -1,6 +1,7 @@
 #define WLED_DEFINE_GLOBAL_VARS //only in one source file, wled.cpp!
 #include "wled.h"
 #include "wled_ethernet.h"
+#include "handler_queue.h"
 #ifdef WLED_ENABLE_AOTA
   #define NO_OTA_PORT
   #include <ArduinoOTA.h>
@@ -184,6 +185,9 @@ void WLED::loop()
     heapTime = millis();
   }
 
+  // Run next deferred request
+  HandlerQueue::runNext();
+
   //LED settings have been saved, re-init busses
   //This code block causes severe FPS drop on ESP32 with the original "if (busConfigs[0] != nullptr)" conditional. Investigate!
   if (doInitBusses) {
@@ -320,6 +324,7 @@ void WLED::setup()
 
   #ifdef ARDUINO_ARCH_ESP32
   pinMode(hardwareRX, INPUT_PULLDOWN); delay(1);        // suppress noise in case RX pin is floating (at low noise energy) - see issue #3128
+  xSemaphoreGive(jsonBufferLockMutex);                  // Init JSON buffer lock
   #endif
   #ifdef WLED_BOOTUPDELAY
   delay(WLED_BOOTUPDELAY); // delay to let voltage stabilize, helps with boot issues on some setups

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -970,7 +970,7 @@ WLED_GLOBAL int8_t spi_sclk  _INIT(SPISCLKPIN);
 // global ArduinoJson buffer
 #if defined(ARDUINO_ARCH_ESP32)
 WLED_GLOBAL JsonDocument *pDoc _INIT(nullptr);
-WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(xSemaphoreCreateRecursiveMutex());
+WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(xSemaphoreCreateBinary());
 #else
 WLED_GLOBAL StaticJsonDocument<JSON_BUFFER_SIZE> gDoc;
 WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);


### PR DESCRIPTION
When a state changing request is received, defer handling that request until a known point on the main loop task.   This mitigates any possible cases of editing memory out from underneath the render task (or, for that matter, any other integration or usermod that's serviced on the main task).

To implement this, the JSON buffer lock is reimplemented as a binary semaphrore, as it needs to pass ownership from one task to another.  This required contexts which can back off and retry to indicate such to the kernel.  There might be better solutions, but this sufficies for demonstrating the overall approach.

This is IMO the quickest path to safety re #4779, though not the most performant.  It soft-guarantees that we don't alter the FX state while rendering, since all those operations are now handled on the one task.  I'd talked about setting up a mutex around WS2812FX in #4779; this approach is simpler to implement now and buys us time to arrange a more granular locking approach in the future.

The biggest drawback is that high FPS systems might observe lag during setting-set operations.  Still that's better than risking crashes, I think!