### PR TITLE
Add new effects: music strobe and flame jet

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = d1_mini, nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
 
 src_dir  = ./wled00
 data_dir = ./wled00/data

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 # ------------------------------------------------------------------------------
 
 # CI/release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
+default_envs = d1_mini, nodemcuv2, esp8266_2m, esp01_1m_full, nodemcuv2_160, esp8266_2m_160, esp01_1m_full_160, nodemcuv2_compat, esp8266_2m_compat, esp01_1m_full_compat, esp32dev, esp32dev_V4, esp32_eth, lolin_s2_mini, esp32c3dev, esp32s3dev_16MB_opi, esp32s3dev_8MB_opi, esp32s3_4M_qspi, esp32_wrover, usermods
 
 src_dir  = ./wled00
 data_dir = ./wled00/data

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -10644,6 +10644,100 @@ uint8_t WS2812FX::addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name)
   }
 }
 
+/*
+  Simple bit strob
+*/
+uint16_t mode_music_strob(void) {
+  um_data_t *um_data = getAudioData();
+  if (!um_data) return FRAMETIME; 
+
+  bool samplePeak = *(bool*)um_data->u_data[3]; 
+  int volumeRaw   = *(int16_t*)um_data->u_data[1]; 
+
+  long mappedSpeed = map(SEGMENT.speed, 0, 255, 0, 20);
+  uint8_t fadeBy = 255 - mappedSpeed;
+  SEGMENT.fade_out(fadeBy);
+
+  uint8_t threshold = SEGMENT.intensity;
+
+  if (samplePeak && volumeRaw > threshold) {
+    SEGMENT.fill(SEGCOLOR(0));
+  }
+  
+  return FRAMETIME;
+}
+
+static const char _data_FX_MODE_MUSIC_STROB[] PROGMEM = "Music Strob@Fade speed,Threshold;!,!;!;1v;ix=128,sx=224,si=1";
+
+/*--------------------------*/
+
+/*
+  Flame jet
+*/
+uint16_t mode_flame_jet(void) {
+  if (!SEGMENT.is2D()) return mode_static();
+
+  um_data_t *um_data = getAudioData();
+  if (!um_data) return FRAMETIME;
+
+  bool samplePeak = *(bool*)um_data->u_data[3];
+  int volumeRaw   = *(int16_t*)um_data->u_data[1];
+
+  long mappedFade = map(SEGMENT.intensity, 0, 255, 0, 64);
+  uint8_t fade_by = 255 - mappedFade;
+
+  uint8_t threshold = SEGMENT.custom1;
+
+  const uint16_t max_height = SEG_H;
+
+  SEGMENT.fade_out(fade_by);
+
+  if (samplePeak && volumeRaw > threshold && SEGENV.aux0 == 0) {
+    SEGENV.aux0 = 1; // start animation
+  }
+
+  // --- Animation ---
+  if (SEGENV.aux0 > 0) {
+    long mappedSpeed = map(SEGMENT.speed, 0, 255, 0, 32);
+    uint16_t rise_amount = 1 + (uint16_t)(volumeRaw * (1 + (uint16_t)mappedSpeed)) / 2000;
+
+    uint16_t start_y = SEG_H - 1;
+    
+    for (uint16_t y_offset = 0; y_offset < SEGENV.aux0; y_offset++) {
+      uint16_t current_y = start_y - y_offset;
+
+      if (current_y >= SEG_H) continue;
+
+      uint32_t base_color = SEGCOLOR(0);
+      CRGB fastled_color = CRGB(base_color);
+
+      uint8_t heat_reduction = map(y_offset, 0, SEG_H, 0, 180);
+      fastled_color.g = qsub8(fastled_color.g, heat_reduction);      
+      fastled_color.b = qsub8(fastled_color.b, heat_reduction * 2);  
+
+      for (uint16_t x = 0; x < SEG_W; x++) {
+        CRGB final_color = fastled_color;
+
+        if (hw_random8() < 50) {
+          final_color.nscale8(220); 
+        }
+        SEGMENT.setPixelColorXY(x, current_y, final_color);
+      }
+    }
+
+    SEGENV.aux0 += rise_amount;
+
+    if (SEGENV.aux0 >= max_height) {
+      SEGENV.aux0 = 0;
+    }
+  }
+  
+  return FRAMETIME;
+}
+
+static const char _data_FX_MODE_FLAME_JET[] PROGMEM = "Flame Jet@Base Speed,Trail Length,Threshold;!;!;!;2v;ix=192,sx=128,c1=128,pal=35";
+
+
 void WS2812FX::setupEffectData() {
   // Solid must be first! (assuming vector is empty upon call to setup)
   _mode.push_back(&mode_static);
@@ -10778,6 +10872,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_DYNAMIC_SMOOTH, &mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
 
   // --- 1D audio effects ---
+  addEffect(FX_MODE_MUSIC_STROB, &mode_music_strob, _data_FX_MODE_MUSIC_STROB); 
   addEffect(FX_MODE_PIXELS, &mode_pixels, _data_FX_MODE_PIXELS);
   addEffect(FX_MODE_PIXELWAVE, &mode_pixelwave, _data_FX_MODE_PIXELWAVE);
   addEffect(FX_MODE_JUGGLES, &mode_juggles, _data_FX_MODE_JUGGLES);
@@ -10851,6 +10946,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_2DOCTOPUS, &mode_2Doctopus, _data_FX_MODE_2DOCTOPUS);
   addEffect(FX_MODE_2DWAVINGCELL, &mode_2Dwavingcell, _data_FX_MODE_2DWAVINGCELL);
   addEffect(FX_MODE_2DAKEMI, &mode_2DAkemi, _data_FX_MODE_2DAKEMI); // audio
+  addEffect(FX_MODE_FLAME_JET, &mode_flame_jet, _data_FX_MODE_FLAME_JET);
 
 #ifndef WLED_DISABLE_PARTICLESYSTEM2D
   addEffect(FX_MODE_PARTICLEVOLCANO, &mode_particlevolcano, _data_FX_MODE_PARTICLEVOLCANO);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -10645,9 +10645,9 @@ uint8_t WS2812FX::addEffect(uint8_t id, mode_ptr mode_fn, const char *mode_name)
 }
 
 /*
-  Simple bit strob
+  Simple bit strobe
 */
-uint16_t mode_music_strob(void) {
+uint16_t mode_music_strobe(void) {
   um_data_t *um_data = getAudioData();
   if (!um_data) return FRAMETIME; 
 
@@ -10667,7 +10667,7 @@ uint16_t mode_music_strob(void) {
   return FRAMETIME;
 }
 
-static const char _data_FX_MODE_MUSIC_STROB[] PROGMEM = "Music Strob@Fade speed,Threshold;!,!;!;1v;ix=128,sx=224,si=1";
+static const char _data_FX_MODE_MUSIC_STROBE[] PROGMEM = "Music Strobe@Fade speed,Threshold;!,!;!;1v;ix=128,sx=224,si=1";
 
 /*
   Flame jet
@@ -10890,7 +10890,7 @@ void WS2812FX::setupEffectData() {
   addEffect(FX_MODE_DYNAMIC_SMOOTH, &mode_dynamic_smooth, _data_FX_MODE_DYNAMIC_SMOOTH);
 
   // --- 1D audio effects ---
-  addEffect(FX_MODE_MUSIC_STROB, &mode_music_strob, _data_FX_MODE_MUSIC_STROB); 
+  addEffect(FX_MODE_MUSIC_STROBE, &mode_music_strobe, _data_FX_MODE_MUSIC_STROBE); 
   addEffect(FX_MODE_PIXELS, &mode_pixels, _data_FX_MODE_PIXELS);
   addEffect(FX_MODE_PIXELWAVE, &mode_pixelwave, _data_FX_MODE_PIXELWAVE);
   addEffect(FX_MODE_JUGGLES, &mode_juggles, _data_FX_MODE_JUGGLES);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -10669,8 +10669,6 @@ uint16_t mode_music_strob(void) {
 
 static const char _data_FX_MODE_MUSIC_STROB[] PROGMEM = "Music Strob@Fade speed,Threshold;!,!;!;1v;ix=128,sx=224,si=1";
 
-/*--------------------------*/
-
 /*
   Flame jet
 */
@@ -10756,7 +10754,6 @@ uint16_t mode_flame_jet(void) {
   return FRAMETIME;
 }
 
-// Также обновите строку метаданных, убрав из нее "2", чтобы показать, что эффект работает и в 1D
 static const char _data_FX_MODE_FLAME_JET[] PROGMEM = "Flame Jet@Base Speed,Trail Length,Threshold;!;!;1v;ix=192,sx=128,c1=128,pal=35,si=1";
 
 void WS2812FX::setupEffectData() {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -374,7 +374,7 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_PS1DSONICBOOM          215
 #define FX_MODE_PS1DSPRINGY            216
 #define FX_MODE_PARTICLEGALAXY         217
-#define FX_MODE_MUSIC_STROB            218
+#define FX_MODE_MUSIC_STROBE            218
 #define FX_MODE_FLAME_JET              219
 #define MODE_COUNT                     220
 

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -374,7 +374,9 @@ extern byte realtimeMode;           // used in getMappedPixelIndex()
 #define FX_MODE_PS1DSONICBOOM          215
 #define FX_MODE_PS1DSPRINGY            216
 #define FX_MODE_PARTICLEGALAXY         217
-#define MODE_COUNT                     218
+#define FX_MODE_MUSIC_STROB            218
+#define FX_MODE_FLAME_JET              219
+#define MODE_COUNT                     220
 
 
 #define BLEND_STYLE_FADE            0x00  // universal

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -282,7 +282,7 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
 // Global Variable definitions
 WLED_GLOBAL char versionString[] _INIT(TOSTRING(WLED_VERSION));
 WLED_GLOBAL char releaseString[] _INIT(WLED_RELEASE_NAME); // must include the quotes when defining, e.g -D WLED_RELEASE_NAME=\"ESP32_MULTI_USREMODS\"
-#define WLED_CODENAME "Niji"
+#define WLED_CODENAME "by Alexander Eroshin"
 
 // AP and OTA default passwords (for maximum security change them!)
 WLED_GLOBAL char apPass[65]  _INIT(WLED_AP_PASS);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -282,7 +282,7 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
 // Global Variable definitions
 WLED_GLOBAL char versionString[] _INIT(TOSTRING(WLED_VERSION));
 WLED_GLOBAL char releaseString[] _INIT(WLED_RELEASE_NAME); // must include the quotes when defining, e.g -D WLED_RELEASE_NAME=\"ESP32_MULTI_USREMODS\"
-#define WLED_CODENAME "by Alexander Eroshin"
+#define WLED_CODENAME "Niji"
 
 // AP and OTA default passwords (for maximum security change them!)
 WLED_GLOBAL char apPass[65]  _INIT(WLED_AP_PASS);


### PR DESCRIPTION
Added audio-reactive strobe and flame jet effects.
The strobe effect adjusts the trigger threshold, the fade time, and the palette.
The flame jet effect adjusts the palette, trigger threshold, fade time, and flame height. The effect looks good on cylindrical matrices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two audio-reactive LED effects: Music Strobe and Flame Jet. Both respond dynamically to audio input and are selectable from the effects list.

* **Improvements**
  * Increased the total number of available effects to include these additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->