### PR TITLE
Add new multiple DRGBW realtime DMX mode

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -263,6 +263,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define DMX_MODE_EFFECT_SEGMENT   8            //trigger standalone effects of WLED (15 channels per segment)
 #define DMX_MODE_EFFECT_SEGMENT_W 9            //trigger standalone effects of WLED (18 channels per segment)
 #define DMX_MODE_PRESET           10           //apply presets (1 channel)
+#define DMX_MODE_MULTIPLE_DRGBW   11           //every LED is addressed with its own RGBW and share a master dimmer (ledCount * 4 + 1 channels)
 
 //Light capability byte (unused) 0bRCCCTTTT
 //bits 0/1/2/3: specifies a type of LED driver. A single "driver" may have different chip models but must have the same protocol/behavior

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -144,8 +144,9 @@ DMX mode:
 <option value=8>Effect Segment</option>
 <option value=9>Effect Segment + White</option>
 <option value=4>Multi RGB</option>
-<option value=5>Dimmer + Multi RGB</option>
 <option value=6>Multi RGBW</option>
+<option value=5>Dimmer + Multi RGB</option>
+<option value=11>Dimmer + Multi RGBW</option>
 <option value=10>Preset</option>
 </select><br>
 <a href="https://kno.wled.ge/interfaces/e1.31-dmx/" target="_blank">E1.31 info</a><br>

--- a/wled00/dmx_input.cpp
+++ b/wled00/dmx_input.cpp
@@ -21,7 +21,7 @@ void rdmPersonalityChangedCb(dmx_port_t dmxPort, const rdm_header_t *header,
 
   if (header->cc == RDM_CC_SET_COMMAND_RESPONSE) {
     const uint8_t personality = dmx_get_current_personality(dmx->inputPortNum);
-    DMXMode = std::min(DMX_MODE_PRESET, std::max(DMX_MODE_SINGLE_RGB, int(personality)));
+    DMXMode = std::min(DMX_MODE_MULTIPLE_DRGBW, std::max(DMX_MODE_SINGLE_RGB, int(personality)));
     configNeedsWrite = true;
     DEBUG_PRINTF("DMX personality changed to to: %d\n", DMXMode);
   }
@@ -79,8 +79,10 @@ static dmx_config_t createConfig()
   config.personalities[8].footprint = std::min(512, strip.getSegmentsNum() * 18);
   config.personalities[9].description = "PRESET";
   config.personalities[9].footprint = 1;
+  config.personalities[10].description = "MULTIPLE_DRGBW";
+  config.personalities[10].footprint = std::min(512, int(strip.getLengthTotal()) * 4 + 1);
 
-  config.personality_count = 10;
+  config.personality_count = 11;
   // rdm personalities are numbered from 1, thus we can just set the DMXMode directly.
   config.current_personality = DMXMode;
 

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -353,10 +353,11 @@ void handleArtnetPollReply(IPAddress ipAddress) {
     case DMX_MODE_MULTIPLE_DRGB:
     case DMX_MODE_MULTIPLE_RGB:
     case DMX_MODE_MULTIPLE_RGBW:
+    case DMX_MODE_MULTIPLE_DRGBW:
       {
-        bool is4Chan = (DMXMode == DMX_MODE_MULTIPLE_RGBW);
+        bool is4Chan = (DMXMode == DMX_MODE_MULTIPLE_RGBW || DMXMode == DMX_MODE_MULTIPLE_DRGBW);
         const unsigned dmxChannelsPerLed = is4Chan ? 4 : 3;
-        const unsigned dimmerOffset = (DMXMode == DMX_MODE_MULTIPLE_DRGB) ? 1 : 0;
+        const unsigned dimmerOffset = (DMXMode == DMX_MODE_MULTIPLE_DRGB || DMXMode == DMX_MODE_MULTIPLE_DRGBW) ? 1 : 0;
         const unsigned dmxLenOffset = (DMXAddress == 0) ? 0 : 1; // For legacy DMX start address 0
         const unsigned ledsInFirstUniverse = (((MAX_CHANNELS_PER_UNIVERSE - DMXAddress) + dmxLenOffset) - dimmerOffset) / dmxChannelsPerLed;
         const unsigned totalLen = strip.getLengthTotal();

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -430,7 +430,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     t = request->arg(F("PY")).toInt();
     if (t >= 0  && t <= 200) e131Priority = t;
     t = request->arg(F("DM")).toInt();
-    if (t >= DMX_MODE_DISABLED && t <= DMX_MODE_PRESET) DMXMode = t;
+    if (t >= DMX_MODE_DISABLED && t <= DMX_MODE_MULTIPLE_DRGBW) DMXMode = t;
     t = request->arg(F("ET")).toInt();
     if (t > 99  && t <= 65000) realtimeTimeoutMs = t;
     arlsForceMaxBri = request->hasArg(F("FB"));


### PR DESCRIPTION
Currently missing realtime DMX Mode: Dimmer + RGBW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new DMX mode: "Dimmer + Multi RGBW" — per-LED RGBW with a master dimmer.
  * Settings UI updated to include and reorder DMX mode options for easier selection.
  * Improved DMX/E1.31 handling so the master dimmer and LED indexing work correctly for multi-LED RGBW setups.
  * RDM/personality support expanded so controllers can detect and use the new mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->