### PR TITLE
0.15 - updated AsyncWebServer and AsyncTCP

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -248,6 +248,7 @@ build_flags = -g
   -DARDUINO_ARCH_ESP32
   #-DCONFIG_LITTLEFS_FOR_IDF_3_2
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   #use LITTLEFS library by lorol in ESP32 core 1.x.x instead of built-in in 2.x.x
   -D LOROL_LITTLEFS
   ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
@@ -280,6 +281,7 @@ build_flags = -g
   -Wshadow=compatible-local ;; emit warning in case a local variable "shadows" another local one
   -DARDUINO_ARCH_ESP32 -DESP32
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
   -D WLED_ENABLE_DMX_INPUT
 lib_deps =
@@ -298,6 +300,7 @@ build_flags = -g
   -DARDUINO_ARCH_ESP32S2
   -DCONFIG_IDF_TARGET_ESP32S2=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=0
   -DCO
   -DARDUINO_USB_MODE=0 ;; this flag is mandatory for ESP32-S2 !
@@ -318,6 +321,7 @@ build_flags = -g
   -DARDUINO_ARCH_ESP32C3
   -DCONFIG_IDF_TARGET_ESP32C3=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -DCO
   -DARDUINO_USB_MODE=1 ;; this flag is mandatory for ESP32-C3
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
@@ -338,6 +342,7 @@ build_flags = -g
   -DARDUINO_ARCH_ESP32S3
   -DCONFIG_IDF_TARGET_ESP32S3=1
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -DARDUINO_USB_MSC_ON_BOOT=0 -DARDUINO_DFU_ON_BOOT=0
   -DCO
   ;; please make sure that the following flags are properly set (to 0 or 1) by your board.json, or included in your custom platformio_override.ini entry:
@@ -644,6 +649,7 @@ build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -D WLED_WATCHDOG_TIMEOUT=0
   -D CONFIG_ASYNC_TCP_USE_WDT=0
+  -D CONFIG_ASYNC_TCP_STACK_SIZE=8192
   -D DATA_PINS=16
   -D HW_PIN_SCL=35
   -D HW_PIN_SDA=33


### PR DESCRIPTION
Backport #4796.  The major improvement here is that the updated AsyncTCP fixes some errors in the handling of unexpectedly closed connections that could cause double frees or use-after-free that result in memory corruption, particularly under sustained load.  The newer AsyncWebServer is backwards compatible and will not activate the queuing feature, though it does add the "emergency 503 on low heap" logic.