### PR TITLE
remove early return from initconnection()

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -649,7 +649,6 @@ void WLED::initConnection()
   if (!WLED_WIFI_CONFIGURED) {
     DEBUG_PRINTLN(F("No connection configured."));
     if (!apActive) initAP();        // instantly go to ap mode
-    return;
   } else if (!apActive) {
     if (apBehavior == AP_BEHAVIOR_ALWAYS) {
       DEBUG_PRINTLN(F("Access point ALWAYS enabled."));


### PR DESCRIPTION
this line was added in https://github.com/wled/WLED/commit/aed03cd03baca7100f7eef713905bc3bae6b55ce as a part of https://github.com/wled/WLED/pull/4495 to fix a bug which no longer seems relevant. 

@arneboe and @netmindz  please test and make sure it does not bring back that bug.

fixes https://github.com/wled/WLED/issues/4655 (tested and confirmed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Additional services now initialize when the device runs in Access Point mode without prior Wi‑Fi setup, enabling broader functionality out of the box.
- Bug Fixes
  - Resolved an issue where certain features did not start in AP mode when no Wi‑Fi was configured, improving reliability during first-time setup and standalone use.
- Chores
  - Internal initialization flow streamlined to ensure consistent startup behavior across connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->