### PR TITLE
Usermod Temperature: use full 12-bit precision

### DIFF
--- a/usermods/Temperature/UsermodTemperature.h
+++ b/usermods/Temperature/UsermodTemperature.h
@@ -48,7 +48,7 @@ class UsermodTemperature : public Usermod {
 
     bool HApublished = false;
     int16_t idx = -1;   // Domoticz virtual sensor idx
-    int8_t highResolution = 0; // 0: 9-bit - 1: 12-bit
+    uint8_t resolution = 0; // 9bits=0, 10bits=1, 11bits=2, 12bits=3
 
     // strings to reduce flash memory usage (used more than twice)
     static const char _name[];
@@ -57,7 +57,7 @@ class UsermodTemperature : public Usermod {
     static const char _parasite[];
     static const char _parasitePin[];
     static const char _domoticzIDX[];
-    static const char _highResolution[];
+    static const char _resolution[];
     static const char _sensor[];
     static const char _temperature[];
     static const char _Temperature[];


### PR DESCRIPTION
The popular DS18B20 temperature sensor offers 12-bit precision, but currently the Temperature Usermod only uses 9-bits of precision and does not use the 3 least significant bits.

This PR changes implementation so the full 12-bit precision when calculating the floating point Celsius value. Also I was able to remove all if statements similar to how the DS18**S**20 is already implemented.

I also checked the datasheets of the DS18B20, DS1822, DS1825 and DS28EA00. They all use the same format and all have the factory default of 12-bit resolution. So this should not break anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temperature usermod now offers a persistent resolution setting (9/10/11/12-bit) via the UI.

* **Bug Fixes**
  * Clarified sensor labeling and DS18S20 handling; no change to runtime behavior for those cases.
  * Temperature reads updated to respect selected resolution, improving reported precision.

* **Notes**
  * Resolution selection changes reported temperature granularity (ignored for DS18S20).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->