### PR TITLE
Update Percent effect to add optional % of time modes

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -3926,11 +3926,11 @@ uint16_t mode_percent(void) {
     }
 
     // lit portion
-    for (uint32_t i = 0; i < lit; i++) {
+    for (unsigned i = 0; i < lit; i++) {
       SEGMENT.setPixelColor(i, SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0));
     }
     // unlit portion
-    for (uint32_t i = lit; i < SEGLEN; i++) {
+    for (unsigned i = lit; i < SEGLEN; i++) {
       SEGMENT.setPixelColor(i, SEGCOLOR(1));
     }
     return FRAMETIME;


### PR DESCRIPTION
I updated the checkboxes on Percent effect to support three new modes to automatically illuminate a % of the LEDs in a segment:
- % of minute
- % of hour
- % of day 
 
This allows you to create dynamic effects based on these timescales. e.g. custom abstract clock displays.  Personally I did this because I am creating a visual daily 'clock' for my kids with physical markers on it for "dad is done with work" and "Bed time" etc. I added minute/hour at the suggestion of others, but now this makes it suitable for true clock functionality which is nice -- and with much more flexibility than the other 'clock' mode option. 

The effect is designed to fill the segment during the last 'tick' of the time period.  At rollover (e.g. second 60/0) it intentionally shows SEGLEN lit for one tick to represent the completed period, then move to 1 LED at second 1. This avoids a visually empty segment at rollover and matches the cadence of a ticking hand (…58, 59, 60/0 full, 1, 2…). 

This also deprecates/repurposes the previous 'use single color' checkbox. This appeared to be completely redundant and unnecessary since it is easy to just set the palette to 'color 1' which achieves the exact same effect. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Percent effect now offers time-based progress options: % of Minute, % of Hour, and % of Day.
  * When a time option is selected, LEDs display elapsed-period progress with automatic period handling and smooth transitions.
  * When time options are off, percent rendering uses a refined gradient and smoother per-LED transitions.

* **Documentation**
  * Mode label updated to include the new time-based Percent options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->