### PR TITLE
Usermod: Add DepartStrip transit departure usermod

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -149,6 +149,7 @@ lib_deps =
   # ESP-NOW library
     ;gmag11/QuickESPNow @ ~0.7.0
     https://github.com/blazoncek/QuickESPNow.git#optional-debug
+    nanopb/Nanopb @ 0.4.7
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For compatible OLED display uncomment following
@@ -232,6 +233,7 @@ lib_deps_compat =
   makuna/NeoPixelBus @ 2.7.9
   https://github.com/blazoncek/QuickESPNow.git#optional-debug
   https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.0
+  nanopb/Nanopb @ 0.4.7
 
 [esp32_all_variants]
 lib_deps =

--- a/usermods/usermod_v2_departstrip/cta_source.cpp
+++ b/usermods/usermod_v2_departstrip/cta_source.cpp
@@ -1,0 +1,614 @@
+#include "cta_source.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <utility>
+
+namespace {
+// Days from civil algorithm copied from SiriSource; converts Y/M/D to days since 1970-01-01.
+static int days_from_civil(int y, unsigned m, unsigned d) {
+  y -= m <= 2;
+  const int era = (y >= 0 ? y : y - 399) / 400;
+  const unsigned yoe = (unsigned)(y - era * 400);
+  const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + yoe / 400 + doy;
+  return era * 146097 + (int)doe - 719468;
+}
+
+static void trimString(String& s) {
+  int start = 0;
+  int end = s.length();
+  while (start < end) {
+    char c = s.charAt(start);
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n') ++start;
+    else break;
+  }
+  while (end > start) {
+    char c = s.charAt(end - 1);
+    if (c == ' ' || c == '\t' || c == '\r' || c == '\n') --end;
+    else break;
+  }
+  if (start == 0 && end == s.length()) return;
+  s = s.substring(start, end);
+}
+} // namespace
+
+CtaTrainTrackerSource::CtaTrainTrackerSource(const char* key) : configKey_(key ? key : "cta_source") {
+  baseUrl_ = F("https://lapi.transitchicago.com/api/1.0/ttarrivals.aspx?mapid={mapid}&max=10&key={apiKey}");
+}
+
+void CtaTrainTrackerSource::reload(std::time_t now) {
+  nextFetch_ = now;
+  backoffMult_ = 1;
+  lastBackoffLog_ = 0;
+}
+
+String CtaTrainTrackerSource::sourceKey() const {
+  String key;
+  key.reserve(agency_.length() + 1 + stopKey_.length());
+  key = agency_;
+  key += ':';
+  key += stopKey_;
+  return key;
+}
+
+void CtaTrainTrackerSource::addToConfig(JsonObject& root) {
+  root["Enabled"] = enabled_;
+  root["Type"] = F("cta");
+  root["UpdateSecs"] = updateSecs_;
+  root["TemplateUrl"] = baseUrl_;
+  root["ApiKey"] = apiKey_;
+  String combined;
+  combined.reserve(agency_.length() + 1 + stopKey_.length());
+  combined = agency_;
+  combined += ':';
+  combined += stopKey_;
+  root["AgencyStopCode"] = combined;
+}
+
+bool CtaTrainTrackerSource::readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) {
+  bool ok = true;
+  bool prevEnabled = enabled_;
+  String prevAgency = agency_;
+  String prevStops = stopKey_;
+  String prevBase = baseUrl_;
+  std::vector<StopQuery> prevQueries = queries_;
+
+  ok &= getJsonValue(root["Enabled"], enabled_, enabled_);
+  ok &= getJsonValue(root["UpdateSecs"], updateSecs_, updateSecs_);
+  ok &= getJsonValue(root["TemplateUrl"], baseUrl_, baseUrl_);
+  ok &= getJsonValue(root["ApiKey"], apiKey_, apiKey_);
+
+  String keyField;
+  bool haveKey = getJsonValue(root["AgencyStopCode"], keyField, (const char*)nullptr);
+  if (!haveKey) haveKey = getJsonValue(root["Key"], keyField, (const char*)nullptr);
+
+  String stopList;
+  if (haveKey && keyField.length() > 0) {
+    keyField.trim();
+    int colon = keyField.indexOf(':');
+    if (colon > 0) {
+      agency_ = keyField.substring(0, colon);
+      stopList = keyField.substring(colon + 1);
+    } else {
+      stopList = keyField;
+    }
+  } else {
+    ok &= getJsonValue(root["Agency"], agency_, agency_);
+    String stopField;
+    if (getJsonValue(root["StopCode"], stopField, (const char*)nullptr)) {
+      stopList = stopField;
+    } else {
+      stopList = stopKey_;
+    }
+  }
+  stopList.trim();
+
+  std::vector<String> tokens;
+  if (stopList.length() > 0) splitStopCodes(stopList, tokens);
+
+  queries_.clear();
+  String inferredAgency = agency_;
+  for (auto& tok : tokens) {
+    StopQuery parsed;
+    String explicitAgency;
+    if (!parseStopToken(tok, parsed, explicitAgency)) continue;
+    if (explicitAgency.length() > 0) inferredAgency = explicitAgency;
+    bool dup = false;
+    for (const auto& existing : queries_) {
+      if (existing.canonical.equalsIgnoreCase(parsed.canonical)) {
+        dup = true;
+        break;
+      }
+    }
+    if (!dup) queries_.push_back(std::move(parsed));
+  }
+
+  if (agency_.length() == 0 && inferredAgency.length() > 0) agency_ = inferredAgency;
+  if (agency_.length() == 0) agency_ = F("CTA");
+
+  if (queries_.empty()) {
+    if (!prevQueries.empty()) {
+      queries_ = prevQueries;
+    } else if (stopList.length() > 0) {
+      StopQuery fallback;
+      String dummy;
+      if (parseStopToken(stopList, fallback, dummy)) {
+        queries_.push_back(fallback);
+      }
+    }
+  }
+
+  stopKey_.clear();
+  for (size_t i = 0; i < queries_.size(); ++i) {
+    if (i > 0) stopKey_ += ',';
+    stopKey_ += queries_[i].canonical;
+  }
+
+  {
+    String sec = F("CtaSource_");
+    sec += agency_;
+    sec += '_';
+    sec += stopKey_;
+    configKey_ = std::string(sec.c_str());
+  }
+
+  if (updateSecs_ < 15) updateSecs_ = 15;
+
+  invalidate_history |= (agency_ != prevAgency) || (stopKey_ != prevStops) || (baseUrl_ != prevBase);
+  if (startup_complete && !prevEnabled && enabled_) reload(departstrip::util::time_now_utc());
+  return ok;
+}
+
+std::unique_ptr<DepartModel> CtaTrainTrackerSource::fetch(std::time_t now) {
+  if (!enabled_) return nullptr;
+  if (queries_.empty()) return nullptr;
+  if (now == 0) return nullptr;
+  if (nextFetch_ != 0 && now < nextFetch_) {
+    time_t interval = updateSecs_ > 0 ? (time_t)updateSecs_ : (time_t)60;
+    if (lastBackoffLog_ == 0 || now - lastBackoffLog_ >= interval) {
+      lastBackoffLog_ = now;
+      long rem = (long)(nextFetch_ - now);
+      if (rem < 0) rem = 0;
+      String key = sourceKey();
+      if (backoffMult_ > 1) {
+        DEBUG_PRINTF("DepartStrip: CTA fetch: backoff x%u %s, next in %lds\n",
+                     (unsigned)backoffMult_, key.c_str(), rem);
+      } else {
+        DEBUG_PRINTF("DepartStrip: CTA fetch: waiting %s, next in %lds\n",
+                     key.c_str(), rem);
+      }
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<DepartModel> model(new DepartModel());
+  model->boards.reserve(queries_.size());
+  size_t totalItems = 0;
+
+  DEBUG_PRINTLN(F("DepartStrip: CTA fetch: begin"));
+
+  for (const auto& query : queries_) {
+    String dirLog = (query.direction > 0) ? String(query.direction) : String(F("-"));
+    DEBUG_PRINTF("DepartStrip: CTA fetch: requesting mapId=%s dir=%s key=%s\n",
+                 query.mapIdStr.c_str(),
+                 dirLog.c_str(),
+                 configKey_.c_str());
+    String url = composeUrl(query);
+    HTTPClient http;
+    bool usedSecure = false;
+    int lenHint = -1;
+    int httpStatus = 0;
+    if (!httpBegin(url, lenHint, httpStatus, http, usedSecure)) {
+      long delay = (long)updateSecs_ * (long)backoffMult_;
+      if (now - lastBackoffLog_ >= 10) {
+        DEBUG_PRINTF("DepartStrip: CTA fetch HTTP error key=%s status=%d scheduling backoff x%u for %lds\n",
+                     sourceKey().c_str(),
+                     httpStatus,
+                     (unsigned)backoffMult_,
+                     delay);
+        lastBackoffLog_ = now;
+      }
+      nextFetch_ = now + delay;
+      if (backoffMult_ < 16) backoffMult_ *= 2;
+      return nullptr;
+    }
+
+    String body;
+    bool gotBody = readHttpBody(http, lenHint, body);
+    closeHttp(http, usedSecure);
+    if (!gotBody) {
+      long delay = (long)updateSecs_ * (long)backoffMult_;
+      if (now - lastBackoffLog_ >= 10) {
+        DEBUG_PRINTF("DepartStrip: CTA fetch empty body key=%s scheduling backoff x%u for %lds\n",
+                     sourceKey().c_str(),
+                     (unsigned)backoffMult_,
+                     delay);
+        lastBackoffLog_ = now;
+      }
+      nextFetch_ = now + delay;
+      if (backoffMult_ < 16) backoffMult_ *= 2;
+      return nullptr;
+    }
+
+    DepartModel::Entry::Batch batch;
+    batch.ourTs = now;
+    if (!parseResponse(body, query, now, batch)) {
+      long delay = (long)updateSecs_ * (long)backoffMult_;
+      if (now - lastBackoffLog_ >= 10) {
+        DEBUG_PRINTF("DepartStrip: CTA fetch parse error key=%s scheduling backoff x%u for %lds\n",
+                     sourceKey().c_str(),
+                     (unsigned)backoffMult_,
+                     delay);
+        lastBackoffLog_ = now;
+      }
+      nextFetch_ = now + delay;
+      if (backoffMult_ < 16) backoffMult_ *= 2;
+      return nullptr;
+    }
+
+    std::sort(batch.items.begin(), batch.items.end(),
+              [](const DepartModel::Entry::Item& a, const DepartModel::Entry::Item& b) {
+                if (a.estDep != b.estDep) return a.estDep < b.estDep;
+                return a.lineRef.compareTo(b.lineRef) < 0;
+              });
+    batch.items.erase(std::unique(batch.items.begin(), batch.items.end(),
+                    [](const DepartModel::Entry::Item& a, const DepartModel::Entry::Item& b) {
+                      return a.estDep == b.estDep && a.lineRef == b.lineRef;
+                    }),
+                      batch.items.end());
+    const size_t MAX_ITEMS = 16;
+    if (batch.items.size() > MAX_ITEMS) batch.items.resize(MAX_ITEMS);
+
+    if (batch.apiTs == 0) batch.apiTs = now;
+
+    DepartModel::Entry board;
+    board.key.reserve(agency_.length() + 1 + query.canonical.length());
+    board.key = agency_;
+    board.key += ':';
+    board.key += query.canonical;
+    board.batch = std::move(batch);
+    totalItems += board.batch.items.size();
+    DEBUG_PRINTF("DepartStrip: CTA fetch: key %s: items=%u\n",
+                 board.key.c_str(),
+                 (unsigned)board.batch.items.size());
+    String dbg = DepartModel::describeBatch(board.batch);
+    if (dbg.length()) DEBUG_PRINTF("DepartStrip: CTA fetch: model %s\n", dbg.c_str());
+    model->boards.push_back(std::move(board));
+  }
+
+  nextFetch_ = now + updateSecs_;
+  backoffMult_ = 1;
+  lastBackoffLog_ = 0;
+
+  if (model->boards.empty() || totalItems == 0) {
+    DEBUG_PRINTF("DepartStrip: CTA fetch: no departures parsed key=%s\n", sourceKey().c_str());
+  }
+
+  return model;
+}
+
+String CtaTrainTrackerSource::composeUrl(const StopQuery& query) const {
+  String url = baseUrl_;
+  if (url.length() == 0) {
+    url = F("http://lapi.transitchicago.com/api/1.0/ttarrivals.aspx?mapid={mapid}&max=50");
+    if (apiKey_.length() > 0) {
+      url += F("&key={apiKey}");
+    }
+  }
+  auto replaceAll = [&](const __FlashStringHelper* needle, const String& value) {
+    if (!needle) return;
+    String key(needle);
+    if (!key.length()) return;
+    url.replace(key, value);
+  };
+
+  replaceAll(F("{agency}"), agency_);
+  replaceAll(F("{AGENCY}"), agency_);
+  replaceAll(F("{Agency}"), agency_);
+
+  replaceAll(F("{mapid}"), query.mapIdStr);
+  replaceAll(F("{mapId}"), query.mapIdStr);
+  replaceAll(F("{MAPID}"), query.mapIdStr);
+
+  String dirStr;
+  if (query.direction > 0) dirStr = String(query.direction);
+  replaceAll(F("{direction}"), dirStr);
+  replaceAll(F("{Direction}"), dirStr);
+  replaceAll(F("{DIRECTION}"), dirStr);
+  replaceAll(F("{trdr}"), dirStr);
+  replaceAll(F("{trDr}"), dirStr);
+  replaceAll(F("{TRDR}"), dirStr);
+
+  if (apiKey_.length() > 0) {
+    replaceAll(F("{apikey}"), apiKey_);
+    replaceAll(F("{apiKey}"), apiKey_);
+    replaceAll(F("{APIKEY}"), apiKey_);
+  }
+  return url;
+}
+
+bool CtaTrainTrackerSource::httpBegin(const String& url, int& outLen, int& outStatus, HTTPClient& http, bool& usedSecure) {
+  http.setTimeout(10000);
+  bool localSecure = false;
+  WiFiClient* client = httpTransport_.begin(url, 10000, localSecure);
+  if (!client) {
+    DEBUG_PRINTLN(F("DepartStrip: CTA: no HTTP client available"));
+    return false;
+  }
+
+  if (!http.begin(*client, url)) {
+    http.end();
+    httpTransport_.end(localSecure);
+    DEBUG_PRINTLN(F("DepartStrip: CTA: HTTP begin failed"));
+    return false;
+  }
+  usedSecure = localSecure;
+  http.setUserAgent("WLED-CTA/0.1");
+  http.setReuse(true);
+  http.addHeader("Connection", "keep-alive", true, true);
+  http.addHeader("Accept", "application/xml", true, true);
+  static const char* hdrs[] = {"Content-Type", "Content-Length", "Content-Encoding", "Transfer-Encoding"};
+  http.collectHeaders(hdrs, 4);
+
+  int status = http.GET();
+  if (status < 200 || status >= 300) {
+    if (status < 0) {
+      String err = HTTPClient::errorToString(status);
+      DEBUG_PRINTF("DepartStrip: CTA HTTP error %d (%s)\n", status, err.c_str());
+    } else {
+      DEBUG_PRINTF("DepartStrip: CTA HTTP status %d\n", status);
+    }
+    http.end();
+    httpTransport_.end(localSecure);
+    outStatus = status;
+    return false;
+  }
+
+  outStatus = status;
+  outLen = http.getSize();
+  return true;
+}
+
+void CtaTrainTrackerSource::closeHttp(HTTPClient& http, bool usedSecure) {
+  http.end();
+  httpTransport_.end(usedSecure);
+}
+
+bool CtaTrainTrackerSource::readHttpBody(HTTPClient& http, int /*lenHint*/, String& outBody) {
+  outBody = http.getString();
+  return outBody.length() > 0;
+}
+
+bool CtaTrainTrackerSource::parseResponse(const String& xml,
+                                          const StopQuery& query,
+                                          std::time_t now,
+                                          DepartModel::Entry::Batch& batch) {
+  batch.items.clear();
+  batch.apiTs = 0;
+  batch.ourTs = now;
+  String firstStopName;
+
+  String timestamp = extractTagValue(xml, F("tmst"));
+  timestamp.trim();
+  if (timestamp.length() > 0) {
+    time_t apiTs = 0;
+    if (parseTimestamp(timestamp, apiTs)) batch.apiTs = apiTs;
+  }
+
+  int searchPos = 0;
+  while (true) {
+    int open = xml.indexOf(F("<eta"), searchPos);
+    if (open < 0) break;
+    int close = xml.indexOf(F("</eta>"), open);
+    if (close < 0) break;
+    int blockStart = xml.indexOf('>', open);
+    if (blockStart < 0 || blockStart >= close) {
+      searchPos = close + 5;
+      continue;
+    }
+    ++blockStart;
+    String block = xml.substring(blockStart, close);
+    searchPos = close + 5;
+
+    String dirStr = extractTagValue(block, F("trDr"));
+    trimString(dirStr);
+    String staName = extractTagValue(block, F("staNm"));
+    trimString(staName);
+    if (firstStopName.length() == 0 && staName.length() > 0) firstStopName = staName;
+
+    if (query.direction > 0) {
+      if (dirStr.length() == 0) continue;
+      uint8_t dirVal = 0;
+      if (!parseUnsigned8(dirStr, dirVal)) continue;
+      if (dirVal != query.direction) continue;
+    }
+
+    String arrStr = extractTagValue(block, F("arrT"));
+    trimString(arrStr);
+    if (arrStr.length() == 0) {
+      arrStr = extractTagValue(block, F("prdt"));
+      trimString(arrStr);
+    }
+    if (arrStr.length() == 0) continue;
+
+    time_t arrivalUtc = 0;
+    if (!parseTimestamp(arrStr, arrivalUtc)) continue;
+
+    if (now > 0 && arrivalUtc + 300 < now) continue;
+
+    String route = extractTagValue(block, F("rt"));
+    trimString(route);
+    if (route.length() == 0) {
+      route = extractTagValue(block, F("destNm"));
+      trimString(route);
+    }
+    if (route.length() == 0) {
+      route = extractTagValue(block, F("stpDe"));
+      trimString(route);
+    }
+    if (route.length() == 0) route = F("Service");
+
+    if (query.labelSuffix.length() > 0) {
+      route += ' ';
+      route += query.labelSuffix;
+    }
+
+    DepartModel::Entry::Item item;
+    item.estDep = arrivalUtc;
+    item.lineRef = route;
+    batch.items.push_back(std::move(item));
+  }
+
+  if (firstStopName.length() > 0) lastStopName_ = firstStopName;
+
+  return true;
+}
+
+bool CtaTrainTrackerSource::parseTimestamp(const String& value, time_t& outUtc) const {
+  if (value.length() < 17) return false;
+  int Y=0, M=0, D=0, h=0, m=0, s=0;
+  if (sscanf(value.c_str(), "%4d%2d%2d %2d:%2d:%2d", &Y, &M, &D, &h, &m, &s) != 6) return false;
+  if (M < 1 || M > 12 || D < 1 || D > 31) return false;
+  if (h < 0 || h > 23 || m < 0 || m > 59 || s < 0 || s > 60) return false;
+  int days = days_from_civil(Y, (unsigned)M, (unsigned)D);
+  long localSeconds = (long)days * 86400L + (long)h * 3600L + (long)m * 60L + (long)s;
+  long offset = departstrip::util::current_offset();
+  outUtc = (time_t)(localSeconds - offset);
+  return true;
+}
+
+void CtaTrainTrackerSource::splitStopCodes(const String& input, std::vector<String>& out) {
+  out.clear();
+  String normalized = input;
+  normalized.replace(';', ',');
+  normalized.replace(' ', ',');
+  normalized.replace('\t', ',');
+  int start = 0;
+  int len = normalized.length();
+  while (start < len) {
+    int comma = normalized.indexOf(',', start);
+    String token = (comma >= 0) ? normalized.substring(start, comma) : normalized.substring(start);
+    token.trim();
+    if (token.length() > 0) out.push_back(token);
+    if (comma < 0) break;
+    start = comma + 1;
+  }
+}
+
+bool CtaTrainTrackerSource::parseStopToken(const String& token, StopQuery& out, String& explicitAgency) {
+  explicitAgency = String();
+  StopQuery parsed;
+
+  String temp = token;
+  temp.trim();
+  if (temp.length() == 0) return false;
+
+  int eq = temp.indexOf('=');
+  if (eq >= 0) {
+    parsed.labelSuffix = temp.substring(eq + 1);
+    temp = temp.substring(0, eq);
+    parsed.labelSuffix.trim();
+    if (parsed.labelSuffix.length() > 0) {
+      parsed.labelSuffix.replace(' ', '-');
+      parsed.labelSuffix.replace('\t', '-');
+    }
+  }
+
+  String agencyToken;
+  String codeToken;
+  int colon = temp.indexOf(':');
+  if (colon > 0) {
+    agencyToken = temp.substring(0, colon);
+    codeToken = temp.substring(colon + 1);
+  } else {
+    codeToken = temp;
+  }
+  codeToken.trim();
+  if (agencyToken.length() > 0) explicitAgency = agencyToken;
+  if (codeToken.length() == 0) return false;
+
+  String mapToken = codeToken;
+  String dirToken;
+  int dot = codeToken.lastIndexOf('.');
+  if (dot > 0) {
+    mapToken = codeToken.substring(0, dot);
+    dirToken = codeToken.substring(dot + 1);
+  }
+  mapToken.trim();
+  dirToken.trim();
+  if (mapToken.length() == 0) return false;
+
+  uint32_t mapId = 0;
+  if (!parseUnsigned(mapToken, mapId)) return false;
+  parsed.mapId = mapId;
+  parsed.mapIdStr = mapToken;
+
+  if (dirToken.length() > 0) {
+    uint32_t dirWide = 0;
+    if (!parseUnsigned(dirToken, dirWide)) return false;
+    if (dirWide > 255) return false;
+    parsed.direction = (uint8_t)dirWide;
+  }
+
+  parsed.canonical = mapToken;
+  if (dirToken.length() > 0) {
+    parsed.canonical += '.';
+    parsed.canonical += dirToken;
+  }
+  if (parsed.labelSuffix.length() > 0) {
+    parsed.canonical += '=';
+    parsed.canonical += parsed.labelSuffix;
+  }
+
+  out = parsed;
+  return true;
+}
+
+bool CtaTrainTrackerSource::parseUnsigned(const String& s, uint32_t& out) {
+  out = 0;
+  if (s.length() == 0) return false;
+  for (unsigned i = 0; i < s.length(); ++i) {
+    char c = s.charAt(i);
+    if (c < '0' || c > '9') return false;
+    out = out * 10u + (uint32_t)(c - '0');
+  }
+  return true;
+}
+
+bool CtaTrainTrackerSource::parseUnsigned8(const String& s, uint8_t& out) {
+  uint32_t wide = 0;
+  if (!parseUnsigned(s, wide)) return false;
+  if (wide > 255) return false;
+  out = (uint8_t)wide;
+  return true;
+}
+
+String CtaTrainTrackerSource::extractTagValue(const String& block, const __FlashStringHelper* tag) {
+  if (!tag) return String();
+  String key(tag);
+  return extractTagValue(block, key.c_str());
+}
+
+String CtaTrainTrackerSource::extractTagValue(const String& block, const char* tag) {
+  if (!tag || !*tag) return String();
+  String open;
+  open.reserve(strlen(tag) + 2);
+  open += '<';
+  open += tag;
+  open += '>';
+  String close;
+  close.reserve(strlen(tag) + 3);
+  close += '<';
+  close += '/';
+  close += tag;
+  close += '>';
+  int start = block.indexOf(open);
+  if (start < 0) return String();
+  start += open.length();
+  int end = block.indexOf(close, start);
+  if (end < 0) return String();
+  return block.substring(start, end);
+}

--- a/usermods/usermod_v2_departstrip/cta_source.h
+++ b/usermods/usermod_v2_departstrip/cta_source.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "interfaces.h"
+#include "depart_model.h"
+#include "http_transport.h"
+#include "util.h"
+#include "wled.h"
+
+#if defined(ARDUINO_ARCH_ESP8266)
+  #include <ESP8266HTTPClient.h>
+#else
+  #include <HTTPClient.h>
+#endif
+
+// Chicago Transit Authority (CTA) TrainTracker XML source.
+// Fetches predicted arrivals and maps them onto DepartStrip boards.
+class CtaTrainTrackerSource : public IDataSourceT<DepartModel> {
+private:
+  struct StopQuery {
+    String canonical;    // normalized "mapId[.direction][=alias]" token
+    String mapIdStr;     // mapId as string (no direction or alias)
+    uint32_t mapId = 0;
+    uint8_t direction = 0; // 0 = any direction as returned by API
+    String labelSuffix;  // optional suffix appended to destNm
+  };
+
+  bool     enabled_ = false;
+  uint32_t updateSecs_ = 60;
+  String   baseUrl_;
+  String   apiKey_;
+  String   agency_ = F("CTA");
+  String   stopKey_;
+  std::vector<StopQuery> queries_;
+  time_t   nextFetch_ = 0;
+  uint8_t  backoffMult_ = 1;
+  time_t   lastBackoffLog_ = 0;
+  std::string configKey_ = "cta_source";
+  departstrip::net::HttpTransport httpTransport_;
+  String   lastStopName_;
+
+public:
+  explicit CtaTrainTrackerSource(const char* key = "cta_source");
+  std::unique_ptr<DepartModel> fetch(std::time_t now) override;
+  void reload(std::time_t now) override;
+  std::string name() const override { return configKey_; }
+  void appendConfigData(Print& s) override {}
+  const char* configKey() const override { return configKey_.c_str(); }
+  String sourceKey() const override;
+  const char* sourceType() const override { return "cta"; }
+  const String& agency() const { return agency_; }
+  const String& stopName() const { return lastStopName_; }
+
+  void addToConfig(JsonObject& root) override;
+  bool readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) override;
+
+private:
+  struct ParsedEta {
+    time_t arrival = 0;
+    String label;
+  };
+
+  String composeUrl(const StopQuery& query) const;
+  bool httpBegin(const String& url, int& outLen, int& outStatus, HTTPClient& http, bool& usedSecure);
+  void closeHttp(HTTPClient& http, bool usedSecure);
+  bool readHttpBody(HTTPClient& http, int lenHint, String& outBody);
+  bool parseResponse(const String& xml,
+                     const StopQuery& query,
+                     std::time_t now,
+                     DepartModel::Entry::Batch& batch);
+  bool parseTimestamp(const String& value, time_t& outUtc) const;
+  static void splitStopCodes(const String& input, std::vector<String>& out);
+  static bool parseStopToken(const String& token, StopQuery& out, String& explicitAgency);
+  static bool parseUnsigned(const String& s, uint32_t& out);
+  static bool parseUnsigned8(const String& s, uint8_t& out);
+  static String extractTagValue(const String& block, const __FlashStringHelper* tag);
+  static String extractTagValue(const String& block, const char* tag);
+};

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -41,19 +41,10 @@ void DepartModel::currentLinesForBoard(const String& key, std::vector<String>& o
     for (const auto& s : out) { if (s == lr) { seen = true; break; } }
     if (!seen) out.push_back(lr);
   }
-  // Natural sort: numeric prefix, then suffix
-  struct CmpLine {
-    static bool parseLeadingInt(const String& s, int& val, int& consumed) {
-      val=0; consumed=0; bool any=false; for (unsigned i=0;i<s.length();++i){ char ch=s.charAt(i); if (ch>='0'&&ch<='9'){ any=true; val=val*10+(ch-'0'); ++consumed; } else break; } return any;
-    }
-    static bool lt(const String& a, const String& b) {
-      int na=0, nb=0, ca=0, cb=0; bool ha=parseLeadingInt(a,na,ca), hb=parseLeadingInt(b,nb,cb);
-      if (ha&&hb){ if(na!=nb) return na<nb; int r=a.substring(ca).compareTo(b.substring(cb)); if(r!=0) return r<0; return false; }
-      if (ha!=hb) return ha; // numeric first
-      return a.compareTo(b) < 0;
-    }
-  };
-  std::sort(out.begin(), out.end(), CmpLine::lt);
+  // Natural sort: numeric prefix, then suffix (shared helper)
+  std::sort(out.begin(), out.end(), [](const String& a, const String& b){
+    return departstrip::util::cmpLineRefNatural(a, b) < 0;
+  });
 }
 
 String DepartModel::describeBatch(const DepartModel::Entry::Batch& batch) {

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -88,7 +88,7 @@ namespace {
     String base = (dash > 0) ? lineRef.substring(0, dash) : lineRef;
     String u = base; u.toUpperCase();
     if (u == F("RED"))    { rgbOut = 0xFF0000; return true; }
-    if (u == F("ORANGE")) { rgbOut = 0xFF961E; return true; }
+    if (u == F("ORANGE")) { rgbOut = 0xFF8000; return true; }
     if (u == F("YELLOW")) { rgbOut = 0xFFFF00; return true; }
     if (u == F("GREEN"))  { rgbOut = 0x00FF00; return true; }
     if (u == F("BLUE"))   { rgbOut = 0x0000FF; return true; }

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -1,0 +1,218 @@
+#include "depart_model.h"
+#include <algorithm>
+#include "util.h"
+
+void DepartModel::update(std::time_t now, DepartModel&& delta) {
+  for (auto &e : delta.boards) {
+    auto it = std::find_if(boards.begin(), boards.end(), [&](const Entry& x){ return x.key == e.key; });
+    if (it != boards.end()) {
+      it->batch = e.batch;
+      DEBUG_PRINTF("DepartStrip: DepartModel::update: key %s: items=%u\n",
+                   it->key.c_str(), (unsigned)it->batch.items.size());
+      String dbg = describeBatch(it->batch);
+      if (dbg.length()) DEBUG_PRINTF("DepartStrip: DepartModel::update: model %s\n", dbg.c_str());
+    } else {
+      boards.push_back(std::move(e));
+      auto &ne = boards.back();
+      DEBUG_PRINTF("DepartStrip: DepartModel::update: added key %s\n", ne.key.c_str());
+      DEBUG_PRINTF("DepartStrip: DepartModel::update: key %s: items=%u\n",
+                   ne.key.c_str(), (unsigned)ne.batch.items.size());
+      String dbg = describeBatch(ne.batch);
+      if (dbg.length()) DEBUG_PRINTF("DepartStrip: DepartModel::update: model %s\n", dbg.c_str());
+    }
+  }
+}
+
+const DepartModel::Entry* DepartModel::find(const String& key) const {
+  for (auto const& e : boards) if (e.key == key) return &e;
+  return nullptr;
+}
+
+void DepartModel::currentLinesForBoard(const String& key, std::vector<String>& out) const {
+  out.clear();
+  const Entry* e = find(key);
+  if (!e) return;
+  const auto& items = e->batch.items;
+  // Deduplicate lines
+  for (const auto& it : items) {
+    const String& lr = it.lineRef;
+    if (lr.length() == 0) continue;
+    bool seen = false;
+    for (const auto& s : out) { if (s == lr) { seen = true; break; } }
+    if (!seen) out.push_back(lr);
+  }
+  // Natural sort: numeric prefix, then suffix
+  struct CmpLine {
+    static bool parseLeadingInt(const String& s, int& val, int& consumed) {
+      val=0; consumed=0; bool any=false; for (unsigned i=0;i<s.length();++i){ char ch=s.charAt(i); if (ch>='0'&&ch<='9'){ any=true; val=val*10+(ch-'0'); ++consumed; } else break; } return any;
+    }
+    static bool lt(const String& a, const String& b) {
+      int na=0, nb=0, ca=0, cb=0; bool ha=parseLeadingInt(a,na,ca), hb=parseLeadingInt(b,nb,cb);
+      if (ha&&hb){ if(na!=nb) return na<nb; int r=a.substring(ca).compareTo(b.substring(cb)); if(r!=0) return r<0; return false; }
+      if (ha!=hb) return ha; // numeric first
+      return a.compareTo(b) < 0;
+    }
+  };
+  std::sort(out.begin(), out.end(), CmpLine::lt);
+}
+
+String DepartModel::describeBatch(const DepartModel::Entry::Batch& batch) {
+  if (batch.items.empty()) return String();
+  char nowBuf[20];
+  departstrip::util::fmt_local(nowBuf, sizeof(nowBuf), batch.ourTs, "%H:%M:%S");
+  int lagSecs = (int)(batch.ourTs - batch.apiTs);
+  String out;
+  out += nowBuf;
+  out += ": lag ";
+  out += lagSecs;
+  out += ":";
+  time_t prevTs = batch.ourTs;
+  for (const auto& e : batch.items) {
+    out += " +";
+    int diffMin = (int)((long)e.estDep - (long)prevTs) / 60;
+    out += diffMin;
+    out += " (";
+    prevTs = e.estDep;
+    char depBuf[20];
+    departstrip::util::fmt_local(depBuf, sizeof(depBuf), e.estDep, "%H:%M:%S");
+    out += depBuf;
+    out += ":";
+    out += e.lineRef;
+    out += ")";
+  }
+  return out;
+}
+
+// ----- Color mapping storage -----
+namespace {
+  std::vector<DepartModel::ColorEntry> g_colors; // key = "AGENCY:LineRef"
+
+  String makeKey(const String& agency, const String& lineRef) {
+    String k = agency; k += ":"; k += lineRef; return k;
+  }
+
+  bool bartDefaultColor(const String& lineRef, uint32_t& rgbOut) {
+    // Accept Red/Orange/Yellow/Green/Blue with optional -N/-S suffix
+    int dash = lineRef.indexOf('-');
+    String base = (dash > 0) ? lineRef.substring(0, dash) : lineRef;
+    String u = base; u.toUpperCase();
+    if (u == F("RED"))    { rgbOut = 0xFF0000; return true; }
+    if (u == F("ORANGE")) { rgbOut = 0xFF961E; return true; }
+    if (u == F("YELLOW")) { rgbOut = 0xFFFF00; return true; }
+    if (u == F("GREEN"))  { rgbOut = 0x00FF00; return true; }
+    if (u == F("BLUE"))   { rgbOut = 0x0000FF; return true; }
+    if (u == F("WHITE"))  { rgbOut = 0xFFFFFF; return true; }
+    return false;
+  }
+
+  bool acDefaultColor(const String& lineRef, uint32_t& rgbOut) {
+    // Map common AC Transit routes to provided colors
+    int dash = lineRef.indexOf('-');
+    String base = (dash > 0) ? lineRef.substring(0, dash) : lineRef;
+    String u = base; u.toUpperCase();
+    if (u == F("6"))    { rgbOut = 0x003680; return true; }
+    if (u == F("12"))   { rgbOut = 0x496F80; return true; }
+    if (u == F("18"))   { rgbOut = 0x800000; return true; }
+    if (u == F("27"))   { rgbOut = 0x00807F; return true; }
+    if (u == F("51A"))  { rgbOut = 0x806000; return true; }
+    if (u == F("72"))   { rgbOut = 0x00804D; return true; }
+    if (u == F("72M"))  { rgbOut = 0x630080; return true; }
+    if (u == F("88"))   { rgbOut = 0x808040; return true; }
+    if (u == F("633"))  { rgbOut = 0x808080; return true; }
+    if (u == F("651"))  { rgbOut = 0x808080; return true; }
+    if (u == F("800"))  { rgbOut = 0x4C8032; return true; }
+    if (u == F("802"))  { rgbOut = 0x804F59; return true; }
+    if (u == F("805"))  { rgbOut = 0x800058; return true; }
+    if (u == F("851"))  { rgbOut = 0x496F80; return true; }
+    return false;
+  }
+}
+
+const std::vector<DepartModel::ColorEntry>& DepartModel::colorMap() {
+  return g_colors;
+}
+
+void DepartModel::clearColorMap() {
+  g_colors.clear();
+}
+
+bool DepartModel::removeColorKeyByKey(const String& key) {
+  for (auto it = g_colors.begin(); it != g_colors.end(); ++it) {
+    if (it->key == key) { g_colors.erase(it); return true; }
+  }
+  return false;
+}
+
+bool DepartModel::removeColorKey(const String& agency, const String& lineRef) {
+  String key = makeKey(agency, lineRef);
+  return removeColorKeyByKey(key);
+}
+
+void DepartModel::setColorRGB(const String& agency, const String& lineRef, uint32_t rgb) {
+  String key = makeKey(agency, lineRef);
+  for (auto &e : g_colors) {
+    if (e.key == key) { e.rgb = rgb; return; }
+  }
+  g_colors.push_back(ColorEntry{key, rgb});
+}
+
+static bool lookupKey(const String& key, uint32_t& rgbOut) {
+  for (const auto& e : g_colors) if (e.key == key) { rgbOut = e.rgb; return true; }
+  return false;
+}
+
+bool DepartModel::getColorRGB(const String& agency, const String& lineRef, uint32_t& rgbOut) {
+  // Exact match
+  String key = makeKey(agency, lineRef);
+  if (lookupKey(key, rgbOut)) return true;
+  // Fallback: strip direction suffix after '-'
+  int dash = lineRef.indexOf('-');
+  if (dash > 0) {
+    String base = lineRef.substring(0, dash);
+    key = makeKey(agency, base);
+    if (lookupKey(key, rgbOut)) return true;
+  }
+  // Unknown: choose default and persist entry
+  uint32_t def = 0x606060; // neutral gray
+  if (agency == F("BA")) {
+    uint32_t bart;
+    if (bartDefaultColor(lineRef, bart)) def = bart;
+  } else if (agency == F("AC")) {
+    uint32_t ac;
+    if (acDefaultColor(lineRef, ac)) def = ac;
+  }
+  setColorRGB(agency, lineRef, def);
+  rgbOut = def;
+  return true;
+}
+
+bool DepartModel::parseColorString(const String& s, uint32_t& rgbOut) {
+  if (s.length() >= 7 && s[0] == '#') {
+    // #RRGGBB
+    char buf[3] = {0,0,0};
+    long r=0,g=0,b=0;
+    buf[0]=s[1]; buf[1]=s[2]; r = strtol(buf,nullptr,16);
+    buf[0]=s[3]; buf[1]=s[4]; g = strtol(buf,nullptr,16);
+    buf[0]=s[5]; buf[1]=s[6]; b = strtol(buf,nullptr,16);
+    rgbOut = ((uint32_t)r<<16)|((uint32_t)g<<8)|(uint32_t)b;
+    return true;
+  }
+  if (s.startsWith("rgb:")) {
+    int r=0,g=0,b=0;
+    if (sscanf(s.c_str()+4, "%d,%d,%d", &r,&g,&b) == 3) {
+      r = std::max(0, std::min(255, r));
+      g = std::max(0, std::min(255, g));
+      b = std::max(0, std::min(255, b));
+      rgbOut = ((uint32_t)r<<16)|((uint32_t)g<<8)|(uint32_t)b;
+      return true;
+    }
+  }
+  // Future: hsv:... format
+  return false;
+}
+
+String DepartModel::colorToString(uint32_t rgb) {
+  char buf[8];
+  snprintf(buf, sizeof(buf), "%06X", (unsigned)rgb & 0xFFFFFF);
+  String s("#"); s += buf; return s;
+}

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -116,19 +116,21 @@ namespace {
     {"AC", "851",  0x496F80, false},
 
     // Metro-North Railroad core line
-    {"MNR", "1",          0x009B3A, false}, // Hudson Line
+    {"MNR", "1",         0x009B3A, false}, // Hudson Line brand green
 
     // MTA Express buses (Bronx) — warm colors
-    {"MTA", "BC_BXM1",   0xEF6C00, false}, // vivid orange
-    {"MTA", "BC_BXM2",   0xFBC02D, false}, // bright golden yellow
-    {"MTA", "BC_BXM18",  0xB71C1C, false}, // deep red to distinguish the special route
+    {"MTA", "BC_BXM1",   0xD4A628, false}, // saturated golden yellow
+    {"MTA", "BC_BXM2",   0xA14444, false}, // warm red
+    {"MTA", "BC_BXM18",  0x6B4FB7, false}, // richer purple to stand out from buses
 
     // MTA Local buses (Bronx) — cool colors
-    {"MTA", "NYCT_BX10", 0x1E88E5, false}, // blue
-    {"MTA", "NYCT_BX20", 0x5E35B1, false}, // indigo
+    {"MTA", "NYCT_BX10", 0x4E80B8, false}, // blue
+    {"MTA", "NYCT_BX20", 0x1010AE, false}, // deep cobalt-blue; customize suffix variants separately
 
-    // Metra UP-N line (Chicago)
-    {"UPN", "UP-N", 0x00843D, false},
+    // Metra UP-N line (Chicago) — core plus DepartStrip variants
+    {"UPN", "UP-N-Local",   0xF2D34C, false}, // vibrant yellow for Central->Main locals
+    {"UPN", "UP-N-Express", 0x5A3BCB, false}, // richer Northwestern purple for Central->OTC express
+    {"UPN", "UP-N-Davis",   0x1FA57A, false}, // more saturated UP-N green for Wilmette->OTC via Davis
   };
 
   String lineTokenForDefault(const String& agency, const String& lineRef) {
@@ -171,7 +173,9 @@ namespace {
         int dash = candidate.indexOf('-');
         if (dash > 0) candidate = candidate.substring(0, dash);
       }
-      if (candidate == entry.line) {
+      String entryLine(entry.line);
+      entryLine.toUpperCase();
+      if (candidate == entryLine) {
         rgbOut = entry.color;
         return true;
       }

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -107,13 +107,14 @@ namespace {
     {"AC", "51A",  0x806000, false},
     {"AC", "72",   0x00804D, false},
     {"AC", "72M",  0x630080, false},
-    {"AC", "88",   0x808040, false},
+    {"AC", "88",   0x706030, false},
     {"AC", "633",  0x808080, false},
     {"AC", "651",  0x808080, false},
     {"AC", "800",  0x4C8032, false},
     {"AC", "802",  0x804F59, false},
     {"AC", "805",  0x800058, false},
     {"AC", "851",  0x496F80, false},
+    {"AC", "F",    0x803000, false},
 
     // Metro-North Railroad core line
     {"MNR", "1",         0x009B3A, false}, // Hudson Line brand green

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -128,9 +128,12 @@ namespace {
     {"MTA", "NYCT_BX20", 0x1010AE, false}, // deep cobalt-blue; customize suffix variants separately
 
     // Metra UP-N line (Chicago) — core plus DepartStrip variants
-    {"UPN", "UP-N-Local",   0xF2D34C, false}, // vibrant yellow for Central->Main locals
-    {"UPN", "UP-N-Express", 0x5A3BCB, false}, // richer Northwestern purple for Central->OTC express
-    {"UPN", "UP-N-Davis",   0x1FA57A, false}, // more saturated UP-N green for Wilmette->OTC via Davis
+    {"UPN", "UP-N-Central", 0x00843D, false}, // green from the map
+    {"UPN", "UP-N-Wilmette",0xDAA520, false}, // gold
+
+    // CTA (Chicago)
+    {"CTA", "P",         0x602398, true},   // Purple Line (official)
+
   };
 
   String lineTokenForDefault(const String& agency, const String& lineRef) {

--- a/usermods/usermod_v2_departstrip/depart_model.cpp
+++ b/usermods/usermod_v2_departstrip/depart_model.cpp
@@ -6,7 +6,7 @@ void DepartModel::update(std::time_t now, DepartModel&& delta) {
   for (auto &e : delta.boards) {
     auto it = std::find_if(boards.begin(), boards.end(), [&](const Entry& x){ return x.key == e.key; });
     if (it != boards.end()) {
-      it->batch = e.batch;
+      it->batch = std::move(e.batch);
       DEBUG_PRINTF("DepartStrip: DepartModel::update: key %s: items=%u\n",
                    it->key.c_str(), (unsigned)it->batch.items.size());
       String dbg = describeBatch(it->batch);

--- a/usermods/usermod_v2_departstrip/depart_model.h
+++ b/usermods/usermod_v2_departstrip/depart_model.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "wled.h"
+#include <vector>
+#include <ctime>
+
+// Generic departure model suitable for SIRI or other sources.
+// - Keyed by "agency:stopCode" (string key)
+// - Each key holds one current batch of departures
+// - Each departure has a LineRef string and an estimated time
+
+struct DepartModel {
+  struct Key {
+    String agency;
+    String stopCode;
+    String toString() const { String s(agency); s += ":"; s += stopCode; return s; }
+  };
+
+  struct Entry {
+    String key; // "agency:stop"
+    struct Item { time_t estDep; String lineRef; };
+    struct Batch { time_t apiTs; time_t ourTs; std::vector<Item> items; };
+    Batch batch; // latest batch
+  };
+
+  std::vector<Entry> boards; // small vector; linear search is fine
+
+  void update(std::time_t now, DepartModel&& delta);
+  const Entry* find(const String& key) const;
+  // Collect unique LineRef values from the most recent batch for a board key
+  void currentLinesForBoard(const String& key, std::vector<String>& out) const;
+
+  // Debug: summarize a batch similar to bartdepart (+N minute deltas and times)
+  static String describeBatch(const Entry::Batch& batch);
+
+  // Color mapping per agency:LineRef → RGB (0xRRGGBB)
+  static bool getColorRGB(const String& agency, const String& lineRef, uint32_t& rgbOut);
+  static void setColorRGB(const String& agency, const String& lineRef, uint32_t rgb);
+  struct ColorEntry { String key; uint32_t rgb; };
+  static const std::vector<ColorEntry>& colorMap();
+  static void clearColorMap();
+  static bool removeColorKey(const String& agency, const String& lineRef);
+  static bool removeColorKeyByKey(const String& key);
+  static bool parseColorString(const String& s, uint32_t& rgbOut);
+  static String colorToString(uint32_t rgb);
+};

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -64,7 +64,10 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
 
     for (const auto& src : sources_) {
       for (auto &e : src.batch->items) {
-        float diff = float(boardingSecs_ + e.estDep - now) * len / 3600.0f;
+        // Map time to pixels over the configured display window (in minutes)
+        uint16_t mins = departstrip::util::getDisplayMinutes();
+        float windowSec = (float)mins * 60.0f;
+        float diff = float(boardingSecs_ + e.estDep - now) * len / windowSec;
         if (diff < 0.0f || diff >= len) continue;
         int idx = int(floor(diff));
         float frac = diff - float(idx);

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -51,9 +51,15 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
 
   const uint8_t CYCLE_ALPHA = 100; // require to participate in cycling
 
+  struct Cand { uint32_t color; uint16_t bsum; String key; uint8_t alpha; };
+  size_t estCap = 0;
+  for (const auto& src : sources) estCap += src.batch->items.size();
+  std::vector<Cand> cands; cands.reserve(estCap);
+  std::vector<Cand> strong; strong.reserve(8);
+
   for (int i = 0; i < len; ++i) {
-    struct Cand { uint32_t color; uint16_t bsum; String key; uint8_t alpha; };
-    std::vector<Cand> cands;
+    cands.clear();
+    strong.clear();
 
     for (const auto& src : sources) {
       for (auto &e : src.batch->items) {
@@ -78,7 +84,6 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
     uint32_t out = 0;
     if (!cands.empty()) {
       // Build strong set for cycling (alpha above threshold)
-      std::vector<Cand> strong; strong.reserve(cands.size());
       for (const auto& c : cands) if (c.alpha >= CYCLE_ALPHA) strong.push_back(c);
       if (strong.empty()) {
         // No strong overlaps; choose the brightest single candidate (no cycle)

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -17,26 +17,27 @@ static CRGB colorForAgencyLine(const String& agency, const String& lineRef) {
 void DepartureView::view(std::time_t now, const DepartModel &model) {
   if (segmentId_ == -1) return;
 
-  struct Src { const DepartModel::Entry::Batch* batch; String agency; };
-  std::vector<Src> sources;
+  // Rebuild sources_ list but reuse its capacity
+  sources_.clear();
+  if (sources_.capacity() < keys_.size()) sources_.reserve(keys_.size());
   // Collect latest batch from each configured board key
   if (!keys_.empty()) {
-    for (const auto& k : keys_) {
+    for (size_t i = 0; i < keys_.size(); ++i) {
+      const String& k = keys_[i];
       const auto* e = model.find(k);
       if (!e) continue;
-      // Agency is prefix before ':'
-      String ag; int c = k.indexOf(':'); if (c > 0) ag = k.substring(0, c);
-      sources.push_back(Src{ &e->batch, ag });
+      const String* ag = (i < agencies_.size()) ? &agencies_[i] : nullptr;
+      sources_.push_back(Src{ &e->batch, ag });
     }
   } else {
     // Backward safety: attempt to use raw viewKey if parsing failed
     const auto* e = model.find(keysStr_);
     if (e) {
-      String ag; int c = keysStr_.indexOf(':'); if (c > 0) ag = keysStr_.substring(0, c);
-      sources.push_back(Src{ &e->batch, ag });
+      // Fallback computes agency transiently; rare path. Use null agency to avoid dangling pointer.
+      sources_.push_back(Src{ &e->batch, nullptr });
     }
   }
-  if (sources.empty()) return;
+  if (sources_.empty()) return;
 
   if (segmentId_ < 0 || segmentId_ >= strip.getMaxSegments()) return;
   Segment &seg = strip.getSegment((uint8_t)segmentId_);
@@ -52,18 +53,16 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
 
   const uint8_t CYCLE_ALPHA = 100; // require to participate in cycling
 
-  // Avoid copying Strings per pixel; keep pointer to existing lineRef
-  struct Cand { uint32_t color; uint16_t bsum; const String* key; uint8_t alpha; };
   size_t estCap = 0;
-  for (const auto& src : sources) estCap += src.batch->items.size();
-  std::vector<Cand> cands; cands.reserve(estCap);
-  std::vector<Cand> strong; strong.reserve(8);
+  for (const auto& src : sources_) estCap += src.batch->items.size();
+  if (cands_.capacity() < estCap) cands_.reserve(estCap);
+  if (strong_.capacity() < 8) strong_.reserve(8);
 
   for (int i = 0; i < len; ++i) {
-    cands.clear();
-    strong.clear();
+    cands_.clear();
+    strong_.clear();
 
-    for (const auto& src : sources) {
+    for (const auto& src : sources_) {
       for (auto &e : src.batch->items) {
         float diff = float(boardingSecs_ + e.estDep - now) * len / 3600.0f;
         if (diff < 0.0f || diff >= len) continue;
@@ -75,34 +74,34 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
         else if (i == idx + 1) alpha = uint8_t(frac * 255);
         else continue;
 
-        CRGB col = colorForAgencyLine(src.agency, e.lineRef);
+        CRGB col = colorForAgencyLine(src.agency ? *src.agency : String(), e.lineRef);
         uint32_t colScaled = (((uint32_t)col.r * alpha / 255) << 16) |
                              (((uint32_t)col.g * alpha / 255) << 8) |
                              ((uint32_t)col.b * alpha / 255);
-        cands.push_back(Cand{colScaled, brightness(colScaled), &e.lineRef, alpha});
+        cands_.push_back(Cand{colScaled, brightness(colScaled), &e.lineRef, alpha});
       }
     }
 
     uint32_t out = 0;
-    if (!cands.empty()) {
+    if (!cands_.empty()) {
       // Build strong set for cycling (alpha above threshold)
-      for (const auto& c : cands) if (c.alpha >= CYCLE_ALPHA) strong.push_back(c);
-      if (strong.empty()) {
+      for (const auto& c : cands_) if (c.alpha >= CYCLE_ALPHA) strong_.push_back(c);
+      if (strong_.empty()) {
         // No strong overlaps; choose the brightest single candidate (no cycle)
         const Cand* best = nullptr;
-        for (const auto& c : cands) if (!best || c.bsum > best->bsum) best = &c;
+        for (const auto& c : cands_) if (!best || c.bsum > best->bsum) best = &c;
         if (best) out = best->color;
-      } else if (strong.size() == 1) {
-        out = strong[0].color;
+      } else if (strong_.size() == 1) {
+        out = strong_[0].color;
       } else {
         // Stable, deterministic order by entity key (lineRef)
-        std::sort(strong.begin(), strong.end(), [](const Cand& a, const Cand& b){
+        std::sort(strong_.begin(), strong_.end(), [](const Cand& a, const Cand& b){
           const char* ak = (a.key && a.key->length()) ? a.key->c_str() : "";
           const char* bk = (b.key && b.key->length()) ? b.key->c_str() : "";
           return strcmp(ak, bk) < 0;
         });
         uint32_t nowMs = millis();
-        size_t n = strong.size();
+        size_t n = strong_.size();
         if (n == 0) {
           // Should be unreachable due to branch conditions; leave pixel off as a safe default
           out = 0;
@@ -111,7 +110,7 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
           uint32_t slice = 1000u / n32; // total cycle ~1s; clamp to >=1ms
           if (slice == 0) slice = 1;
           uint32_t phase = (nowMs / slice) % n32;
-          out = strong[phase].color;
+          out = strong_[phase].color;
         }
       }
     }

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -91,10 +91,17 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
         // Stable, deterministic order by entity key (lineRef)
         std::sort(strong.begin(), strong.end(), [](const Cand& a, const Cand& b){ return a.key.compareTo(b.key) < 0; });
         uint32_t nowMs = millis();
-        uint8_t n = (uint8_t)strong.size();
-        uint32_t slice = 1000u / (uint32_t)n; if (slice == 0) slice = 1;
-        uint32_t phase = (nowMs % (slice * n)) / slice;
-        out = strong[phase].color;
+        size_t n = strong.size();
+        if (n == 0) {
+          // Should be unreachable due to branch conditions; leave pixel off as a safe default
+          out = 0;
+        } else {
+          uint32_t n32 = (uint32_t)n;
+          uint32_t slice = 1000u / n32; // total cycle ~1s; clamp to >=1ms
+          if (slice == 0) slice = 1;
+          uint32_t phase = (nowMs / slice) % n32;
+          out = strong[phase].color;
+        }
       }
     }
 

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -1,0 +1,127 @@
+#include "departure_view.h"
+#include "util.h"
+#include "wled.h"
+#include <vector>
+#include <algorithm>
+
+using departstrip::util::FreezeGuard;
+
+static CRGB colorForAgencyLine(const String& agency, const String& lineRef) {
+  uint32_t rgb;
+  // Model provides defaults (neutral gray) when unknown
+  DepartModel::getColorRGB(agency, lineRef, rgb);
+  return CRGB((rgb>>16)&0xFF, (rgb>>8)&0xFF, rgb&0xFF);
+}
+
+void DepartureView::view(std::time_t now, const DepartModel &model) {
+  if (segmentId_ == -1) return;
+
+  struct Src { const DepartModel::Entry::Batch* batch; String agency; };
+  std::vector<Src> sources;
+  // Collect latest batch from each configured board key
+  if (!keys_.empty()) {
+    for (const auto& k : keys_) {
+      const auto* e = model.find(k);
+      if (!e) continue;
+      // Agency is prefix before ':'
+      String ag; int c = k.indexOf(':'); if (c > 0) ag = k.substring(0, c);
+      sources.push_back(Src{ &e->batch, ag });
+    }
+  } else {
+    // Backward safety: attempt to use raw viewKey if parsing failed
+    const auto* e = model.find(keysStr_);
+    if (e) {
+      String ag; int c = keysStr_.indexOf(':'); if (c > 0) ag = keysStr_.substring(0, c);
+      sources.push_back(Src{ &e->batch, ag });
+    }
+  }
+  if (sources.empty()) return;
+
+  if (segmentId_ < 0 || segmentId_ >= strip.getMaxSegments()) return;
+  Segment &seg = strip.getSegment((uint8_t)segmentId_);
+  int len = seg.virtualLength();
+  if (len <= 0) return;
+
+  seg.beginDraw();
+  FreezeGuard freezeGuard(seg, false);
+
+  auto brightness = [&](uint32_t c) {
+    return (uint16_t)(((c >> 16) & 0xFF) + ((c >> 8) & 0xFF) + (c & 0xFF));
+  };
+
+  const uint8_t CYCLE_ALPHA = 100; // require to participate in cycling
+
+  for (int i = 0; i < len; ++i) {
+    struct Cand { uint32_t color; uint16_t bsum; String key; uint8_t alpha; };
+    std::vector<Cand> cands;
+
+    for (const auto& src : sources) {
+      for (auto &e : src.batch->items) {
+        float diff = float(boardingSecs_ + e.estDep - now) * len / 3600.0f;
+        if (diff < 0.0f || diff >= len) continue;
+        int idx = int(floor(diff));
+        float frac = diff - float(idx);
+
+        uint8_t alpha = 0;
+        if (i == idx) alpha = uint8_t((1.0f - frac) * 255);
+        else if (i == idx + 1) alpha = uint8_t(frac * 255);
+        else continue;
+
+        CRGB col = colorForAgencyLine(src.agency, e.lineRef);
+        uint32_t colScaled = (((uint32_t)col.r * alpha / 255) << 16) |
+                             (((uint32_t)col.g * alpha / 255) << 8) |
+                             ((uint32_t)col.b * alpha / 255);
+        cands.push_back(Cand{colScaled, brightness(colScaled), e.lineRef, alpha});
+      }
+    }
+
+    uint32_t out = 0;
+    if (!cands.empty()) {
+      // Build strong set for cycling (alpha above threshold)
+      std::vector<Cand> strong; strong.reserve(cands.size());
+      for (const auto& c : cands) if (c.alpha >= CYCLE_ALPHA) strong.push_back(c);
+      if (strong.empty()) {
+        // No strong overlaps; choose the brightest single candidate (no cycle)
+        const Cand* best = nullptr;
+        for (const auto& c : cands) if (!best || c.bsum > best->bsum) best = &c;
+        if (best) out = best->color;
+      } else if (strong.size() == 1) {
+        out = strong[0].color;
+      } else {
+        // Stable, deterministic order by entity key (lineRef)
+        std::sort(strong.begin(), strong.end(), [](const Cand& a, const Cand& b){ return a.key.compareTo(b.key) < 0; });
+        uint32_t nowMs = millis();
+        uint8_t n = (uint8_t)strong.size();
+        uint32_t slice = 1000u / (uint32_t)n; if (slice == 0) slice = 1;
+        uint32_t phase = (nowMs % (slice * n)) / slice;
+        out = strong[phase].color;
+      }
+    }
+
+    seg.setPixelColor(i, out);
+  }
+}
+
+void DepartureView::appendConfigData(Print &s, const DepartModel *model) {
+  // Placeholder for UI helpers (e.g., show recent LineRefs)
+  s.print(F("addInfo('DepartStrip:"));
+  s.print(configKey());
+  s.print(F(":SegmentId',1,'<div style=\\'margin-top:12px;\\'>"));
+  if (model) {
+    int total = 0; int boards = 0;
+    if (!keys_.empty()) {
+      for (const auto& k : keys_) {
+        const auto* e = model->find(k);
+        if (e) { total += (int)e->batch.items.size(); ++boards; }
+      }
+    } else {
+      const auto* e = model->find(keysStr_);
+      if (e) { total += (int)e->batch.items.size(); boards = 1; }
+    }
+    if (boards > 0) { s.print(F("Items: ")); s.print(total); }
+    else { s.print(F("No data yet")); }
+  } else { s.print(F("No data yet")); }
+  s.print(F("</div>',"));
+  s.print(F("'&nbsp;<small style=\\'opacity:.8\\'>(-1 disables)</small>'"));
+  s.println(F(");"));
+}

--- a/usermods/usermod_v2_departstrip/departure_view.cpp
+++ b/usermods/usermod_v2_departstrip/departure_view.cpp
@@ -123,10 +123,14 @@ void DepartureView::view(std::time_t now, const DepartModel &model) {
 }
 
 void DepartureView::appendConfigData(Print &s, const DepartModel *model) {
-  // Placeholder for UI helpers (e.g., show recent LineRefs)
+  // Segment hint plus trailing stats rendered via addInfo helpers
   s.print(F("addInfo('DepartStrip:"));
   s.print(configKey());
-  s.print(F(":SegmentId',1,'<div style=\\'margin-top:12px;\\'>"));
+  s.println(F(":SegmentId',1,'','&nbsp;<small style=\\'opacity:.8\\'>(-1 disables)</small>');"));
+
+  s.print(F("addInfo('DepartStrip:"));
+  s.print(configKey());
+  s.print(F(":Delete',1,'<div style=\\'margin-top:12px;\\'>"));
   if (model) {
     int total = 0; int boards = 0;
     if (!keys_.empty()) {
@@ -141,7 +145,5 @@ void DepartureView::appendConfigData(Print &s, const DepartModel *model) {
     if (boards > 0) { s.print(F("Items: ")); s.print(total); }
     else { s.print(F("No data yet")); }
   } else { s.print(F("No data yet")); }
-  s.print(F("</div>',"));
-  s.print(F("'&nbsp;<small style=\\'opacity:.8\\'>(-1 disables)</small>'"));
-  s.println(F(");"));
+  s.println(F("</div>','');"));
 }

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -14,6 +14,8 @@ private:
   std::vector<String> agencies_; // Precomputed agencies for each key (same indexing as keys_)
   int16_t segmentId_ = -1;
   std::string configKey_;
+  bool wasFrozen_ = false;
+  int16_t frozenSegmentId_ = -1;
 
   // Reusable buffers to avoid per-frame heap churn
   struct Cand { uint32_t color; uint16_t bsum; const String* key; uint8_t alpha; };
@@ -36,6 +38,7 @@ public:
   }
   void appendConfigData(Print& s) override { appendConfigData(s, nullptr); }
   void appendConfigData(Print& s, const DepartModel* model) override;
+  void ensureUnfrozen();
   bool readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) override {
     bool ok = true;
     ok &= getJsonValue(root["SegmentId"], segmentId_, segmentId_);
@@ -105,5 +108,12 @@ private:
     s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
     s.replace('\'', '_'); s.replace('\"', '_'); s.replace('\\', '_');
     configKey_ = std::string(s.c_str());
+  }
+
+  Segment* segmentForId_(int16_t id) const {
+    if (id < 0) return nullptr;
+    uint8_t max = strip.getMaxSegments();
+    if (id >= max) return nullptr;
+    return &strip.getSegment((uint8_t)id);
   }
 };

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -14,8 +14,7 @@ private:
   std::vector<String> agencies_; // Precomputed agencies for each key (same indexing as keys_)
   int16_t segmentId_ = -1;
   std::string configKey_;
-  bool wasFrozen_ = false;
-  int16_t frozenSegmentId_ = -1;
+  departstrip::util::SegmentFreezeHandle freezeHandle_;
 
   // Reusable buffers to avoid per-frame heap churn
   struct Cand { uint32_t color; uint16_t bsum; const String* key; uint8_t alpha; };

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -68,17 +68,23 @@ private:
     String agencyHint, token;
     auto flush = [&]() {
       token.trim();
+      token.replace("\r", "");
       if (!token.length()) return;
       int c = token.indexOf(':');
       if (c > 0) {
-        keys_.push_back(token);
         String ag = token.substring(0, c);
+        ag.trim();
+        ag.replace("\r", "");
+        keys_.push_back(token);
         agencies_.push_back(ag);
-        if (!agencyHint.length()) agencyHint = ag;
+        agencyHint = ag;
       } else {
         if (agencyHint.length() > 0) {
-          String k = agencyHint; k += ':'; k += token; keys_.push_back(k);
-          agencies_.push_back(agencyHint);
+          String hintClean = agencyHint;
+          hintClean.trim();
+          hintClean.replace("\r", "");
+          String k = hintClean; k += ':'; k += token; keys_.push_back(k);
+          agencies_.push_back(hintClean);
         } else {
           keys_.push_back(token);
           agencies_.push_back(String());
@@ -88,7 +94,7 @@ private:
     };
     for (unsigned i = 0; i < in.length(); ++i) {
       char ch = in.charAt(i);
-      if (ch == ',' || ch == ' ' || ch == '\t' || ch == '\n' || ch == ';') flush();
+      if (ch == ',' || ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == ';') flush();
       else token += ch;
     }
     flush();

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -8,7 +8,7 @@
 // A simple view that renders one or more agency:stopCode boards onto a segment.
 class DepartureView : public IDataViewT<DepartModel> {
 private:
-  uint16_t boardingSecs_ = 60; // show past etd for this long
+  uint16_t boardingSecs_ = 0;  // show past etd for this long (default)
   String keysStr_;             // Raw string (e.g., "AC:50958,AC:50959" or "AC:50958 50959")
   std::vector<String> keys_;   // Parsed keys (each "AGENCY:StopCode")
   std::vector<String> agencies_; // Precomputed agencies for each key (same indexing as keys_)
@@ -32,6 +32,7 @@ public:
   void addToConfig(JsonObject& root) override {
     root["SegmentId"] = segmentId_;
     root["AgencyStopCodes"] = keysStr_;
+    root["BoardingSecs"] = boardingSecs_;
   }
   void appendConfigData(Print& s) override { appendConfigData(s, nullptr); }
   void appendConfigData(Print& s, const DepartModel* model) override;
@@ -54,6 +55,7 @@ public:
         updateConfigKey_();
       }
     }
+    ok &= getJsonValue(root["BoardingSecs"], boardingSecs_, (uint16_t)0);
     return ok;
   }
   const char* configKey() const override { return configKey_.c_str(); }

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "interfaces.h"
+#include "depart_model.h"
+#include "util.h"
+#include <vector>
+
+// A simple view that renders one or more agency:stopCode boards onto a segment.
+class DepartureView : public IDataViewT<DepartModel> {
+private:
+  uint16_t boardingSecs_ = 60; // show past etd for this long
+  String keysStr_;             // Raw string (e.g., "AC:50958,AC:50959" or "AC:50958 50959")
+  std::vector<String> keys_;   // Parsed keys (each "AGENCY:StopCode")
+  int16_t segmentId_ = -1;
+  std::string configKey_;
+public:
+  explicit DepartureView(const String& keys) : keysStr_(keys), segmentId_(-1), configKey_() {
+    // Parse now so view() has a ready list
+    auto parseKeys = [&](const String& in) {
+      keys_.clear();
+      // Split by comma or whitespace
+      String agencyHint;
+      String token;
+      auto flush = [&]() {
+        token.trim();
+        if (!token.length()) return;
+        int c = token.indexOf(':');
+        if (c > 0) {
+          keys_.push_back(token);
+          if (agencyHint.length() == 0) agencyHint = token.substring(0, c);
+        } else {
+          if (agencyHint.length() > 0) {
+            String k = agencyHint; k += ':'; k += token; keys_.push_back(k);
+          } else {
+            // As a fallback, keep token as-is (may be full key already)
+            keys_.push_back(token);
+          }
+        }
+        token = String();
+      };
+      for (unsigned i = 0; i < in.length(); ++i) {
+        char ch = in.charAt(i);
+        if (ch == ',' || ch == ' ' || ch == '\t' || ch == '\n' || ch == ';') flush();
+        else token += ch;
+      }
+      flush();
+    };
+    parseKeys(keysStr_);
+    String s = String("DepartureView_") + keysStr_;
+    s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
+    configKey_ = std::string(s.c_str());
+  }
+  const String& viewKey() const { return keysStr_; }
+
+  void view(std::time_t now, const DepartModel& model) override;
+  void addToConfig(JsonObject& root) override {
+    root["SegmentId"] = segmentId_;
+    root["AgencyStopCodes"] = keysStr_;
+  }
+  void appendConfigData(Print& s) override { appendConfigData(s, nullptr); }
+  void appendConfigData(Print& s, const DepartModel* model) override;
+  bool readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) override {
+    bool ok = true;
+    ok &= getJsonValue(root["SegmentId"], segmentId_, segmentId_);
+    {
+      String prev = keysStr_;
+      String tmp;
+      bool got = getJsonValue(root["AgencyStopCodes"], tmp, (const char*)nullptr);
+      if (got) keysStr_ = tmp; else {
+        // Backward compatibility with single code fields
+        tmp = String();
+        bool gotOld = getJsonValue(root["AgencyStopCode"], tmp, (const char*)nullptr);
+        if (gotOld) keysStr_ = tmp; else ok &= getJsonValue(root["Key"], keysStr_, keysStr_);
+      }
+      if (keysStr_ != prev) {
+        // Re-parse and update config key
+        // Parse keys
+        keys_.clear();
+        {
+          String in = keysStr_;
+          String agencyHint;
+          String token;
+          auto flush = [&]() {
+            token.trim();
+            if (!token.length()) return;
+            int c = token.indexOf(':');
+            if (c > 0) {
+              keys_.push_back(token);
+              if (agencyHint.length() == 0) agencyHint = token.substring(0, c);
+            } else {
+              if (agencyHint.length() > 0) { String k = agencyHint; k += ':'; k += token; keys_.push_back(k); }
+              else keys_.push_back(token);
+            }
+            token = String();
+          };
+          for (unsigned i = 0; i < in.length(); ++i) {
+            char ch = in.charAt(i);
+            if (ch == ',' || ch == ' ' || ch == '\t' || ch == '\n' || ch == ';') flush();
+            else token += ch;
+          }
+          flush();
+        }
+        String s = String("DepartureView_") + keysStr_;
+        s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
+        configKey_ = std::string(s.c_str());
+      }
+    }
+    return ok;
+  }
+  const char* configKey() const override { return configKey_.c_str(); }
+  std::string name() const override { return configKey_; }
+};

--- a/usermods/usermod_v2_departstrip/departure_view.h
+++ b/usermods/usermod_v2_departstrip/departure_view.h
@@ -16,10 +16,7 @@ private:
 public:
   explicit DepartureView(const String& keys) : keysStr_(keys), segmentId_(-1), configKey_() {
     parseKeysFrom(keysStr_);
-    String s = String("DepartureView_") + keysStr_;
-    s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
-    s.replace('\'', '_'); s.replace('\"', '_'); s.replace('\\', '_');
-    configKey_ = std::string(s.c_str());
+    updateConfigKey_();
   }
   const String& viewKey() const { return keysStr_; }
 
@@ -46,10 +43,7 @@ public:
       if (keysStr_ != prev) {
         // Re-parse and update config key
         parseKeysFrom(keysStr_);
-        String s = String("DepartureView_") + keysStr_;
-        s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
-        s.replace('\'', '_'); s.replace('\"', '_'); s.replace('\\', '_');
-        configKey_ = std::string(s.c_str());
+        updateConfigKey_();
       }
     }
     return ok;
@@ -83,5 +77,12 @@ private:
       else token += ch;
     }
     flush();
+  }
+
+  void updateConfigKey_() {
+    String s = String("DepartureView_") + keysStr_;
+    s.replace(':', '_'); s.replace(',', '_'); s.replace(' ', '_'); s.replace(';', '_');
+    s.replace('\'', '_'); s.replace('\"', '_'); s.replace('\\', '_');
+    configKey_ = std::string(s.c_str());
   }
 };

--- a/usermods/usermod_v2_departstrip/explainer/.gitignore
+++ b/usermods/usermod_v2_departstrip/explainer/.gitignore
@@ -1,0 +1,1 @@
+installs/*/explainer.html

--- a/usermods/usermod_v2_departstrip/explainer/Makefile
+++ b/usermods/usermod_v2_departstrip/explainer/Makefile
@@ -1,0 +1,28 @@
+INSTALLS := spuyten oakstop temescal
+
+HTMLS := $(INSTALLS:%=installs/%/explainer.html)
+COMMON_TEMPLATES := common/template.html common/template_oakstop.html common/template_temescal.html
+COMMON_FAQS := common/faq.md common/faq_quick.md
+
+.PHONY: all clean FORCE $(INSTALLS:%=build-%) open-%
+
+all: $(HTMLS)
+
+define INSTALL_template
+build-$(1): installs/$(1)/explainer.html
+
+installs/$(1)/explainer.html: FORCE common/build.py $(COMMON_TEMPLATES) $(COMMON_FAQS) installs/$(1)/legend.json
+	@echo [departstrip] build $(1)
+	python3 common/build.py $(1)
+
+open-$(1): build-$(1)
+	xdg-open installs/$(1)/explainer.html || open installs/$(1)/explainer.html
+endef
+
+$(foreach inst,$(INSTALLS),$(eval $(call INSTALL_template,$(inst))))
+
+clean:
+	rm -f $(HTMLS)
+
+FORCE:
+	@true

--- a/usermods/usermod_v2_departstrip/explainer/common/build.py
+++ b/usermods/usermod_v2_departstrip/explainer/common/build.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""
+Builds a two-page, half-letter explainer for a given installation name.
+
+Usage:
+    python3 common/build.py <install_name>
+
+Reads:
+    installs/<install_name>/legend.json  (per-install lines/colors or direction/stops)
+    common/faq.md                        (shared FAQ; optional — falls back to defaults)
+    common/template*.html                (shared HTML with placeholders)
+
+Writes:
+    installs/<install_name>/explainer.html
+
+No external dependencies (stdlib only).
+"""
+from __future__ import annotations
+import sys
+import json
+import re
+from pathlib import Path
+from datetime import date
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMON = ROOT / "common"
+INSTALLS = ROOT / "installs"
+
+TEMPLATE_PLACEHOLDERS = {
+    "legend": "{{LEGEND_ITEMS}}",
+    "groups": "{{LEGEND_GROUPS}}",
+    "faq": "{{FAQ_BLOCKS}}",
+    "title": "{{TITLE}}",
+    "subtitle": "{{SUBTITLE}}",
+    "updated": "{{UPDATED}}",
+    "directions": "{{DIRECTIONS}}",
+}
+
+DEFAULT_TITLE = "DepartStrip"
+DEFAULT_SUBTITLE = "Arrivals at a glance"
+
+DEFAULT_FAQ_MD = """
+### What am I looking at?
+Each LED represents a scheduled arrival. Colors map to the legend. Dots move right as arrival time approaches.
+
+### How recent is the data?
+Continuously updated from official GTFS-Realtime/agency sources. If a feed drops, we fall back to last known schedule.
+
+### What do blinking or dim lights mean?
+Blinking = status change (delay/new estimate). Dimmer = farther out in time; brighter = imminent.
+
+### Can I change which lines are shown?
+Yes—use the config file or app to enable/disable routes and tweak colors.
+""".strip()
+
+FAQ_H3 = re.compile(r"^###\s+(.+)$", re.M)
+
+
+def parse_faq(md_text: str) -> list[tuple[str, str]]:
+    """Return list of (question, answer_html) parsed from markdown with H3 questions.
+    Very light parser: groups paragraphs until next H3.
+    """
+    items: list[tuple[str, str]] = []
+    positions = list(FAQ_H3.finditer(md_text))
+    if not positions:
+        md_text = DEFAULT_FAQ_MD
+        positions = list(FAQ_H3.finditer(md_text))
+
+    for i, m in enumerate(positions):
+        q = m.group(1).strip()
+        start = m.end()
+        end = positions[i + 1].start() if i + 1 < len(positions) else len(md_text)
+        body = md_text[start:end].strip()
+        # Convert bare newlines to <br> within paragraphs, and blank lines to paragraph breaks
+        paras = [p.strip() for p in re.split(r"\n\s*\n", body) if p.strip()]
+        html_paras = []
+        for p in paras:
+            inner = re.sub(r"\n+", "<br>", p)
+            html_paras.append(f"<p>{inner}</p>")
+        a_html = "\n".join(html_paras) if html_paras else "<p></p>"
+        items.append((q, a_html))
+    return items
+
+
+def load_legend(legend_path: Path) -> dict:
+    with legend_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    # Basic validation
+    has_lines = "lines" in data
+    has_directions = "directions" in data
+    if not has_lines and not has_directions:
+        raise ValueError(f"Missing 'lines' or 'directions' in {legend_path}")
+    if has_lines and not isinstance(data["lines"], list):
+        raise ValueError(f"Missing 'lines' list in {legend_path}")
+    if not has_lines:
+        data["lines"] = []
+    return data
+
+
+def render_legend_items(lines: list[dict]) -> str:
+    buf = []
+    for item in lines:
+        label = item.get("label", "")
+        desc = item.get("desc", "")
+        hex_color = item.get("hex", "#000000")
+        buf.append(
+            f"""
+      <div class="legend-item" role="listitem">
+        <div class="swatch" style="background:{hex_color}"></div>
+        <div>
+          <div class="label">{label}</div>
+          <div class="desc">{desc}</div>
+        </div>
+      </div>"""
+        )
+    return "\n".join(buf)
+
+
+def render_legend_groups(groups: list[dict], faq_html: str = "") -> str:
+    sections = []
+    for group in groups:
+        title = group.get("title", "")
+        lines = group.get("lines", [])
+        classes = "legend-group"
+        group_class = group.get("class")
+        if group_class:
+            classes += " " + group_class
+        extra = ""
+        if group.get("appendFaq") and faq_html:
+            extra = f"""
+        <div class="legend-spacer" aria-hidden="true"></div>
+        <div class="faq faq-inline">
+          <h3>Quick FAQ</h3>
+{faq_html}
+        </div>"""
+        sections.append(
+            f"""
+      <section class="{classes}">
+        <h3>{title}</h3>
+        <div class="legend-list" role="list">
+{render_legend_items(lines)}
+        </div>{extra}
+      </section>"""
+        )
+    return "\n".join(sections)
+
+
+def render_routes(routes: list[dict]) -> str:
+    buf = []
+    for route in routes:
+        label = route.get("label", "")
+        desc = route.get("desc", "")
+        hex_color = route.get("hex", "#000000")
+        buf.append(
+            f"""
+        <div class="route" role="listitem">
+          <div class="swatch" style="background:{hex_color}"></div>
+          <div class="route-body">
+            <div class="route-label">{label}</div>
+            <div class="route-desc">{desc}</div>
+          </div>
+        </div>"""
+        )
+    return "\n".join(buf)
+
+
+def render_stops(stops: list[dict]) -> str:
+    cards = []
+    for stop in stops:
+        name = stop.get("name", "")
+        stop_id = stop.get("id", "")
+        routes = stop.get("routes", [])
+        cards.append(
+            f"""
+      <article class="stop-card">
+        <div class="stop-header">
+          <div class="stop-name">{name}</div>
+          <div class="stop-id">Stop {stop_id}</div>
+        </div>
+        <div class="route-list" role="list">
+{render_routes(routes)}
+        </div>
+      </article>"""
+        )
+    return "\n".join(cards)
+
+
+def render_directions(directions: list[dict]) -> str:
+    sections = []
+    for direction in directions:
+        title = direction.get("title", "")
+        stops = direction.get("stops", [])
+        sections.append(
+            f"""
+    <section class="direction">
+      <div class="direction-heading">
+        <div class="direction-label">{title}</div>
+      </div>
+      <div class="stop-grid" role="list">
+{render_stops(stops)}
+      </div>
+    </section>"""
+        )
+    return "\n".join(sections)
+
+
+def render_faq_blocks(items: list[tuple[str, str]]) -> str:
+    buf = []
+    for q, a_html in items:
+        buf.append(
+            f"""
+      <div class="qa">
+        <div class="q">{q}</div>
+        <div class="a">{a_html}</div>
+      </div>"""
+        )
+    return "\n".join(buf)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python3 common/build.py <install_name>")
+        return 2
+    name = sys.argv[1]
+
+    legend_path = INSTALLS / name / "legend.json"
+
+    if not legend_path.exists():
+        raise SystemExit(f"Missing legend file: {legend_path}")
+
+    legend = load_legend(legend_path)
+    title = legend.get("title", DEFAULT_TITLE)
+    subtitle = legend.get("subtitle", DEFAULT_SUBTITLE)
+
+    template_name = legend.get("template", "template.html")
+    template_path = COMMON / template_name
+    if not template_path.exists():
+        raise SystemExit(f"Missing template: {template_path}")
+
+    faq_name = legend.get("faq")
+    faq_md_path = COMMON / faq_name if faq_name else COMMON / "faq.md"
+    faq_md = faq_md_path.read_text(encoding="utf-8") if faq_md_path.exists() else DEFAULT_FAQ_MD
+    faq_items = parse_faq(faq_md)
+
+    template = template_path.read_text(encoding="utf-8")
+    html = template
+    faq_html = render_faq_blocks(faq_items)
+    lines = legend.get("lines", [])
+    groups = legend.get("groups", [])
+    directions = legend.get("directions", [])
+    if groups:
+        bart = next((g for g in groups if g.get("title") == "BART"), None)
+        ac = next((g for g in groups if g.get("title") == "AC Transit"), None)
+        html = html.replace("{{BART_LEGEND}}", render_legend_groups([bart], faq_html) if bart else "")
+        html = html.replace("{{AC_LEGEND}}", render_legend_groups([ac], "") if ac else "")
+    else:
+        html = html.replace("{{BART_LEGEND}}", "")
+        html = html.replace("{{AC_LEGEND}}", "")
+    html = html.replace(TEMPLATE_PLACEHOLDERS["legend"], render_legend_items(lines))
+    html = html.replace(TEMPLATE_PLACEHOLDERS["faq"], faq_html)
+    html = html.replace(TEMPLATE_PLACEHOLDERS["directions"], render_directions(directions) if directions else "")
+    html = html.replace(TEMPLATE_PLACEHOLDERS["title"], title)
+    html = html.replace(TEMPLATE_PLACEHOLDERS["subtitle"], subtitle)
+
+    out_path = INSTALLS / name / "explainer.html"
+    out_path.write_text(html, encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/usermods/usermod_v2_departstrip/explainer/common/faq.md
+++ b/usermods/usermod_v2_departstrip/explainer/common/faq.md
@@ -1,0 +1,26 @@
+### What am I looking at?
+Each lit LED represents a scheduled departure. The color identifies
+the bus/train.  The top of strip shows transit arriving from the north
+and heading south.  The bottom of the strip shows transit arriving
+from the south and heading north.  The tape in the middle represents
+the point of departure.  The marks above and below the center mark
+show a good time to leave to catch a particular bus/train.
+
+Each minute the DepartStrip connects to the official transit feeds and
+updates the estimates.
+
+When multiple transit departure estimates converge the lights will
+alternate between each of their colors.
+
+### How do I connect it to my WiFi the first time (or move it to a new WiFi)?
+1. Plug the light controller into the wall power (it's not important if the lights are attached).
+2. Temporarily switch your phone's WiFi to the "WLED-AP" created by the controller.
+3. A form appears, enter your network name and password in the top fields and click "Save & Connect".
+4. Connect your phone back to your WiFi network (if it hasn't by itself already)
+
+From now on the controller should automatically reconnect when powered on.
+
+### How can I see and change the configuration?
+1. Install the "WLED Native" app on your phone.
+2. Open "WLED Native", choose your light strip from the menu.
+3. Choose "Config" -> "Usermods", scroll down to "DepartStrip" ...

--- a/usermods/usermod_v2_departstrip/explainer/common/faq_quick.md
+++ b/usermods/usermod_v2_departstrip/explainer/common/faq_quick.md
@@ -1,0 +1,16 @@
+### What am I looking at?
+Each lit LED represents a scheduled departure. The color identifies the bus/train.
+
+As buses/trains get closer to departure they move towards the center of the display.
+
+The tape marks above and below the center tape mark show a good time to leave to catch a particular bus/train.
+
+The top half of the display shows transit arriving from the north and heading south.
+
+The bottom half of the display  shows transit arriving from the south and heading north.
+
+The tape in the middle represents the point of departure.
+
+The DepartStrip connects to the official transit feeds and updates the estimates every minute.
+
+When multiple estimates are scheduled for the same time the lights will alternate between each of their colors.

--- a/usermods/usermod_v2_departstrip/explainer/common/template.html
+++ b/usermods/usermod_v2_departstrip/explainer/common/template.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DepartStrip — Explainer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    /* ====== PRINT + PAGE SETUP ======
+       Designed for LETTER (8.5in × 11in) one-sided.
+       Print at 100% scale with background graphics enabled.
+    */
+    @page { size: 8.5in 11in; margin: 0.2in 0.4in; }
+    @media print { .noprint { display: none !important; } }
+
+    :root {
+      --text: #111;
+      --muted: #555;
+      --rule: #ddd;
+      --bg: #fff;
+      --chip-radius: 12px;
+      --swatch-size: 28px;
+      --font: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+    }
+    html, body { background: var(--bg); color: var(--text); font-family: var(--font); }
+    .page { width: 8.5in; min-height: 11in; box-sizing: border-box; padding: 0.3in 0.4in 0.35in; display: flex; flex-direction: column; gap: 22px; }
+    .header { border-bottom: 1px solid var(--rule); padding-bottom: 10px; }
+    .title { font-weight: 700; letter-spacing: 0.2px; font-size: 1.6rem; }
+    .subtitle { color: var(--muted); font-size: 1rem; margin-top: 4px; }
+
+    .section { display: flex; flex-direction: column; gap: 18px; }
+    .section h2 { margin: 0; font-size: 1.3rem; font-weight: 700; }
+
+    /* ====== LEGEND LAYOUT ====== */
+    .legend-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(3.2in, 1fr)); gap: 12px; }
+    .legend-item { display: grid; grid-template-columns: auto 1fr; gap: 12px; align-items: center; padding: 8px 12px; border: 1px solid var(--rule); border-radius: var(--chip-radius); }
+    .swatch { width: var(--swatch-size); height: var(--swatch-size); border-radius: 8px; border: 1px solid rgba(0,0,0,0.15); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25); }
+    .label { font-weight: 600; font-size: 1rem; line-height: 1.1; }
+    .desc { color: var(--muted); font-size: 0.9rem; margin-top: 4px; }
+
+    /* ====== FAQ ====== */
+    .faq { display: grid; grid-template-columns: 1fr; gap: 12px; }
+    .qa { border: 1px solid var(--rule); border-radius: var(--chip-radius); padding: 10px 12px; }
+    .q { font-weight: 700; margin-bottom: 8px; font-size: 1rem; }
+    .a { color: var(--text); font-size: 0.95rem; line-height: 1.4; }
+
+    .footer { margin-top: auto; display: flex; justify-content: flex-end; align-items: center; color: var(--muted); font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+  <section class="page" aria-label="DepartStrip Explainer">
+    <header class="header">
+      <div>
+        <div class="title">{{TITLE}}</div>
+        <div class="subtitle">{{SUBTITLE}}</div>
+      </div>
+    </header>
+
+    <div class="section" aria-labelledby="legend-heading">
+      <h2 id="legend-heading">Line Colors</h2>
+      <div class="legend-grid" role="list">
+        {{LEGEND_ITEMS}}
+      </div>
+    </div>
+
+    <div class="section" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Quick FAQ</h2>
+      <div class="faq">
+        {{FAQ_BLOCKS}}
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/usermods/usermod_v2_departstrip/explainer/common/template_oakstop.html
+++ b/usermods/usermod_v2_departstrip/explainer/common/template_oakstop.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DepartStrip — Explainer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    @page { size: 8.5in 11in; margin: 0.2in 0.4in; }
+    @media print { .noprint { display: none !important; } }
+
+    :root {
+      --text: #111;
+      --muted: #555;
+      --rule: #ddd;
+      --bg: #fff;
+      --chip-radius: 12px;
+      --swatch-size: 28px;
+      --font: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+    }
+
+    html, body { background: var(--bg); color: var(--text); font-family: var(--font); }
+    .page { width: 8.5in; min-height: 11in; box-sizing: border-box; padding: 0.3in 0.4in 0.35in; display: flex; flex-direction: column; gap: 22px; }
+    .header { border-bottom: 1px solid var(--rule); padding-bottom: 10px; }
+    .title { font-weight: 700; letter-spacing: 0.2px; font-size: 1.6rem; }
+    .subtitle { color: var(--muted); font-size: 1rem; margin-top: 4px; }
+
+    .legend-split { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .legend-group { display: flex; flex-direction: column; gap: 12px; }
+    .legend-group.faq-append { justify-content: space-between; }
+    .legend-group h3 { margin: 0 0 8px; font-size: 1.2rem; font-weight: 700; letter-spacing: 0.3px; }
+    .legend-list { display: grid; grid-template-columns: 1fr; gap: 10px; }
+    .legend-item { display: grid; grid-template-columns: auto 1fr; gap: 12px; align-items: center; padding: 8px 12px; border: 1px solid var(--rule); border-radius: var(--chip-radius); }
+    .swatch { width: var(--swatch-size); height: var(--swatch-size); border-radius: 8px; border: 1px solid rgba(0,0,0,0.15); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25); }
+    .label { font-weight: 600; font-size: 1rem; line-height: 1.1; }
+    .desc { color: var(--muted); font-size: 0.9rem; margin-top: 4px; }
+
+    .section { display: flex; flex-direction: column; gap: 16px; }
+    .section h2 { margin: 0; font-size: 1.3rem; font-weight: 700; }
+
+    .legend-spacer { flex: 0 0 calc(var(--swatch-size) * 2 + 24px); }
+    .faq { display: grid; grid-template-columns: 1fr; gap: 12px; }
+    .legend-group.faq-append .faq-inline { margin-top: auto; padding-top: 12px; }
+    .faq-inline h3 { margin: 0 0 8px; font-size: 1.1rem; font-weight: 700; }
+    .qa { border: 1px solid var(--rule); border-radius: var(--chip-radius); padding: 10px 12px; }
+    .q { font-weight: 700; margin-bottom: 8px; font-size: 1rem; }
+    .a { color: var(--text); font-size: 0.95rem; line-height: 1.4; }
+  </style>
+</head>
+<body>
+  <section class="page" aria-label="DepartStrip Explainer">
+    <header class="header">
+      <div>
+        <div class="title">{{TITLE}}</div>
+        <div class="subtitle">{{SUBTITLE}}</div>
+      </div>
+    </header>
+
+    <div class="section">
+      <div class="legend-split">
+        {{BART_LEGEND}}
+        {{AC_LEGEND}}
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/usermods/usermod_v2_departstrip/explainer/common/template_temescal.html
+++ b/usermods/usermod_v2_departstrip/explainer/common/template_temescal.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>DepartStrip — Explainer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    @page { size: 8.5in 11in; margin: 0.15in; }
+    @media print { .noprint { display: none !important; } }
+
+    :root {
+      --text: #0f172a;
+      --muted: #52616c;
+      --rule: #d8dee6;
+      --bg: #ffffff;
+      --card: #f7f9fc;
+      --chip-radius: 12px;
+      --swatch-size: 28px;
+      --font: "Space Grotesk", "DM Sans", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    }
+
+    html, body { background: var(--bg); color: var(--text); font-family: var(--font); }
+    .page { max-width: 8.45in; min-height: 10.9in; box-sizing: border-box; padding: 0.5in 0.1in 0.24in; display: flex; flex-direction: column; gap: 12px; margin: 0 auto; width: 100%; }
+    .header { border-bottom: 1px solid var(--rule); padding-bottom: 10px; display: flex; flex-direction: column; gap: 6px; }
+    .title { font-weight: 800; letter-spacing: 0.3px; font-size: 1.7rem; }
+    .subtitle { color: var(--muted); font-size: 1rem; }
+    .hint { color: var(--muted); font-size: 0.92rem; }
+
+    .layout { display: grid; grid-template-columns: 1fr 1fr; gap: 54px; align-items: start; margin-top: 24px; }
+    @media (max-width: 960px) {
+      .layout { grid-template-columns: 1fr; }
+    }
+    @media print {
+      .layout { grid-template-columns: 1fr 1fr !important; gap: 54px !important; }
+    }
+
+    .faq-panel { display: flex; flex-direction: column; gap: 10px; break-inside: avoid; }
+    .faq-panel h2 { margin: 0; font-size: 1.05rem; font-weight: 800; letter-spacing: 0.3px; text-transform: uppercase; }
+    .faq { display: grid; grid-template-columns: 1fr; gap: 8px; }
+    .qa { border: 1px solid var(--rule); border-radius: var(--chip-radius); padding: 8px 10px; background: #fff; break-inside: avoid; }
+    .q { font-weight: 700; margin-bottom: 5px; font-size: 0.98rem; }
+    .a { color: var(--text); font-size: 0.93rem; line-height: 1.36; }
+
+    .directions { display: flex; flex-direction: column; gap: 14px; }
+    .direction { display: flex; flex-direction: column; gap: 10px; break-inside: avoid; page-break-inside: avoid; }
+    .direction + .direction { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--rule); }
+    .direction-heading { display: flex; align-items: baseline; gap: 8px; }
+    .direction-label { font-size: 1.1rem; letter-spacing: 0.6px; font-weight: 800; text-transform: uppercase; }
+
+    .stop-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(3.8in, 1fr)); gap: 8px; }
+    .stop-card { border: 1px solid var(--rule); border-radius: var(--chip-radius); background: var(--card); padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; break-inside: avoid; page-break-inside: avoid; }
+    .stop-header { display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
+    .stop-name { font-weight: 700; font-size: 0.95rem; letter-spacing: 0.05px; }
+    .stop-id { color: var(--muted); font-size: 0.93rem; white-space: nowrap; }
+
+    .route-list { display: grid; grid-template-columns: 1fr; gap: 6px; }
+    .route { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: center; padding: 6px 8px; border-radius: 10px; background: rgba(0,0,0,0.02); border: 1px solid rgba(0,0,0,0.04); }
+    .swatch { width: var(--swatch-size); height: var(--swatch-size); border-radius: 8px; border: 1px solid rgba(0,0,0,0.15); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.25); }
+    .route-body { display: flex; flex-direction: column; gap: 2px; }
+    .route-label { font-weight: 700; font-size: 0.98rem; letter-spacing: 0.2px; }
+    .route-desc { color: var(--muted); font-size: 0.92rem; }
+  </style>
+</head>
+<body>
+  <section class="page" aria-label="DepartStrip Explainer">
+    <header class="header">
+      <div>
+        <div class="title">{{TITLE}}</div>
+        <div class="subtitle">{{SUBTITLE}}</div>
+      </div>
+      <div class="hint">Southbound stops are listed first to match the strip orientation.</div>
+    </header>
+
+    <div class="layout">
+      <section class="faq-panel" aria-labelledby="faq-heading">
+        <h2 id="faq-heading">Quick FAQ</h2>
+        <div class="faq">
+{{FAQ_BLOCKS}}
+        </div>
+      </section>
+
+      <div class="directions" aria-label="Stops and routes">
+{{DIRECTIONS}}
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/usermods/usermod_v2_departstrip/explainer/installs/oakstop/legend.json
+++ b/usermods/usermod_v2_departstrip/explainer/installs/oakstop/legend.json
@@ -1,0 +1,188 @@
+{
+  "title": "DepartStrip",
+  "subtitle": "Live Transit Departures",
+  "template": "template_oakstop.html",
+  "faq": "faq_quick.md",
+  "groups": [
+    {
+      "title": "BART",
+      "appendFaq": true,
+      "class": "faq-append",
+      "lines": [
+        {
+          "label": "Red Line",
+          "desc": "Richmond \u2194 SF",
+          "hex": "#FF5959",
+          "group": "bart"
+        },
+        {
+          "label": "Orange Line",
+          "desc": "Richmond \u2194 Berryessa",
+          "hex": "#FFAC59",
+          "group": "bart"
+        },
+        {
+          "label": "Yellow Line",
+          "desc": "Antioch \u2194 SFO",
+          "hex": "#FFFF59",
+          "group": "bart"
+        }
+      ]
+    },
+    {
+      "title": "AC Transit",
+      "lines": [
+        {
+          "label": "6",
+          "desc": "Berkeley \u2194 Oakland",
+          "hex": "#2F72FF"
+        },
+        {
+          "label": "12",
+          "desc": "Jack London \u2194 Grand",
+          "hex": "#66D2FF"
+        },
+        {
+          "label": "18",
+          "desc": "Lake Merritt \u2194 Albany",
+          "hex": "#FF4C4C"
+        },
+        {
+          "label": "51A",
+          "desc": "Berkeley \u2194 Alameda",
+          "hex": "#FFC247"
+        },
+        {
+          "label": "72",
+          "desc": "San Pablo Rapid",
+          "hex": "#32FFA4"
+        },
+        {
+          "label": "72M",
+          "desc": "San Pablo \u21c6 Richmond",
+          "hex": "#C066FF"
+        },
+        {
+          "label": "88",
+          "desc": "Downtown Loop",
+          "hex": "#D6D6A0"
+        },
+        {
+          "label": "633",
+          "desc": "School Tripper",
+          "hex": "#D9D9D9"
+        },
+        {
+          "label": "651",
+          "desc": "School Tripper",
+          "hex": "#D9D9D9"
+        },
+        {
+          "label": "800",
+          "desc": "All-Nighter (SF)",
+          "hex": "#C4E8B2"
+        },
+        {
+          "label": "802",
+          "desc": "All-Nighter (Fruitvale)",
+          "hex": "#DFC4CA"
+        },
+        {
+          "label": "805",
+          "desc": "All-Nighter (Emeryville)",
+          "hex": "#FF8CDB"
+        },
+        {
+          "label": "851",
+          "desc": "Express (Marin)",
+          "hex": "#C1D7E1"
+        }
+      ]
+    }
+  ],
+  "lines": [
+    {
+      "label": "Red Line",
+      "desc": "Richmond \u2194 SF",
+      "hex": "#FF5959",
+      "group": "bart"
+    },
+    {
+      "label": "Orange Line",
+      "desc": "Richmond \u2194 Berryessa",
+      "hex": "#FFAC59",
+      "group": "bart"
+    },
+    {
+      "label": "Yellow Line",
+      "desc": "Antioch \u2194 SFO",
+      "hex": "#FFFF59",
+      "group": "bart"
+    },
+    {
+      "label": "6",
+      "desc": "Berkeley \u2194 Oakland",
+      "hex": "#2F72FF"
+    },
+    {
+      "label": "12",
+      "desc": "Jack London \u2194 Grand",
+      "hex": "#66D2FF"
+    },
+    {
+      "label": "18",
+      "desc": "Lake Merritt \u2194 Albany",
+      "hex": "#FF4C4C"
+    },
+    {
+      "label": "51A",
+      "desc": "Berkeley \u2194 Alameda",
+      "hex": "#FFC247"
+    },
+    {
+      "label": "72",
+      "desc": "San Pablo Rapid",
+      "hex": "#32FFA4"
+    },
+    {
+      "label": "72M",
+      "desc": "San Pablo \u21c6 Richmond",
+      "hex": "#C066FF"
+    },
+    {
+      "label": "88",
+      "desc": "Downtown Loop",
+      "hex": "#D6F0F5"
+    },
+    {
+      "label": "633",
+      "desc": "School Tripper",
+      "hex": "#D9D9D9"
+    },
+    {
+      "label": "651",
+      "desc": "School Tripper",
+      "hex": "#D9D9D9"
+    },
+    {
+      "label": "800",
+      "desc": "All-Nighter (SF)",
+      "hex": "C4E8B2"
+    },
+    {
+      "label": "802",
+      "desc": "All-Nighter (Fruitvale)",
+      "hex": "DFC4CA"
+    },
+    {
+      "label": "805",
+      "desc": "All-Nighter (Emeryville)",
+      "hex": "#FF8CDB"
+    },
+    {
+      "label": "851",
+      "desc": "Express (Marin)",
+      "hex": "#C1D7E1"
+    }
+  ]
+}

--- a/usermods/usermod_v2_departstrip/explainer/installs/spuyten/legend.json
+++ b/usermods/usermod_v2_departstrip/explainer/installs/spuyten/legend.json
@@ -1,0 +1,36 @@
+{
+  "title": "DepartStrip",
+  "lines": [
+    {
+      "label": "MNR 1 \u2022 Hudson Line",
+      "desc": "Green",
+      "hex": "#1CFF71"
+    },
+    {
+      "label": "BxM1 \u2022 Express",
+      "desc": "Yellow",
+      "hex": "#E8D08F"
+    },
+    {
+      "label": "BxM2 \u2022 Express",
+      "desc": "Red",
+      "hex": "#E26E6E"
+    },
+    {
+      "label": "BxM18 \u2022 Express",
+      "desc": "Purple",
+      "hex": "#B2A3D9"
+    },
+    {
+      "label": "Bx10 \u2022 Local",
+      "desc": "Light blue",
+      "hex": "#A2BCD9"
+    },
+    {
+      "label": "Bx20 \u2022 Local",
+      "desc": "Cobalt blue",
+      "hex": "#8282D4"
+    }
+  ],
+  "subtitle": "Live Transit Departures"
+}

--- a/usermods/usermod_v2_departstrip/explainer/installs/temescal/legend.json
+++ b/usermods/usermod_v2_departstrip/explainer/installs/temescal/legend.json
@@ -1,0 +1,110 @@
+{
+  "title": "DepartStrip",
+  "subtitle": "55th St stops — live departures",
+  "template": "template_temescal.html",
+  "faq": "faq_quick.md",
+  "lines": [
+    {
+      "label": "6",
+      "desc": "Telegraph / Southbound & Northbound",
+      "hex": "#2F72FF"
+    },
+    {
+      "label": "12",
+      "desc": "MacArthur & MLK corridors",
+      "hex": "#66D2FF"
+    },
+    {
+      "label": "18",
+      "desc": "Shattuck & Lake Merritt",
+      "hex": "#FF4C4C"
+    },
+    {
+      "label": "88",
+      "desc": "Market St loop",
+      "hex": "#D6D6A0"
+    },
+    {
+      "label": "800",
+      "desc": "All-Nighter",
+      "hex": "#C4E8B2"
+    },
+    {
+      "label": "F",
+      "desc": "Transbay",
+      "hex": "#FF9A1A"
+    }
+  ],
+  "directions": [
+    {
+      "title": "Southbound",
+      "stops": [
+        {
+          "name": "Telegraph Ave. at 55th St.",
+          "id": "51851",
+          "routes": [
+            { "label": "#6", "desc": "to Downtown Oakland", "hex": "#2F72FF" },
+            { "label": "#800", "desc": "to San Francisco", "hex": "#C4E8B2" }
+          ]
+        },
+        {
+          "name": "Martin Luther King Jr Way & 55th St",
+          "id": "53773",
+          "routes": [
+            { "label": "#18", "desc": "to Montclair", "hex": "#FF4C4C" }
+          ]
+        },
+        {
+          "name": "55th St & Martin Luther King Jr Way",
+          "id": "50475",
+          "routes": [
+            { "label": "#12", "desc": "to Amtrak at Jack London Square", "hex": "#66D2FF" }
+          ]
+        },
+        {
+          "name": "Market St & 55th St",
+          "id": "57558",
+          "routes": [
+            { "label": "#88", "desc": "to Piedmont", "hex": "#D6D6A0" },
+            { "label": "#F", "desc": "to San Francisco", "hex": "#FF9A1A" }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Northbound",
+      "stops": [
+        {
+          "name": "Telegraph Av & 55th St",
+          "id": "53548",
+          "routes": [
+            { "label": "#6", "desc": "to Downtown Berkeley", "hex": "#2F72FF" },
+            { "label": "#800", "desc": "to Richmond BART", "hex": "#C4E8B2" }
+          ]
+        },
+        {
+          "name": "Martin Luther King Jr Way & 55th St",
+          "id": "50602",
+          "routes": [
+            { "label": "#12", "desc": "to Northwest Berkeley", "hex": "#66D2FF" }
+          ]
+        },
+        {
+          "name": "55th St & Martin Luther King Jr Way",
+          "id": "50475",
+          "routes": [
+            { "label": "#18", "desc": "to University Village, Albany", "hex": "#FF4C4C" }
+          ]
+        },
+        {
+          "name": "Market St & 55th St",
+          "id": "58118",
+          "routes": [
+            { "label": "#88", "desc": "to Downtown Berkeley", "hex": "#D6D6A0" },
+            { "label": "#F", "desc": "to U.C. Campus", "hex": "#FF9A1A" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/usermods/usermod_v2_departstrip/gtfsrt_source.cpp
+++ b/usermods/usermod_v2_departstrip/gtfsrt_source.cpp
@@ -1,0 +1,1286 @@
+#include "gtfsrt_source.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstddef>
+#include <memory>
+#include <limits>
+#include <string>
+#include <vector>
+#include <utility>
+#include <cstdio>
+#include <climits>
+
+#include <pb_decode.h>
+
+namespace {
+
+// Trim leading and trailing ASCII whitespace from a std::string.
+static void trimStringInPlace(std::string& s) {
+  size_t begin = 0;
+  while (begin < s.size() && std::isspace(static_cast<unsigned char>(s[begin]))) ++begin;
+  size_t end = s.size();
+  while (end > begin && std::isspace(static_cast<unsigned char>(s[end - 1]))) --end;
+  if (begin == 0 && end == s.size()) return;
+  s = s.substr(begin, end - begin);
+}
+
+// Lowercase a string (ASCII) for case-insensitive comparisons.
+static std::string toLowerCopy(const std::string& s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  return out;
+}
+
+struct StopMatchData {
+  std::string fullStd;
+  std::string fullLower;
+  std::string tailStd;
+  std::string tailLower;
+
+  bool empty() const {
+    return fullStd.empty() && tailStd.empty();
+  }
+};
+
+struct CandidateStopId {
+  std::string full;
+  std::string lower;
+  std::string tail;
+  std::string tailLower;
+
+  void clear() {
+    full.clear();
+    lower.clear();
+    tail.clear();
+    tailLower.clear();
+  }
+};
+
+static void populateMatchData(const String& agency, const String& token, StopMatchData& out) {
+  String trimmed = token;
+  trimmed.trim();
+  out.tailStd = std::string(trimmed.c_str());
+  trimStringInPlace(out.tailStd);
+  out.tailLower = toLowerCopy(out.tailStd);
+  if (agency.length() > 0 && out.tailStd.length() > 0) {
+    String full = agency + ':' + trimmed;
+    out.fullStd = std::string(full.c_str());
+    trimStringInPlace(out.fullStd);
+    out.fullLower = toLowerCopy(out.fullStd);
+  } else {
+    out.fullStd = out.tailStd;
+    out.fullLower = out.tailLower;
+  }
+}
+
+static bool buildCandidateStopId(const std::string& rawId, CandidateStopId& out) {
+  out.clear();
+  if (rawId.empty()) return false;
+  out.full = rawId;
+  trimStringInPlace(out.full);
+  if (out.full.empty()) return false;
+  out.lower = toLowerCopy(out.full);
+  size_t colon = out.full.find(':');
+  if (colon != std::string::npos && colon + 1 < out.full.size()) {
+    out.tail = out.full.substr(colon + 1);
+    trimStringInPlace(out.tail);
+    if (!out.tail.empty()) out.tailLower = toLowerCopy(out.tail);
+  }
+  return true;
+}
+
+static bool candidateMatches(const CandidateStopId& cand, const StopMatchData& match) {
+  if (match.empty()) return false;
+  if (!match.fullStd.empty() && (cand.full == match.fullStd || cand.lower == match.fullLower)) return true;
+  if (!match.tailStd.empty()) {
+    if (cand.full == match.tailStd || cand.lower == match.tailLower) return true;
+    if (!cand.tail.empty()) {
+      if (cand.tail == match.tailStd) return true;
+      if (!cand.tailLower.empty() && cand.tailLower == match.tailLower) return true;
+    }
+  }
+  return false;
+}
+
+struct ParseContext {
+  struct StopContext {
+    String stopCode;                // e.g. "900202"
+    StopMatchData primary;
+    StopMatchData destination;
+    bool hasDestination = false;
+    std::vector<DepartModel::Entry::Item> items;
+    bool lastStopSeqValid = false;
+    uint32_t lastStopSeq = 0;
+  };
+
+  String agency;
+  time_t now;
+  time_t apiTimestamp = 0;
+  size_t feedEntityCount = 0;
+  size_t tripUpdateCount = 0;
+  size_t tripUpdateMatched = 0;
+  size_t stopUpdatesTotal = 0;
+  size_t stopUpdatesMatched = 0;
+  size_t bytesRead = 0;
+  size_t logMatches = 0;
+  uint32_t lastStopSeq = 0;
+  bool lastStopSeqValid = false;
+  std::vector<StopContext> stops;
+
+  ParseContext(const String& agencyIn, const std::vector<String>& stopCodesIn, time_t nowIn)
+      : agency(agencyIn), now(nowIn) {
+    stops.reserve(stopCodesIn.empty() ? 1 : stopCodesIn.size());
+    if (stopCodesIn.empty()) {
+      StopContext sc;
+      sc.stopCode = String();
+      if (agency.length() > 0) {
+        String full = agency + ':';
+        sc.primary.fullStd = std::string(full.c_str());
+        trimStringInPlace(sc.primary.fullStd);
+        sc.primary.fullLower = toLowerCopy(sc.primary.fullStd);
+      }
+      sc.items.reserve(16);
+      stops.push_back(std::move(sc));
+    } else {
+      for (const String& raw : stopCodesIn) {
+        String trimmed = raw;
+        trimmed.trim();
+        int arrowPos = trimmed.indexOf(F("->"));
+        String baseToken = trimmed;
+        String destToken;
+        if (arrowPos >= 0) {
+          baseToken = trimmed.substring(0, arrowPos);
+          destToken = trimmed.substring(arrowPos + 2);
+        }
+        baseToken.trim();
+        destToken.trim();
+
+        StopContext sc;
+        if (destToken.length() > 0) {
+          sc.stopCode = baseToken;
+          sc.stopCode += F("->");
+          sc.stopCode += destToken;
+        } else {
+          sc.stopCode = baseToken;
+        }
+        populateMatchData(agency, baseToken, sc.primary);
+        if (destToken.length() > 0) {
+          populateMatchData(agency, destToken, sc.destination);
+          sc.hasDestination = !sc.destination.empty();
+        }
+        sc.items.reserve(16);
+        stops.push_back(std::move(sc));
+      }
+    }
+  }
+};
+
+struct TripAccumulator {
+  struct PendingStop {
+    int64_t epoch = 0;
+    bool hasSequence = false;
+    uint32_t stopSequence = 0;
+    int stopIndex = -1;
+    bool needsDestination = false;
+    bool destinationSatisfied = false;
+  };
+  struct TripInfo {
+    std::string routeId;
+    std::string tripId;
+  } trip;
+  static constexpr size_t kMaxPendingStops = 32;
+  PendingStop matches[kMaxPendingStops];
+  size_t matchCount = 0;
+  bool matchOverflow = false;
+  size_t totalStopUpdates = 0;
+  size_t matchedStopUpdates = 0;
+
+  bool addMatch(const PendingStop& pending) {
+    if (matchCount < kMaxPendingStops) {
+      matches[matchCount++] = pending;
+      return true;
+    }
+    matchOverflow = true;
+    return false;
+  }
+};
+
+struct HttpStreamState {
+  Stream* stream = nullptr;
+  ParseContext* ctx = nullptr;
+  bool limited = false;
+  size_t remaining = 0;
+  bool shortRead = false;
+};
+
+static size_t findMatchingStopIndexes(const CandidateStopId& cand,
+                                      const ParseContext& ctx,
+                                      int* out,
+                                      size_t maxOut,
+                                      bool& overflowed) {
+  overflowed = false;
+  if (!out || maxOut == 0) return 0;
+  size_t count = 0;
+  for (size_t i = 0; i < ctx.stops.size(); ++i) {
+    const auto& stop = ctx.stops[i];
+    if (!candidateMatches(cand, stop.primary)) continue;
+    if (count < maxOut) {
+      out[count++] = static_cast<int>(i);
+    } else {
+      overflowed = true;
+      break;
+    }
+  }
+  return count;
+}
+
+static bool destinationSatisfied(const TripAccumulator::PendingStop& pending) {
+  if (!pending.needsDestination) return true;
+  return pending.destinationSatisfied;
+}
+
+static void splitStopCodes(const String& input, std::vector<String>& out) {
+  out.clear();
+  String normalized = input;
+  normalized.replace(';', ',');
+  normalized.replace(' ', ',');
+  normalized.replace('\t', ',');
+  int start = 0;
+  int len = normalized.length();
+  while (start < len) {
+    int comma = normalized.indexOf(',', start);
+    String token = (comma >= 0) ? normalized.substring(start, comma) : normalized.substring(start);
+    token.trim();
+    if (token.length() > 0) out.push_back(token);
+    if (comma < 0) break;
+    start = comma + 1;
+  }
+}
+
+static bool streamRead(pb_istream_t* stream, pb_byte_t* buf, size_t count) {
+  if (!stream || !stream->state) return false;
+  HttpStreamState* state = static_cast<HttpStreamState*>(stream->state);
+  if (!state || !state->stream) return false;
+  if (state->limited && count > state->remaining) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT stream requested %u beyond remaining %u\n",
+                 (unsigned)count,
+                 (unsigned)state->remaining);
+    stream->bytes_left = 0;
+    return false;
+  }
+  size_t total = 0;
+  while (total < count) {
+    size_t n = state->stream->readBytes(reinterpret_cast<char*>(buf) + total, count - total);
+    if (n == 0) {
+      if (!state->shortRead) {
+        state->shortRead = true;
+        DEBUG_PRINTF("DepartStrip: GTFS-RT stream short read after %u bytes (need %u more)\n",
+                     (unsigned)total,
+                     (unsigned)(count - total));
+      }
+      if (state->limited) {
+        state->remaining = 0;
+        stream->bytes_left = 0;
+      }
+      return false;
+    }
+    total += n;
+    if (state->ctx) state->ctx->bytesRead += n;
+    if (state->limited && state->remaining >= n) state->remaining -= n;
+  }
+  return true;
+}
+
+static bool readStringToStd(pb_istream_t* stream, std::string& out) {
+  out.clear();
+  size_t remaining = stream->bytes_left;
+  if (remaining == 0) return true;
+  out.reserve(out.size() + remaining);
+  uint8_t buffer[64];
+  while (stream->bytes_left > 0) {
+    size_t take = stream->bytes_left;
+    if (take > sizeof(buffer)) take = sizeof(buffer);
+    if (!pb_read(stream, buffer, take)) return false;
+    out.append(reinterpret_cast<const char*>(buffer), take);
+  }
+  return true;
+}
+
+static bool decodeStopTimeEvent(pb_istream_t* stream, int64_t& outTime, bool& hasTime) {
+  outTime = 0;
+  hasTime = false;
+  int64_t scheduledTime = 0;
+  bool hasScheduled = false;
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    switch (tag) {
+      case 2: { // time
+        if (wireType != PB_WT_VARINT) {
+          DEBUG_PRINTF("DepartStrip: GTFS-RT StopTimeEvent unexpected wireType %u for time\n", wireType);
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        uint64_t raw = 0;
+        if (!pb_decode_varint(stream, &raw)) return false;
+        outTime = static_cast<int64_t>(raw);
+        hasTime = true;
+        break;
+      }
+      case 4: { // scheduled_time (experimental)
+        if (wireType != PB_WT_VARINT) {
+          DEBUG_PRINTF("DepartStrip: GTFS-RT StopTimeEvent unexpected wireType %u for scheduled_time\n", wireType);
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        uint64_t raw = 0;
+        if (!pb_decode_varint(stream, &raw)) return false;
+        scheduledTime = static_cast<int64_t>(raw);
+        hasScheduled = true;
+        break;
+      }
+      default:
+        if (!pb_skip_field(stream, wireType)) return false;
+        break;
+    }
+  }
+  if (!eof) {
+    DEBUG_PRINTLN(F("DepartStrip: GTFS-RT StopTimeEvent missing EOF"));
+    return false;
+  }
+  if (!hasTime && hasScheduled) {
+    outTime = scheduledTime;
+    hasTime = true;
+  }
+  return true;
+}
+
+static bool decodeStopTimeProperties(pb_istream_t* stream, std::string& assignedStopId) {
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    if (tag == 1 && wireType == PB_WT_STRING) {
+      pb_istream_t sub;
+      if (!pb_make_string_substream(stream, &sub)) return false;
+      bool ok = readStringToStd(&sub, assignedStopId);
+      pb_close_string_substream(stream, &sub);
+      if (!ok) return false;
+    } else {
+      if (!pb_skip_field(stream, wireType)) return false;
+    }
+  }
+  return eof;
+}
+
+static bool decodeStopTimeUpdate(pb_istream_t* stream, TripAccumulator& accum, ParseContext& ctx) {
+  uint32_t stopSequence = 0;
+  bool hasStopSequence = false;
+  std::string stopId;
+  int64_t arrivalTime = 0;
+  bool hasArrival = false;
+  int64_t departureTime = 0;
+  bool hasDeparture = false;
+  int scheduleRelationship = 0; // SCHEDULED by default
+
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    switch (tag) {
+      case 1: { // stop_sequence
+        if (wireType != PB_WT_VARINT) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        uint64_t raw = 0;
+        if (!pb_decode_varint(stream, &raw)) return false;
+        stopSequence = static_cast<uint32_t>(raw);
+        hasStopSequence = true;
+        break;
+      }
+      case 4: { // stop_id
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open stop_id substream"));
+          return false;
+        }
+        bool ok = readStringToStd(&sub, stopId);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        // if (ctx.stopUpdatesTotal < 5) {
+        //   DEBUG_PRINTF("DepartStrip: GTFS-RT raw stop_id='%s'\n", stopId.c_str());
+        // }
+        break;
+      }
+      case 2: { // arrival
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open arrival substream"));
+          return false;
+        }
+        bool ok = decodeStopTimeEvent(&sub, arrivalTime, hasArrival);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        if (!hasArrival) DEBUG_PRINTLN(F("DepartStrip: GTFS-RT arrival missing time"));
+        break;
+      }
+      case 3: { // departure
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open departure substream"));
+          return false;
+        }
+        bool ok = decodeStopTimeEvent(&sub, departureTime, hasDeparture);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        if (!hasDeparture) DEBUG_PRINTLN(F("DepartStrip: GTFS-RT departure missing time"));
+        break;
+      }
+      case 5: { // schedule relationship
+        if (wireType != PB_WT_VARINT) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        uint64_t raw = 0;
+        if (!pb_decode_varint(stream, &raw)) return false;
+        scheduleRelationship = static_cast<int>(raw);
+        break;
+      }
+      case 6: { // StopTimeProperties (assigned_stop_id)
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open StopTimeProperties substream"));
+          return false;
+        }
+        std::string assigned;
+        bool ok = decodeStopTimeProperties(&sub, assigned);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        if (stopId.empty() && !assigned.empty()) stopId = assigned;
+        break;
+      }
+      default:
+        if (!pb_skip_field(stream, wireType)) return false;
+        break;
+    }
+  }
+  if (!eof) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT StopTimeUpdate missing EOF (stopUpdates=%u)\n",
+                 (unsigned)ctx.stopUpdatesTotal);
+    return false;
+  }
+
+  ctx.stopUpdatesTotal++;
+  accum.totalStopUpdates++;
+  if ((ctx.stopUpdatesTotal & 0xF) == 0) yield();
+
+  // Skip SKIPPED or NO_DATA updates.
+  if (scheduleRelationship == 1 || scheduleRelationship == 2) {
+    if (ctx.stopUpdatesTotal <= 5) {
+      DEBUG_PRINTLN(F("DepartStrip: GTFS-RT stop skipped/no-data"));
+    }
+    return true;
+  }
+
+  int64_t chosen = 0;
+  if (hasDeparture) chosen = departureTime;
+  else if (hasArrival) chosen = arrivalTime;
+
+  if (chosen <= 0) {
+    if (ctx.stopUpdatesTotal <= 5) {
+      DEBUG_PRINTF("DepartStrip: GTFS-RT stop had no usable time (stopId='%s')\n", stopId.c_str());
+    }
+    return true;
+  }
+
+  if (stopId.empty()) {
+    if (ctx.stopUpdatesTotal <= 5) {
+      DEBUG_PRINTLN(F("DepartStrip: GTFS-RT stop missing stop_id"));
+    }
+    return true;
+  }
+
+  trimStringInPlace(stopId);
+  CandidateStopId cand;
+  if (!buildCandidateStopId(stopId, cand)) return true;
+
+  constexpr size_t kMaxStopMatches = 8;
+  int matchingIndexes[kMaxStopMatches];
+  bool matchOverflow = false;
+  size_t matchCount = findMatchingStopIndexes(cand, ctx, matchingIndexes, kMaxStopMatches, matchOverflow);
+  if (matchOverflow && ctx.stopUpdatesTotal <= 5) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT stop_id '%s' matched more than %u stops; truncating list\n",
+                 stopId.c_str(),
+                 (unsigned)kMaxStopMatches);
+  }
+  if (matchCount == 0) {
+    // if (ctx.stopUpdatesTotal <= 5 || (ctx.stopUpdatesTotal % 200) == 0) {
+    //   DEBUG_PRINTF("DepartStrip: GTFS-RT stop_id '%s' ignored\n", stopId.c_str());
+    // }
+    // Even if no base stop matches, this stop might satisfy a destination.
+  } else {
+    for (size_t idx = 0; idx < matchCount; ++idx) {
+      int stopIndex = matchingIndexes[idx];
+      if (stopIndex < 0) continue;
+      TripAccumulator::PendingStop pending;
+      pending.epoch = chosen;
+      pending.hasSequence = hasStopSequence;
+      pending.stopSequence = stopSequence;
+      pending.stopIndex = stopIndex;
+      pending.needsDestination = ctx.stops[stopIndex].hasDestination;
+      pending.destinationSatisfied = !pending.needsDestination;
+      bool overflowedBefore = accum.matchOverflow;
+      bool stored = accum.addMatch(pending);
+      accum.matchedStopUpdates++;
+      if (!stored && !overflowedBefore && ctx.stopUpdatesTotal <= 5) {
+        DEBUG_PRINTF("DepartStrip: GTFS-RT TripAccumulator pending buffer full (max=%u)\n",
+                     (unsigned)TripAccumulator::kMaxPendingStops);
+      }
+      if (hasStopSequence && (size_t)stopIndex < ctx.stops.size()) {
+        ctx.stops[stopIndex].lastStopSeqValid = true;
+        ctx.stops[stopIndex].lastStopSeq = stopSequence;
+      }
+    }
+  }
+
+  for (size_t idx = 0; idx < accum.matchCount; ++idx) {
+    auto& pending = accum.matches[idx];
+    if (!pending.needsDestination || pending.destinationSatisfied) continue;
+    if (pending.stopIndex < 0 || (size_t)pending.stopIndex >= ctx.stops.size()) continue;
+    const auto& stopCtx = ctx.stops[pending.stopIndex];
+    if (stopCtx.destination.empty()) {
+      pending.destinationSatisfied = true;
+      continue;
+    }
+    if (candidateMatches(cand, stopCtx.destination)) pending.destinationSatisfied = true;
+  }
+
+  ctx.lastStopSeqValid = hasStopSequence;
+  ctx.lastStopSeq = stopSequence;
+  return true;
+}
+
+static bool decodeTripDescriptor(pb_istream_t* stream, TripAccumulator& accum, ParseContext& ctx) {
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    switch (tag) {
+      case 1: { // trip_id
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTF("DepartStrip: GTFS-RT TripDescriptor failed substream (tag=%u)\n", tag);
+          return false;
+        }
+        bool ok = readStringToStd(&sub, accum.trip.tripId);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        //if (accum.trip.tripId.size() && ctx.tripUpdateCount <= 5) {
+        //  DEBUG_PRINTF("DepartStrip: GTFS-RT TripDescriptor trip_id='%s'\n", accum.trip.tripId.c_str());
+        //}
+        break;
+      }
+      case 5: { // route_id
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTF("DepartStrip: GTFS-RT TripDescriptor failed substream (route tag=%u)\n", tag);
+          return false;
+        }
+        bool ok = readStringToStd(&sub, accum.trip.routeId);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        //if (accum.trip.routeId.size() && ctx.tripUpdateCount <= 5) {
+        //  DEBUG_PRINTF("DepartStrip: GTFS-RT TripDescriptor route_id='%s'\n", accum.trip.routeId.c_str());
+        //}
+        break;
+      }
+      default:
+        if (!pb_skip_field(stream, wireType)) return false;
+        break;
+    }
+  }
+  if (!eof) {
+    DEBUG_PRINTLN(F("DepartStrip: GTFS-RT TripDescriptor missing EOF"));
+    return false;
+  }
+  return true;
+}
+
+static time_t clampToTimeT(int64_t value) {
+  if (value <= 0) return 0;
+  const int64_t maxT = static_cast<int64_t>(std::numeric_limits<time_t>::max());
+  if (value > maxT) return static_cast<time_t>(maxT);
+  return static_cast<time_t>(value);
+}
+
+static size_t flushTripAccumulator(TripAccumulator& accum, ParseContext& ctx) {
+  if (accum.matchCount == 0) return 0;
+  //DEBUG_PRINTF("DepartStrip: GTFS-RT flushing %u pending matches (route='%s' trip='%s')\n",
+  //             (unsigned)accum.matchCount,
+  //             accum.trip.routeId.c_str(),
+  //             accum.trip.tripId.c_str());
+  String lineRef;
+  if (!accum.trip.routeId.empty()) lineRef = accum.trip.routeId.c_str();
+  else if (!accum.trip.tripId.empty()) lineRef = accum.trip.tripId.c_str();
+  if (lineRef.length() == 0) lineRef = F("?");
+
+  size_t added = 0;
+  for (size_t idx = 0; idx < accum.matchCount; ++idx) {
+    const auto& pending = accum.matches[idx];
+    if ((added & 0x3) == 0) yield();
+    if (pending.stopIndex < 0 || (size_t)pending.stopIndex >= ctx.stops.size()) continue;
+    auto& stopCtx = ctx.stops[pending.stopIndex];
+    if (!destinationSatisfied(pending)) continue;
+    time_t dep = clampToTimeT(pending.epoch);
+    if (dep == 0) continue;
+    if (ctx.now > 0 && dep + 3600 < ctx.now) continue;
+    DepartModel::Entry::Item item;
+    item.estDep = dep;
+    item.lineRef = departstrip::util::formatLineLabel(ctx.agency, lineRef);
+    stopCtx.items.push_back(std::move(item));
+    const DepartModel::Entry::Item& pushed = stopCtx.items.back();
+    ctx.stopUpdatesMatched++;
+    ++added;
+    if (ctx.logMatches < 6) {
+      char timeBuf[24];
+      departstrip::util::fmt_local(timeBuf, sizeof(timeBuf), pushed.estDep, "%H:%M:%S");
+      char seqBuf[12];
+      if (pending.hasSequence) snprintf(seqBuf, sizeof(seqBuf), "%u", (unsigned)pending.stopSequence);
+      else { seqBuf[0] = '?'; seqBuf[1] = '\0'; }
+      //DEBUG_PRINTF("DepartStrip: GTFS-RT match #%u: line='%s' dep=%s seq=%s (stop=%s)\n",
+      //             (unsigned)(ctx.logMatches + 1),
+      //             pushed.lineRef.c_str(),
+      //             timeBuf,
+      //             seqBuf,
+      //             stopCtx.stopCode.c_str());
+      ctx.logMatches++;
+    }
+  }
+  return added;
+}
+
+static bool decodeTripUpdate(pb_istream_t* stream, ParseContext& ctx) {
+  TripAccumulator accum;
+  uint64_t tripTimestamp = 0;
+  ctx.tripUpdateCount++;
+  //DEBUG_PRINTF("DepartStrip: GTFS-RT decoding TripUpdate #%u (matched=%u)\n",
+  //             (unsigned)ctx.tripUpdateCount,
+  //             (unsigned)ctx.tripUpdateMatched);
+
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    switch (tag) {
+      case 1: { // TripDescriptor
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open TripDescriptor substream"));
+          return false;
+        }
+        bool ok = decodeTripDescriptor(&sub, accum, ctx);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        break;
+      }
+      case 2: { // StopTimeUpdate
+        if (wireType != PB_WT_STRING) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        pb_istream_t sub;
+        if (!pb_make_string_substream(stream, &sub)) {
+          DEBUG_PRINTLN(F("DepartStrip: GTFS-RT failed to open StopTimeUpdate substream"));
+          return false;
+        }
+        bool ok = decodeStopTimeUpdate(&sub, accum, ctx);
+        pb_close_string_substream(stream, &sub);
+        if (!ok) return false;
+        break;
+      }
+      case 4: { // timestamp
+        if (wireType != PB_WT_VARINT) {
+          if (!pb_skip_field(stream, wireType)) return false;
+          break;
+        }
+        uint64_t raw = 0;
+        if (!pb_decode_varint(stream, &raw)) return false;
+        if (raw > tripTimestamp) tripTimestamp = raw;
+        break;
+      }
+      default:
+        if (!pb_skip_field(stream, wireType)) return false;
+        break;
+    }
+  }
+  if (!eof) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT TripUpdate missing EOF after %u stopUpdates\n",
+                 (unsigned)accum.totalStopUpdates);
+    return false;
+  }
+
+  if (tripTimestamp > 0) {
+    time_t t = clampToTimeT(static_cast<int64_t>(tripTimestamp));
+    if (t > ctx.apiTimestamp) ctx.apiTimestamp = t;
+  }
+
+  size_t added = flushTripAccumulator(accum, ctx);
+  if (added > 0) {
+    ctx.tripUpdateMatched++;
+    //DEBUG_PRINTF("DepartStrip: GTFS-RT trip matched route='%s' trip='%s' stopUpdates=%u matchedStops=%u added=%u\n",
+    //             accum.trip.routeId.c_str(),
+    //             accum.trip.tripId.c_str(),
+    //             (unsigned)accum.totalStopUpdates,
+    //             (unsigned)accum.matchedStopUpdates,
+    //             (unsigned)added);
+  } else if (ctx.tripUpdateCount <= 5 || (ctx.tripUpdateCount % 50 == 0)) {
+    //const char* route = accum.trip.routeId.empty() ? "" : accum.trip.routeId.c_str();
+    //const char* trip = accum.trip.tripId.empty() ? "" : accum.trip.tripId.c_str();
+    //DEBUG_PRINTF("DepartStrip: GTFS-RT trip had no matching stops (route='%s' trip='%s' stopUpdates=%u)\n",
+    //             route,
+    //             trip,
+    //             (unsigned)accum.totalStopUpdates);
+  }
+  //DEBUG_PRINTF("DepartStrip: GTFS-RT TripUpdate #%u finished added=%u matchedTrips=%u\n",
+  //             (unsigned)ctx.tripUpdateCount,
+  //             (unsigned)added,
+  //             (unsigned)ctx.tripUpdateMatched);
+  //DEBUG_PRINTLN(F("DepartStrip: GTFS-RT TripUpdate exit"));
+  return true;
+}
+
+static bool decodeFeedEntity(pb_istream_t* stream, ParseContext& ctx) {
+  ctx.feedEntityCount++;
+  //DEBUG_PRINTF("DepartStrip: GTFS-RT decoding FeedEntity #%u\n", (unsigned)ctx.feedEntityCount);
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    if (tag == 3 && wireType == PB_WT_STRING) { // trip_update
+      pb_istream_t sub;
+      if (!pb_make_string_substream(stream, &sub)) return false;
+      bool ok = decodeTripUpdate(&sub, ctx);
+      pb_close_string_substream(stream, &sub);
+      if (!ok) return false;
+    } else {
+      if (!pb_skip_field(stream, wireType)) return false;
+    }
+  }
+  if (!eof) {
+    DEBUG_PRINTLN(F("DepartStrip: GTFS-RT FeedEntity missing EOF"));
+    return false;
+  }
+  //DEBUG_PRINTF("DepartStrip: GTFS-RT FeedEntity #%u done tripUpdates=%u matchedTrips=%u\n",
+  //             (unsigned)ctx.feedEntityCount,
+  //             (unsigned)ctx.tripUpdateCount,
+  //             (unsigned)ctx.tripUpdateMatched);
+  return true;
+}
+
+static bool decodeFeedHeader(pb_istream_t* stream, ParseContext& ctx) {
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    if (tag == 3 && wireType == PB_WT_VARINT) { // timestamp
+      uint64_t raw = 0;
+      if (!pb_decode_varint(stream, &raw)) return false;
+      time_t t = clampToTimeT(static_cast<int64_t>(raw));
+      if (t > ctx.apiTimestamp) ctx.apiTimestamp = t;
+      if (raw > 0 && ctx.feedEntityCount == 0 && ctx.tripUpdateCount == 0) {
+        char tsBuf[24];
+        departstrip::util::fmt_local(tsBuf, sizeof(tsBuf), ctx.apiTimestamp, "%H:%M:%S");
+        DEBUG_PRINTF("DepartStrip: GTFS-RT header timestamp %s\n", tsBuf);
+      }
+    } else {
+      if (!pb_skip_field(stream, wireType)) return false;
+    }
+  }
+  return eof;
+}
+
+static bool decodeFeedMessage(pb_istream_t* stream, ParseContext& ctx) {
+  pb_wire_type_t wireType;
+  uint32_t tag;
+  bool eof = false;
+  bool sawHeader = false;
+  while (pb_decode_tag(stream, &wireType, &tag, &eof)) {
+    if (tag == 1 && wireType == PB_WT_STRING) {
+      pb_istream_t sub;
+      if (!pb_make_string_substream(stream, &sub)) return false;
+      bool ok = decodeFeedHeader(&sub, ctx);
+      pb_close_string_substream(stream, &sub);
+      if (!ok) return false;
+      sawHeader = true;
+    } else if (tag == 2 && wireType == PB_WT_STRING) {
+      pb_istream_t sub;
+      if (!pb_make_string_substream(stream, &sub)) return false;
+      bool ok = decodeFeedEntity(&sub, ctx);
+      pb_close_string_substream(stream, &sub);
+      if (!ok) return false;
+    } else {
+      if (!pb_skip_field(stream, wireType)) return false;
+    }
+  }
+  if (!sawHeader) {
+    DEBUG_PRINTLN(F("DepartStrip: GTFS-RT feed missing header"));
+  }
+  if (!eof) {
+    DEBUG_PRINTLN(F("DepartStrip: GTFS-RT FeedMessage missing EOF"));
+  }
+  return eof && sawHeader;
+}
+
+static bool parseGtfsRtStream(Stream& body, size_t contentLength, ParseContext& ctx, const char** errOut) {
+  HttpStreamState state;
+  state.stream = &body;
+  state.ctx = &ctx;
+  if (contentLength > 0) {
+    state.limited = true;
+    state.remaining = contentLength;
+  }
+  pb_istream_t istream = {streamRead, &state, contentLength > 0 ? contentLength : PB_SIZE_MAX};
+#ifndef PB_NO_ERRMSG
+  istream.errmsg = nullptr;
+#endif
+  ctx.bytesRead = 0;
+  bool ok = decodeFeedMessage(&istream, ctx);
+  if (errOut) {
+#ifndef PB_NO_ERRMSG
+    *errOut = ok ? nullptr : istream.errmsg;
+#else
+    *errOut = ok ? nullptr : "decode error";
+#endif
+  }
+  if (state.shortRead) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT stream short read flagged bytes=%u remaining=%u\n",
+                 (unsigned)ctx.bytesRead,
+                 (unsigned)state.remaining);
+  }
+  if (state.limited && state.remaining > 0) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT stream finished with %u bytes remaining\n",
+                 (unsigned)state.remaining);
+  }
+  if (!ok) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT decodeFeedMessage returned false after feedEntities=%u tripUpdates=%u\n",
+                 (unsigned)ctx.feedEntityCount,
+                 (unsigned)ctx.tripUpdateCount);
+  }
+  return ok;
+}
+
+} // namespace
+
+GtfsRtSource::GtfsRtSource(const char* key) {
+  if (key && *key) configKey_ = key;
+}
+
+std::unique_ptr<DepartModel> GtfsRtSource::fetch(std::time_t now) {
+  if (!enabled_ || now == 0) return nullptr;
+  if (now < nextFetch_) {
+    uint32_t interval = updateSecs_ > 0 ? updateSecs_ : 60;
+    if (lastBackoffLog_ == 0 || now - lastBackoffLog_ >= interval) {
+      lastBackoffLog_ = now;
+      long rem = (long)(nextFetch_ - now);
+      if (rem < 0) rem = 0;
+      if (backoffMult_ > 1) {
+        DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: backoff x%u %s, next in %lds\n",
+                     (unsigned)backoffMult_, sourceKey().c_str(), rem);
+      } else {
+        DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: waiting %s, next in %lds\n",
+                     sourceKey().c_str(), rem);
+      }
+    }
+    return nullptr;
+  }
+
+  String firstStop = stopCodes_.empty() ? String() : stopCodes_[0];
+  String url = composeUrl(agency_, firstStop);
+  String redacted = url;
+  auto redactParam = [&](const __FlashStringHelper* key) {
+    String k(key);
+    int idx = redacted.indexOf(k);
+    if (idx >= 0) {
+      int valStart = idx + k.length();
+      int valEnd = redacted.indexOf('&', valStart);
+      if (valEnd < 0) valEnd = redacted.length();
+      redacted = redacted.substring(0, valStart) + F("REDACTED") + redacted.substring(valEnd);
+    }
+  };
+  redactParam(F("api_key="));
+  redactParam(F("apikey="));
+  redactParam(F("key="));
+  DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: URL: %s\n", redacted.c_str());
+
+  int contentLen = 0;
+  int httpStatus = 0;
+  HTTPClient http;
+  bool usedSecure = false;
+  if (!httpBegin(url, contentLen, httpStatus, http, usedSecure)) {
+    long delay = (long)updateSecs_ * (long)backoffMult_;
+    DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: scheduling backoff x%u %s for %lds (HTTP error)\n",
+                 (unsigned)backoffMult_, sourceKey().c_str(), delay);
+    nextFetch_ = now + delay;
+    if (backoffMult_ < 16) backoffMult_ *= 2;
+    return nullptr;
+  }
+
+  String ctype = http.header("Content-Type");
+  String clen = http.header("Content-Length");
+  String cenc = http.header("Content-Encoding");
+  String tenc = http.header("Transfer-Encoding");
+  String rateRemain = http.header("RateLimit-Remaining");
+  if (rateRemain.length() > 0) {
+    DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: RateLimit-Remaining=%s\n", rateRemain.c_str());
+  }
+
+  DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: status=%d type='%s' lenHint=%d contentLengthHdr=%s encoding='%s' transfer='%s'\n",
+               httpStatus,
+               ctype.c_str(),
+               contentLen,
+               clen.c_str(),
+               cenc.c_str(),
+               tenc.c_str());
+  ParseContext ctx(agency_, stopCodes_, now);
+  const char* decodeErr = nullptr;
+  bool parsed = false;
+
+  Stream& body = http.getStream();
+  size_t streamLen = (contentLen > 0) ? (size_t)contentLen : 0;
+  parsed = parseGtfsRtStream(body, streamLen, ctx, &decodeErr);
+
+  closeHttpClient(http, usedSecure);
+
+  nextFetch_ = now + updateSecs_;
+  backoffMult_ = 1;
+  lastBackoffLog_ = 0;
+
+  if (!parsed) {
+    DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: protobuf decode failed (%s) bytes=%u feedEntities=%u tripUpdates=%u stopUpdates=%u\n",
+                 decodeErr ? decodeErr : "unknown error",
+                 (unsigned)ctx.bytesRead,
+                 (unsigned)ctx.feedEntityCount,
+                 (unsigned)ctx.tripUpdateCount,
+                 (unsigned)ctx.stopUpdatesTotal);
+    return nullptr;
+  }
+
+  DEBUG_PRINTF("DepartStrip: GTFS-RT decode complete bytes=%u feedEntities=%u tripUpdates=%u matchedTrips=%u stopUpdates=%u matchedStopUpdates=%u\n",
+               (unsigned)ctx.bytesRead,
+               (unsigned)ctx.feedEntityCount,
+               (unsigned)ctx.tripUpdateCount,
+               (unsigned)ctx.tripUpdateMatched,
+               (unsigned)ctx.stopUpdatesTotal,
+               (unsigned)ctx.stopUpdatesMatched);
+  if (ctx.lastStopSeqValid) {
+    DEBUG_PRINTF("DepartStrip: GTFS-RT last matched stop sequence=%u\n", (unsigned)ctx.lastStopSeq);
+  }
+
+  //DEBUG_PRINTLN(F("DepartStrip: GTFS-RT building board"));
+
+  const size_t MAX_ITEMS = 24;
+  size_t totalItems = 0;
+
+  std::unique_ptr<DepartModel> model(new DepartModel());
+  model->boards.reserve(ctx.stops.size());
+
+  for (auto& stopCtx : ctx.stops) {
+    auto& items = stopCtx.items;
+    if (items.empty()) continue;
+    std::sort(items.begin(), items.end(), [](const DepartModel::Entry::Item& a, const DepartModel::Entry::Item& b) {
+      if (a.estDep != b.estDep) return a.estDep < b.estDep;
+      return a.lineRef.compareTo(b.lineRef) < 0;
+    });
+    items.erase(std::unique(items.begin(), items.end(), [](const DepartModel::Entry::Item& a, const DepartModel::Entry::Item& b) {
+      return a.estDep == b.estDep && a.lineRef == b.lineRef;
+    }), items.end());
+    if (items.size() > MAX_ITEMS) {
+      items.resize(MAX_ITEMS);
+    }
+
+    DepartModel::Entry board;
+    board.key.reserve(agency_.length() + 1 + stopCtx.stopCode.length());
+    board.key = agency_;
+    board.key += ':';
+    board.key += stopCtx.stopCode;
+    board.batch.apiTs = ctx.apiTimestamp ? ctx.apiTimestamp : now;
+    if (board.batch.apiTs == 0) board.batch.apiTs = now;
+    board.batch.ourTs = now;
+    board.batch.items = std::move(items);
+    totalItems += board.batch.items.size();
+    model->boards.push_back(std::move(board));
+  }
+
+  if (model->boards.empty()) {
+    DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: no departures parsed (feedEntities=%u tripUpdates=%u stopUpdates=%u matched=%u bytes=%u)\n",
+                 (unsigned)ctx.feedEntityCount,
+                 (unsigned)ctx.tripUpdateCount,
+                 (unsigned)ctx.stopUpdatesTotal,
+                 (unsigned)ctx.stopUpdatesMatched,
+                 (unsigned)ctx.bytesRead);
+    return nullptr;
+  }
+
+  DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: parsed feedEntities=%u tripUpdates=%u matchedTrips=%u stopUpdates=%u matchedStopUpdates=%u bytes=%u items=%u boards=%u\n",
+               (unsigned)ctx.feedEntityCount,
+               (unsigned)ctx.tripUpdateCount,
+               (unsigned)ctx.tripUpdateMatched,
+               (unsigned)ctx.stopUpdatesTotal,
+               (unsigned)ctx.stopUpdatesMatched,
+               (unsigned)ctx.bytesRead,
+               (unsigned)totalItems,
+               (unsigned)model->boards.size());
+
+  return model;
+}
+
+void GtfsRtSource::reload(std::time_t now) {
+  nextFetch_ = now;
+  backoffMult_ = 1;
+  lastBackoffLog_ = 0;
+}
+
+String GtfsRtSource::sourceKey() const {
+  String k(agency_);
+  k += ':';
+  if (!stopCodes_.empty()) {
+    for (size_t i = 0; i < stopCodes_.size(); ++i) {
+      if (i > 0) k += ',';
+      k += stopCodes_[i];
+    }
+  }
+  return k;
+}
+
+void GtfsRtSource::addToConfig(JsonObject& root) {
+  root["Enabled"] = enabled_;
+  root["Type"] = F("gtfsrt");
+  root["UpdateSecs"] = updateSecs_;
+  root["TemplateUrl"] = baseUrl_;
+  root["ApiKey"] = apiKey_;
+  String key;
+  key = agency_;
+  key += ':';
+  if (!stopCodes_.empty()) {
+    for (size_t i = 0; i < stopCodes_.size(); ++i) {
+      if (i > 0) key += ',';
+      key += stopCodes_[i];
+    }
+  }
+  root["AgencyStopCode"] = key;
+}
+
+bool GtfsRtSource::readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) {
+  bool ok = true;
+  bool prevEnabled = enabled_;
+  String prevAgency = agency_;
+  std::vector<String> prevStops = stopCodes_;
+  String prevBase = baseUrl_;
+
+  ok &= getJsonValue(root["Enabled"], enabled_, enabled_);
+  ok &= getJsonValue(root["UpdateSecs"], updateSecs_, updateSecs_);
+  ok &= getJsonValue(root["TemplateUrl"], baseUrl_, baseUrl_);
+  ok &= getJsonValue(root["ApiKey"], apiKey_, apiKey_);
+
+  String keyStr;
+  std::vector<String> newStops = prevStops;
+  bool haveKey = getJsonValue(root["AgencyStopCode"], keyStr, (const char*)nullptr);
+  if (!haveKey) haveKey = getJsonValue(root["Key"], keyStr, (const char*)nullptr);
+  if (haveKey && keyStr.length() > 0) {
+    int colon = keyStr.indexOf(':');
+    if (colon > 0) {
+      agency_ = keyStr.substring(0, colon);
+      String list = keyStr.substring(colon + 1);
+      newStops.clear();
+      splitStopCodes(list, newStops);
+    }
+  } else {
+    ok &= getJsonValue(root["Agency"], agency_, agency_);
+    String stopField;
+    if (getJsonValue(root["StopCode"], stopField, (const char*)nullptr)) {
+      newStops.clear();
+      splitStopCodes(stopField, newStops);
+    }
+  }
+
+  stopCodes_ = std::move(newStops);
+  for (auto& sc : stopCodes_) {
+    sc.trim();
+    String base = sc;
+    String dest;
+    int arrowPos = sc.indexOf(F("->"));
+    if (arrowPos >= 0) {
+      base = sc.substring(0, arrowPos);
+      dest = sc.substring(arrowPos + 2);
+    }
+    base.trim();
+    dest.trim();
+    int colonBase = base.lastIndexOf(':');
+    if (colonBase >= 0) base = base.substring(colonBase + 1);
+    base.trim();
+    if (dest.length() > 0) {
+      int colonDest = dest.lastIndexOf(':');
+      if (colonDest >= 0) dest = dest.substring(colonDest + 1);
+      dest.trim();
+    }
+    if (dest.length() > 0) {
+      sc = base;
+      sc += F("->");
+      sc += dest;
+    } else {
+      sc = base;
+    }
+  }
+  if (stopCodes_.size() > 1) {
+    std::vector<String> unique;
+    unique.reserve(stopCodes_.size());
+    for (const auto& sc : stopCodes_) {
+      bool exists = false;
+      for (const auto& us : unique) {
+        if (us.equalsIgnoreCase(sc)) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists) unique.push_back(sc);
+    }
+    stopCodes_.swap(unique);
+  }
+
+  if (updateSecs_ < 10) updateSecs_ = 10;
+
+  auto stopsEqual = [](const std::vector<String>& a, const std::vector<String>& b) {
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  };
+
+  invalidate_history |= (agency_ != prevAgency) || !stopsEqual(prevStops, stopCodes_) || (baseUrl_ != prevBase);
+
+  {
+    String label = F("GtfsRtSource_");
+    label += agency_;
+    label += '_';
+    if (!stopCodes_.empty()) label += stopCodes_.front();
+    else label += '*';
+    configKey_ = std::string(label.c_str());
+  }
+
+  if (startup_complete && !prevEnabled && enabled_) reload(departstrip::util::time_now_utc());
+  return ok;
+}
+
+String GtfsRtSource::composeUrl(const String& agency, const String& stopCode) const {
+  String url = baseUrl_;
+  url.replace(F("{agency}"), agency);
+  url.replace(F("{AGENCY}"), agency);
+  url.replace(F("{stopcode}"), stopCode);
+  url.replace(F("{stopCode}"), stopCode);
+  url.replace(F("{STOPCODE}"), stopCode);
+  if (apiKey_.length() > 0) {
+    url.replace(F("{apikey}"), apiKey_);
+    url.replace(F("{apiKey}"), apiKey_);
+    url.replace(F("{APIKEY}"), apiKey_);
+  }
+  return url;
+}
+
+bool GtfsRtSource::httpBegin(const String& url, int& outLen, int& outStatus, HTTPClient& http, bool& usedSecure) {
+  http.setTimeout(10000);
+  bool isHttps = url.startsWith(F("https://")) || url.startsWith(F("HTTPS://"));
+  usedSecure = false;
+  WiFiClient* client = &client_;
+  client_.setTimeout(10000);
+  client_.stop();
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  if (isHttps) {
+    usedSecure = true;
+    clientSecure_.stop();
+    clientSecure_.setTimeout(10000);
+    clientSecure_.setInsecure();
+    client = &clientSecure_;
+  }
+#else
+  (void)isHttps;
+#endif
+  client->stop();  // ensure any prior socket is closed before reusing
+
+  if (!http.begin(*client, url)) {
+    http.end();
+    client->stop();
+    DEBUG_PRINTLN(F("DepartStrip: GtfsRtSource::fetch: begin() failed"));
+    return false;
+  }
+  http.useHTTP10(true);
+  http.setUserAgent("WLED-GTFSRT/0.1");
+  http.setReuse(false);
+  http.addHeader("Connection", "close");
+  http.addHeader("Accept", "application/octet-stream", true, true);
+  static const char* hdrs[] = {"Content-Type", "Content-Length", "Content-Encoding", "Transfer-Encoding", "RateLimit-Remaining"};
+  http.collectHeaders(hdrs, 5);
+
+  int status = http.GET();
+  if (status < 200 || status >= 300) {
+    if (status < 0) {
+      String err = HTTPClient::errorToString(status);
+      DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: HTTP error %d (%s)\n", status, err.c_str());
+    } else {
+      DEBUG_PRINTF("DepartStrip: GtfsRtSource::fetch: HTTP status %d\n", status);
+    }
+    http.end();
+    client->stop();
+    return false;
+  }
+
+  outStatus = status;
+  outLen = http.getSize();
+  return true;
+}
+
+void GtfsRtSource::closeHttpClient(HTTPClient& http, bool usedSecure) {
+  http.end();
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  if (usedSecure) {
+    clientSecure_.stop();
+  } else {
+    client_.stop();
+  }
+#else
+  client_.stop();
+#endif
+}

--- a/usermods/usermod_v2_departstrip/gtfsrt_source.cpp
+++ b/usermods/usermod_v2_departstrip/gtfsrt_source.cpp
@@ -1236,10 +1236,9 @@ bool GtfsRtSource::httpBegin(const String& url, int& outLen, int& outStatus, HTT
     return false;
   }
   usedSecure = localSecure;
-  http.useHTTP10(true);
   http.setUserAgent("WLED-GTFSRT/0.1");
-  http.setReuse(false);
-  http.addHeader("Connection", "close");
+  http.setReuse(true);
+  http.addHeader("Connection", "keep-alive", true, true);
   http.addHeader("Accept", "application/octet-stream", true, true);
   static const char* hdrs[] = {"Content-Type", "Content-Length", "Content-Encoding", "Transfer-Encoding", "RateLimit-Remaining"};
   http.collectHeaders(hdrs, 5);

--- a/usermods/usermod_v2_departstrip/gtfsrt_source.h
+++ b/usermods/usermod_v2_departstrip/gtfsrt_source.h
@@ -3,11 +3,8 @@
 #include "interfaces.h"
 #include "depart_model.h"
 #include "util.h"
+#include "http_transport.h"
 #include "wled.h"
-#include <WiFiClient.h>
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-#include <WiFiClientSecure.h>
-#endif
 #include <vector>
 #if defined(ARDUINO_ARCH_ESP8266)
 #include <ESP8266HTTPClient.h>
@@ -28,10 +25,7 @@ private:
   uint8_t  backoffMult_ = 1;
   time_t   lastBackoffLog_ = 0;
   std::string configKey_ = "gtfsrt_source";
-  WiFiClient client_;
-#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
-  WiFiClientSecure clientSecure_;
-#endif
+  departstrip::net::HttpTransport httpTransport_;
 
 public:
   explicit GtfsRtSource(const char* key = "gtfsrt_source");

--- a/usermods/usermod_v2_departstrip/gtfsrt_source.h
+++ b/usermods/usermod_v2_departstrip/gtfsrt_source.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "interfaces.h"
+#include "depart_model.h"
+#include "util.h"
+#include "wled.h"
+#include <WiFiClient.h>
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+#include <WiFiClientSecure.h>
+#endif
+#include <vector>
+#if defined(ARDUINO_ARCH_ESP8266)
+#include <ESP8266HTTPClient.h>
+#else
+#include <HTTPClient.h>
+#endif
+
+// Placeholder GTFS-RT source that currently only handles configuration.
+class GtfsRtSource : public IDataSourceT<DepartModel> {
+private:
+  bool     enabled_ = false;
+  uint32_t updateSecs_ = 60;
+  String   baseUrl_;
+  String   apiKey_;
+  String   agency_;
+  std::vector<String> stopCodes_;
+  time_t   nextFetch_ = 0;
+  uint8_t  backoffMult_ = 1;
+  time_t   lastBackoffLog_ = 0;
+  std::string configKey_ = "gtfsrt_source";
+  WiFiClient client_;
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  WiFiClientSecure clientSecure_;
+#endif
+
+public:
+  explicit GtfsRtSource(const char* key = "gtfsrt_source");
+  std::unique_ptr<DepartModel> fetch(std::time_t now) override;
+  void reload(std::time_t now) override;
+  std::string name() const override { return configKey_; }
+  void appendConfigData(Print& s) override {}
+  String sourceKey() const override;
+  const char* sourceType() const override { return "gtfsrt"; }
+
+  void addToConfig(JsonObject& root) override;
+  bool readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) override;
+  const char* configKey() const override { return configKey_.c_str(); }
+
+  const String& agency() const { return agency_; }
+  const std::vector<String>& stopCodes() const { return stopCodes_; }
+
+private:
+  String composeUrl(const String& agency, const String& stopCode) const;
+  bool httpBegin(const String& url, int& outLen, int& outStatus, HTTPClient& http, bool& usedSecure);
+  void closeHttpClient(HTTPClient& http, bool usedSecure);
+};

--- a/usermods/usermod_v2_departstrip/http_transport.cpp
+++ b/usermods/usermod_v2_departstrip/http_transport.cpp
@@ -1,4 +1,7 @@
 #include "http_transport.h"
+#if defined(ARDUINO_ARCH_ESP32)
+#include "esp_heap_caps.h"
+#endif
 
 namespace {
 bool parseEndpoint(const String& url, bool isHttps, String& hostOut, uint16_t& portOut) {
@@ -42,22 +45,41 @@ WiFiClient* HttpTransport::begin(const String& url, uint32_t timeoutMs, bool& us
   uint16_t port = isHttps ? 443 : 80;
   bool haveEndpoint = parseEndpoint(url, isHttps, host, port);
 
+#if defined(WLED_DEBUG)
+  size_t largest = 0;
+  size_t freeHeap = 0;
+#if defined(ARDUINO_ARCH_ESP32)
+  largest = heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT);
+  freeHeap = heap_caps_get_free_size(MALLOC_CAP_DEFAULT);
+#else
+  largest = ESP.getMaxAllocHeap();
+  freeHeap = ESP.getFreeHeap();
+#endif
+  DEBUG_PRINTF("DepartStrip: HttpTransport::begin: %s host=%s port=%u largest=%u free=%u\n",
+               isHttps ? "https" : "http",
+               haveEndpoint ? host.c_str() : "(unknown)",
+               (unsigned)port,
+               (unsigned)largest,
+               (unsigned)freeHeap);
+#endif
+
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   if (isHttps) {
     usedSecure = true;
-    bool needReset = !clientSecure_.connected();
-    if (haveEndpoint) {
-      if (!secureHost_.length() || host != secureHost_ || port != securePort_) {
-        needReset = true;
-      }
-    }
-    if (needReset) {
-      clientSecure_.stop();
-      clientSecure_ = WiFiClientSecure();
+    if (!secureConfigured_) {
       clientSecure_.setInsecure();
       clientSecure_.setNoDelay(true);
-      secureHost_ = haveEndpoint ? host : String();
-      securePort_ = haveEndpoint ? port : 0;
+      secureConfigured_ = true;
+    }
+    if (haveEndpoint) {
+      if (!secureHost_.length() || host != secureHost_ || port != securePort_) {
+        if (clientSecure_.connected()) clientSecure_.stop();
+        secureHost_ = host;
+        securePort_ = port;
+      }
+    } else {
+      secureHost_.clear();
+      securePort_ = 0;
     }
     clientSecure_.setTimeout(timeoutMs);
     clientSecure_.setNoDelay(true);
@@ -93,7 +115,6 @@ void HttpTransport::end(bool usedSecure) {
   if (usedSecure) {
     if (!clientSecure_.connected()) {
       clientSecure_.stop();
-      clientSecure_ = WiFiClientSecure();
       secureHost_.clear();
       securePort_ = 0;
     }

--- a/usermods/usermod_v2_departstrip/http_transport.cpp
+++ b/usermods/usermod_v2_departstrip/http_transport.cpp
@@ -1,0 +1,46 @@
+#include "http_transport.h"
+
+namespace departstrip {
+namespace net {
+
+WiFiClient* HttpTransport::begin(const String& url, uint32_t timeoutMs, bool& usedSecure) {
+  bool isHttps = url.startsWith(F("https://")) || url.startsWith(F("HTTPS://"));
+  usedSecure = false;
+
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  if (isHttps) {
+    usedSecure = true;
+    clientSecure_.stop();
+    clientSecure_ = WiFiClientSecure();
+    clientSecure_.setTimeout(timeoutMs);
+    clientSecure_.setInsecure();
+    clientSecure_.setNoDelay(true);
+    return &clientSecure_;
+  }
+#else
+  (void)isHttps;
+#endif
+
+  client_.stop();
+  client_ = WiFiClient();
+  client_.setTimeout(timeoutMs);
+  client_.setNoDelay(true);
+  return &client_;
+}
+
+void HttpTransport::end(bool usedSecure) {
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  if (usedSecure) {
+    clientSecure_.stop();
+    clientSecure_ = WiFiClientSecure();
+    return;
+  }
+#else
+  (void)usedSecure;
+#endif
+  client_.stop();
+  client_ = WiFiClient();
+}
+
+} // namespace net
+} // namespace departstrip

--- a/usermods/usermod_v2_departstrip/http_transport.cpp
+++ b/usermods/usermod_v2_departstrip/http_transport.cpp
@@ -1,5 +1,36 @@
 #include "http_transport.h"
 
+namespace {
+bool parseEndpoint(const String& url, bool isHttps, String& hostOut, uint16_t& portOut) {
+  int schemeIdx = url.indexOf(F("://"));
+  int hostStart = (schemeIdx >= 0) ? schemeIdx + 3 : 0;
+  int pathIdx = url.indexOf('/', hostStart);
+  String authority = (pathIdx >= 0) ? url.substring(hostStart, pathIdx)
+                                    : url.substring(hostStart);
+  authority.trim();
+  if (!authority.length()) return false;
+
+  int atIdx = authority.lastIndexOf('@');
+  if (atIdx >= 0) authority = authority.substring(atIdx + 1);
+
+  int colonIdx = authority.lastIndexOf(':');
+  if (colonIdx >= 0) {
+    hostOut = authority.substring(0, colonIdx);
+    String portStr = authority.substring(colonIdx + 1);
+    uint32_t parsed = (uint32_t)portStr.toInt();
+    if (parsed == 0 || parsed > 65535) parsed = isHttps ? 443u : 80u;
+    portOut = static_cast<uint16_t>(parsed);
+  } else {
+    hostOut = authority;
+    portOut = isHttps ? 443 : 80;
+  }
+
+  hostOut.trim();
+  if (!hostOut.length()) return false;
+  return true;
+}
+} // namespace
+
 namespace departstrip {
 namespace net {
 
@@ -7,22 +38,51 @@ WiFiClient* HttpTransport::begin(const String& url, uint32_t timeoutMs, bool& us
   bool isHttps = url.startsWith(F("https://")) || url.startsWith(F("HTTPS://"));
   usedSecure = false;
 
+  String host;
+  uint16_t port = isHttps ? 443 : 80;
+  bool haveEndpoint = parseEndpoint(url, isHttps, host, port);
+
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   if (isHttps) {
     usedSecure = true;
-    clientSecure_.stop();
-    clientSecure_ = WiFiClientSecure();
+    bool needReset = !clientSecure_.connected();
+    if (haveEndpoint) {
+      if (!secureHost_.length() || host != secureHost_ || port != securePort_) {
+        needReset = true;
+      }
+    }
+    if (needReset) {
+      clientSecure_.stop();
+      clientSecure_ = WiFiClientSecure();
+      clientSecure_.setInsecure();
+      clientSecure_.setNoDelay(true);
+      secureHost_ = haveEndpoint ? host : String();
+      securePort_ = haveEndpoint ? port : 0;
+    }
     clientSecure_.setTimeout(timeoutMs);
-    clientSecure_.setInsecure();
     clientSecure_.setNoDelay(true);
     return &clientSecure_;
   }
 #else
   (void)isHttps;
+  (void)haveEndpoint;
+  (void)host;
+  (void)port;
 #endif
 
-  client_.stop();
-  client_ = WiFiClient();
+  bool needReset = !client_.connected();
+  if (haveEndpoint) {
+    if (!clientHost_.length() || host != clientHost_ || port != clientPort_) {
+      needReset = true;
+    }
+  }
+  if (needReset) {
+    client_.stop();
+    client_ = WiFiClient();
+    client_.setNoDelay(true);
+    clientHost_ = haveEndpoint ? host : String();
+    clientPort_ = haveEndpoint ? port : 0;
+  }
   client_.setTimeout(timeoutMs);
   client_.setNoDelay(true);
   return &client_;
@@ -31,15 +91,23 @@ WiFiClient* HttpTransport::begin(const String& url, uint32_t timeoutMs, bool& us
 void HttpTransport::end(bool usedSecure) {
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   if (usedSecure) {
-    clientSecure_.stop();
-    clientSecure_ = WiFiClientSecure();
+    if (!clientSecure_.connected()) {
+      clientSecure_.stop();
+      clientSecure_ = WiFiClientSecure();
+      secureHost_.clear();
+      securePort_ = 0;
+    }
     return;
   }
 #else
   (void)usedSecure;
 #endif
-  client_.stop();
-  client_ = WiFiClient();
+  if (!client_.connected()) {
+    client_.stop();
+    client_ = WiFiClient();
+    clientHost_.clear();
+    clientPort_ = 0;
+  }
 }
 
 } // namespace net

--- a/usermods/usermod_v2_departstrip/http_transport.h
+++ b/usermods/usermod_v2_departstrip/http_transport.h
@@ -24,6 +24,7 @@ private:
   WiFiClientSecure clientSecure_;
   String secureHost_;
   uint16_t securePort_ = 0;
+  bool secureConfigured_ = false;
 #endif
 };
 

--- a/usermods/usermod_v2_departstrip/http_transport.h
+++ b/usermods/usermod_v2_departstrip/http_transport.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "wled.h"
+#include <WiFiClient.h>
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  #include <WiFiClientSecure.h>
+#endif
+
+namespace departstrip {
+namespace net {
+
+class HttpTransport {
+public:
+  HttpTransport() = default;
+
+  WiFiClient* begin(const String& url, uint32_t timeoutMs, bool& usedSecure);
+  void end(bool usedSecure);
+
+private:
+  WiFiClient client_;
+#if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
+  WiFiClientSecure clientSecure_;
+#endif
+};
+
+} // namespace net
+} // namespace departstrip
+

--- a/usermods/usermod_v2_departstrip/http_transport.h
+++ b/usermods/usermod_v2_departstrip/http_transport.h
@@ -18,11 +18,14 @@ public:
 
 private:
   WiFiClient client_;
+  String clientHost_;
+  uint16_t clientPort_ = 0;
 #if defined(ARDUINO_ARCH_ESP8266) || defined(ARDUINO_ARCH_ESP32)
   WiFiClientSecure clientSecure_;
+  String secureHost_;
+  uint16_t securePort_ = 0;
 #endif
 };
 
 } // namespace net
 } // namespace departstrip
-

--- a/usermods/usermod_v2_departstrip/interfaces.h
+++ b/usermods/usermod_v2_departstrip/interfaces.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <ctime>
+#include <memory>
+#include <string>
+#include "wled.h"
+
+// Copied pattern from bartdepart/skystrip
+
+struct IConfigurable {
+  virtual ~IConfigurable() = default;
+  virtual void addToConfig(JsonObject& root) = 0;
+  virtual void appendConfigData(Print& s) {}
+  virtual bool readFromConfig(JsonObject& root,
+                              bool startup_complete,
+                              bool& invalidate_history) = 0;
+  virtual const char* configKey() const = 0;
+};
+
+template<typename ModelType>
+class IDataSourceT : public IConfigurable {
+public:
+  virtual ~IDataSourceT() = default;
+  virtual std::unique_ptr<ModelType> fetch(std::time_t now) = 0;
+  virtual void reload(std::time_t now) = 0;
+  virtual std::string name() const = 0;
+};
+
+template<typename ModelType>
+class IDataViewT : public IConfigurable {
+public:
+  virtual ~IDataViewT() = default;
+  virtual void view(std::time_t now, const ModelType& model) = 0;
+  virtual std::string name() const = 0;
+  virtual void appendConfigData(Print& s, const ModelType* model) {
+    IConfigurable::appendConfigData(s);
+  }
+};

--- a/usermods/usermod_v2_departstrip/interfaces.h
+++ b/usermods/usermod_v2_departstrip/interfaces.h
@@ -24,6 +24,8 @@ public:
   virtual std::unique_ptr<ModelType> fetch(std::time_t now) = 0;
   virtual void reload(std::time_t now) = 0;
   virtual std::string name() const = 0;
+  virtual String sourceKey() const = 0;
+  virtual const char* sourceType() const = 0;
 };
 
 template<typename ModelType>

--- a/usermods/usermod_v2_departstrip/library.json
+++ b/usermods/usermod_v2_departstrip/library.json
@@ -1,0 +1,5 @@
+{
+  "name": "usermod_v2_departstrip",
+  "build": { "libArchive": false }
+}
+

--- a/usermods/usermod_v2_departstrip/pio-scripts/departstrip_version.py
+++ b/usermods/usermod_v2_departstrip/pio-scripts/departstrip_version.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+from pathlib import Path
+
+try:
+  Import("env")  # type: ignore  # pylint: disable=undefined-variable
+except NameError:
+  env = None  # pylint: disable=invalid-name
+
+
+def append_define(target_env, define):
+  if not target_env:
+    return
+  try:
+    target_env.Append(CPPDEFINES=[define])
+  except Exception as exc:  # pylint: disable=broad-except
+    print("DepartStrip: failed to append define: {}".format(exc))
+
+
+def get_project_dir():
+  if env:
+    return env.get("PROJECT_DIR", ".")
+  current_dir = Path(__file__).resolve().parent
+  for candidate in [current_dir] + list(current_dir.parents):
+    if (candidate / "platformio.ini").is_file() or (candidate / ".git").is_dir():
+      return str(candidate)
+  return os.getcwd()
+
+
+def get_git_describe(project_dir):
+  try:
+    cmd = ["git", "describe", "--tags", "--long", "--dirty", "--always"]
+    output = subprocess.check_output(cmd, cwd=project_dir, stderr=subprocess.STDOUT)
+    version = output.decode("utf-8", errors="ignore").strip()
+    if version:
+      return version
+  except Exception as exc:  # pylint: disable=broad-except
+    print("DepartStrip: git describe failed: {}".format(exc))
+  return "unknown"
+
+
+project_dir = get_project_dir()
+git_version = get_git_describe(project_dir)
+escaped = git_version.replace('"', '\\"')
+define = ("DEPARTSTRIP_GIT_DESCRIBE", '\\"{}\\"'.format(escaped))
+
+if env and hasattr(env, "Append"):
+  append_define(env, define)
+  modules = env.get("WLED_MODULES") or []
+  for dep in modules:
+    append_define(getattr(dep, "env", None), define)
+elif __name__ == "__main__":
+  print(git_version)

--- a/usermods/usermod_v2_departstrip/readme.md
+++ b/usermods/usermod_v2_departstrip/readme.md
@@ -40,6 +40,10 @@ Source sections (siri_source1, siri_source2, …)
 - ApiKey — substituted into `{apikey}`.
 - AgencyStopCode — `AGENCY:StopCode` (e.g., `AC:50958`, `BA:900201`).
 
+Top-level DepartStrip settings
+- Enabled — master enable.
+- DisplayMinutes — total minutes shown across a strip (default 60).
+
 View sections (e.g., `DepartureView_AC:50958`, `DepartureView_BA:900201`)
 - SegmentId — segment index to render (set `-1` to disable the view).
 - AgencyStopCodes — one or more stop keys. Accepts full

--- a/usermods/usermod_v2_departstrip/readme.md
+++ b/usermods/usermod_v2_departstrip/readme.md
@@ -67,8 +67,8 @@ Examples
 
 ## Notes & Tips
 
-- Colors: The colors for each line in an agencies feed may be set in
-  the ColorMap section at the bottom.
+- Colors: Per-line colors can be set under `DepartStrip → ColorMap` in the
+  usermod config UI (keyed by `AGENCY:LineRef`).
 - Rate limits: If you exceed a feed’s rate limit, you’ll see HTTP 429
   and a per‑source backoff message in the debug log. Each source backs
   off independently.

--- a/usermods/usermod_v2_departstrip/readme.md
+++ b/usermods/usermod_v2_departstrip/readme.md
@@ -1,0 +1,74 @@
+# DepartStrip
+
+Render upcoming departures from SIRI StopMonitoring feeds on WLED LED
+segments, keyed by `AGENCY:StopCode`.
+
+## SIRI Basics
+
+- What is SIRI? SIRI stands for “Service Interface for Real Time
+  Information” — a CEN/Transmodel family standard for exchanging
+  real‑time public transport data. StopMonitoring is the SIRI service
+  that returns predicted arrivals/departures at a stop.
+
+## Feed Examples: 511.org (SF Bay Area) and MTA (New York)
+
+- 511.org StopMonitoring (Bay Area)
+  - Endpoint: `http://api.511.org/transit/StopMonitoring?format=json&api_key=KEY&agency=AGENCY&stopCode=STOP`
+  - Agencies include BART (`BA`), AC Transit (`AC`), and many others across the nine‑county region.
+
+- MTA Bus Time StopMonitoring (NYC)
+  - Endpoint: `http://bustime.mta.info/api/siri/stop-monitoring.json?key=KEY&OperatorRef=MTA&MonitoringRef=STOP`
+  - Coverage: the New York City bus network (hundreds of routes
+    including local, limited, SBS, and express).
+
+- Where else can SIRI work?
+  - SIRI is widely used in Europe (it’s a European CEN standard) and
+    by a number of North American integrators. If your operator or
+    regional aggregator mentions “SIRI” or “SIRI StopMonitoring” in
+    their developer docs, you can likely adapt it here by setting the
+    TemplateUrl and parameters.
+
+## Configuration (WLED → Config → Usermods → DepartStrip)
+
+- DepartStrip.Enabled — master enable.
+
+Source sections (siri_source1, siri_source2, …)
+- Enabled — enable/disable this source.
+- UpdateSecs — fetch interval seconds (default 60).
+- TemplateUrl — URL template with placeholders (see below):
+  `http://api.511.org/transit/StopMonitoring?format=json&api_key={apikey}&agency={agency}&stopCode={stopcode}`
+- ApiKey — substituted into `{apikey}`.
+- AgencyStopCode — `AGENCY:StopCode` (e.g., `AC:50958`, `BA:900201`).
+
+View sections (e.g., `DepartureView_AC:50958`, `DepartureView_BA:900201`)
+- SegmentId — segment index to render (set `-1` to disable the view).
+- AgencyStopCodes — one or more stop keys. Accepts full
+  `AGENCY:StopCode` tokens or a leading full token followed by
+  additional stop codes from the same agency, separated by
+  comma/space. Examples: `AC:50958`, `AC:50958,50959`, `BA:900201
+  900202`.
+
+### URL Templates and Placeholders
+
+Each source uses a `TemplateUrl` with placeholders replaced at fetch time:
+- `{agency}` or `{AGENCY}` → agency code (e.g., `AC`, `BA`, `MTA`).
+- `{stopcode}` or `{stopCode}` → stop code (e.g., `50958`).
+- `{apikey}`, `{apiKey}`, or `{APIKEY}` → your API key.
+
+If placeholders are present they are replaced directly. If none are
+present, the provided URL is used as‑is (no legacy query parameters
+are appended).
+
+Examples
+- 511.org:
+  `http://api.511.org/transit/StopMonitoring?format=json&api_key={apikey}&agency={agency}&stopCode={stopcode}`
+- MTA Bus Time:
+  `http://bustime.mta.info/api/siri/stop-monitoring.json?key={apikey}&OperatorRef=MTA&MonitoringRef={stopcode}`
+
+## Notes & Tips
+
+- Colors: The colors for each line in an agencies feed may be set in
+  the ColorMap section at the bottom.
+- Rate limits: If you exceed a feed’s rate limit, you’ll see HTTP 429
+  and a per‑source backoff message in the debug log. Each source backs
+  off independently.

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -179,7 +179,9 @@ bool SiriSource::parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter, bo
     if (wideFilter) {
       // Wide filter: keep the whole StopMonitoringDelivery subtree to ensure visits are present.
       // Used when Content-Length is known (capacity sized accordingly).
-      StaticJsonDocument<768> filter;
+      static StaticJsonDocument<768> filter;
+      filter.clear();
+
       filter["Siri"]["ServiceDelivery"]["ResponseTimestamp"] = true;
       filter["Siri"]["ServiceDelivery"]["StopMonitoringDelivery"] = true;
       filter["ServiceDelivery"]["ResponseTimestamp"] = true;
@@ -189,7 +191,9 @@ bool SiriSource::parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter, bo
                             DeserializationOption::NestingLimit(80));
     } else {
       // Targeted/narrow filter for unknown Content-Length to limit memory.
-      StaticJsonDocument<4096> filter;
+      static StaticJsonDocument<4096> filter;
+      filter.clear();
+
       auto addMVJMask = [&](JsonObject mvj) {
         mvj["LineRef"] = true; // allow string or object
         JsonObject call = mvj["MonitoredCall"].to<JsonObject>();

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -15,7 +15,7 @@ struct SkipBOMStream : public Stream {
   explicit SkipBOMStream(Stream& s) : in(s) {}
   // Satisfy Print's pure virtuals
   size_t write(uint8_t) override { return 0; }
-  size_t write(const uint8_t*, size_t) { return 0; }
+  size_t write(const uint8_t*, size_t) override { return 0; }
   void ensureInit() {
     if (init) return;
     init = true;
@@ -55,8 +55,6 @@ struct SkipBOMStream : public Stream {
 };
 } // namespace
 
-using departstrip::util::time_now;
-
 SiriSource::SiriSource(const char* key, const char* defAgency, const char* defStopCode, const char* defBaseUrl) {
   if (key && *key) configKey_ = key;
   if (defAgency) agency_ = defAgency;
@@ -78,6 +76,7 @@ String SiriSource::composeUrl(const String& agency, const String& stopCode) cons
   url.replace(F("{AGENCY}"), agency);
   url.replace(F("{stopcode}"), stopCode);
   url.replace(F("{stopCode}"), stopCode);
+  url.replace(F("{STOPCODE}"), stopCode);
   if (apiKey_.length() > 0) {
     url.replace(F("{apikey}"), apiKey_);
     url.replace(F("{apiKey}"), apiKey_);

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -1,0 +1,446 @@
+#include "siri_source.h"
+#include "util.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace {
+// Stream wrapper that discards a leading UTF-8 BOM if present, then passes through bytes unchanged.
+struct SkipBOMStream : public Stream {
+  Stream& in;
+  bool init = false;
+  uint8_t head[3];
+  size_t headLen = 0;
+  size_t headPos = 0;
+  explicit SkipBOMStream(Stream& s) : in(s) {}
+  // Satisfy Print's pure virtuals
+  size_t write(uint8_t) override { return 0; }
+  size_t write(const uint8_t*, size_t) { return 0; }
+  void ensureInit() {
+    if (init) return;
+    init = true;
+    uint8_t buf[3];
+    size_t got = in.readBytes(buf, sizeof(buf));
+    if (got == 3 && buf[0] == 0xEF && buf[1] == 0xBB && buf[2] == 0xBF) {
+      headLen = 0; headPos = 0; // skip BOM
+    } else {
+      headLen = got; headPos = 0;
+      for (size_t i = 0; i < got; ++i) head[i] = buf[i];
+    }
+  }
+  int available() override {
+    ensureInit();
+    return (int)(headLen - headPos) + in.available();
+  }
+  int read() override {
+    ensureInit();
+    if (headPos < headLen) return head[headPos++];
+    return in.read();
+  }
+  int peek() override {
+    ensureInit();
+    if (headPos < headLen) return head[headPos];
+    return in.peek();
+  }
+  void flush() override { in.flush(); }
+  size_t readBytes(char* buffer, size_t length) override {
+    ensureInit();
+    size_t n = 0;
+    while (n < length && headPos < headLen) buffer[n++] = head[headPos++];
+    if (n < length) n += in.readBytes(buffer + n, length - n);
+    return n;
+  }
+  size_t readBytes(uint8_t* buffer, size_t length) { return readBytes((char*)buffer, length); }
+  using Stream::readBytes;
+};
+} // namespace
+
+using departstrip::util::time_now;
+
+SiriSource::SiriSource(const char* key, const char* defAgency, const char* defStopCode, const char* defBaseUrl) {
+  if (key && *key) configKey_ = key;
+  if (defAgency) agency_ = defAgency;
+  if (defStopCode) stopCode_ = defStopCode;
+  if (defBaseUrl) baseUrl_ = defBaseUrl;
+}
+
+void SiriSource::reload(std::time_t now) {
+  nextFetch_ = now;
+  backoffMult_ = 1;
+}
+
+String SiriSource::composeUrl(const String& agency, const String& stopCode) const {
+  // Treat baseUrl_ strictly as a template: perform placeholder substitutions if present
+  // and otherwise use it as-is without appending legacy query parameters.
+  String url = baseUrl_;
+  // Placeholder substitutions (case variants)
+  url.replace(F("{agency}"), agency);
+  url.replace(F("{AGENCY}"), agency);
+  url.replace(F("{stopcode}"), stopCode);
+  url.replace(F("{stopCode}"), stopCode);
+  if (apiKey_.length() > 0) {
+    url.replace(F("{apikey}"), apiKey_);
+    url.replace(F("{apiKey}"), apiKey_);
+    url.replace(F("{APIKEY}"), apiKey_);
+  }
+  return url;
+}
+
+// Minimal RFC3339 parser to UTC epoch (seconds). Supports:
+// YYYY-MM-DDTHH:MM:SS[.fff][Z|±HH:MM]
+static int days_from_civil(int y, unsigned m, unsigned d) {
+  y -= m <= 2;
+  const int era = (y >= 0 ? y : y-399) / 400;
+  const unsigned yoe = (unsigned)(y - era * 400);
+  const unsigned doy = (153*(m + (m > 2 ? -3 : 9)) + 2)/5 + d - 1;
+  const unsigned doe = yoe*365 + yoe/4 - yoe/100 + yoe/400 + doy;
+  return era*146097 + (int)doe - 719468;
+}
+
+bool SiriSource::parseRFC3339ToUTC(const char* s, time_t& outUtc) {
+  if (!s || !*s) return false;
+  int Y=0,M=0,D=0,h=0,m=0,sec=0;
+  if (sscanf(s, "%4d-%2d-%2dT%2d:%2d:%2d", &Y,&M,&D,&h,&m,&sec) != 6) return false;
+  const char* tz = strpbrk(s, "Z+-");
+  int tzSign = 0, tzH=0, tzM=0;
+  if (!tz) { tzSign = 0; tzH = tzM = 0; }
+  else if (*tz == 'Z' || *tz == 'z') { tzSign = 0; tzH = tzM = 0; }
+  else if (*tz == '+' || *tz == '-') {
+    tzSign = (*tz == '+') ? +1 : -1;
+    int th=0, tmn=0; if (sscanf(tz+1, "%2d:%2d", &th, &tmn) == 2) { tzH = th; tzM = tmn; }
+  }
+  int days = days_from_civil(Y, (unsigned)M, (unsigned)D);
+  long sec_of_day = h*3600L + m*60L + sec;
+  long tz_off = tzSign * (tzH*3600L + tzM*60L);
+  long long epoch = (long long)days*86400LL + (long long)sec_of_day - tz_off;
+  outUtc = (time_t)epoch;
+  return true;
+}
+
+bool SiriSource::httpBegin(const String& url, int& outLen) {
+  http_.setTimeout(10000);
+  if (!http_.begin(client_, url)) {
+    http_.end();
+    DEBUG_PRINTLN(F("DepartStrip: SiriSource::fetch: begin() failed"));
+    return false;
+  }
+  // Try to mimic curl behavior to avoid gzip responses
+  http_.useHTTP10(true);
+  http_.setUserAgent("curl/7.79.1");
+  http_.setReuse(false);
+  http_.addHeader("Connection", "close");
+  http_.addHeader("Accept", "*/*", true, true);
+  http_.addHeader("Accept-Encoding", "identity", true, true);
+  static const char* hdrs[] = {"Content-Type", "Content-Encoding", "Content-Length", "RateLimit-Remaining"};
+  http_.collectHeaders(hdrs, 4);
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: free heap before GET: %u\n", ESP.getFreeHeap());
+  int httpCode = http_.GET();
+  // Log rate limit remaining if provided by the server
+  {
+    String rl = http_.header("RateLimit-Remaining");
+    if (rl.length() > 0) {
+      DEBUG_PRINTF("DepartStrip: SiriSource::fetch: RateLimit-Remaining=%s\n", rl.c_str());
+    }
+  }
+  if (httpCode < 200 || httpCode >= 300) {
+    http_.end();
+    if (httpCode < 0) {
+      String err = HTTPClient::errorToString(httpCode);
+      DEBUG_PRINTF("DepartStrip: SiriSource::fetch: HTTP error %d (%s)\n", httpCode, err.c_str());
+    } else {
+      DEBUG_PRINTF("DepartStrip: SiriSource::fetch: HTTP status %d\n", httpCode);
+    }
+    return false;
+  }
+  String enc = http_.header("Content-Encoding");
+  String ctype = http_.header("Content-Type");
+  outLen = http_.getSize();
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: enc='%s' type='%s' len=%d\n", enc.c_str(), ctype.c_str(), outLen);
+  return true;
+}
+
+bool SiriSource::parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter, bool wideFilter) {
+  SkipBOMStream s(http_.getStream());
+  DeserializationError err;
+  if (withFilter) {
+    if (wideFilter) {
+      // Wide filter: keep the whole StopMonitoringDelivery subtree to ensure visits are present.
+      // Used when Content-Length is known (capacity sized accordingly).
+      StaticJsonDocument<768> filter;
+      filter["Siri"]["ServiceDelivery"]["ResponseTimestamp"] = true;
+      filter["Siri"]["ServiceDelivery"]["StopMonitoringDelivery"] = true;
+      filter["ServiceDelivery"]["ResponseTimestamp"] = true;
+      filter["ServiceDelivery"]["StopMonitoringDelivery"] = true;
+      err = deserializeJson(doc, s,
+                            DeserializationOption::Filter(filter),
+                            DeserializationOption::NestingLimit(80));
+    } else {
+      // Targeted/narrow filter for unknown Content-Length to limit memory.
+      StaticJsonDocument<4096> filter;
+      auto addMVJMask = [&](JsonObject mvj) {
+        mvj["LineRef"] = true; // allow string or object
+        JsonObject call = mvj["MonitoredCall"].to<JsonObject>();
+        call["StopPointName"] = true;
+        call["ExpectedDepartureTime"] = true;
+        call["ExpectedArrivalTime"] = true;
+        call["AimedDepartureTime"] = true;
+        call["AimedArrivalTime"] = true;
+      };
+      // With Siri wrapper
+      filter["Siri"]["ServiceDelivery"]["ResponseTimestamp"] = true;
+      {
+        JsonObject mvj = filter["Siri"]["ServiceDelivery"]["StopMonitoringDelivery"][0]
+                               ["MonitoredStopVisit"][0]
+                               ["MonitoredVehicleJourney"].to<JsonObject>();
+        addMVJMask(mvj);
+      }
+      {
+        JsonObject mvj = filter["Siri"]["ServiceDelivery"]["StopMonitoringDelivery"]
+                               ["MonitoredStopVisit"][0]
+                               ["MonitoredVehicleJourney"].to<JsonObject>();
+        addMVJMask(mvj);
+      }
+      // Without Siri wrapper (top-level ServiceDelivery)
+      filter["ServiceDelivery"]["ResponseTimestamp"] = true;
+      {
+        JsonObject mvj = filter["ServiceDelivery"]["StopMonitoringDelivery"][0]
+                               ["MonitoredStopVisit"][0]
+                               ["MonitoredVehicleJourney"].to<JsonObject>();
+        addMVJMask(mvj);
+      }
+      {
+        JsonObject mvj = filter["ServiceDelivery"]["StopMonitoringDelivery"]
+                               ["MonitoredStopVisit"][0]
+                               ["MonitoredVehicleJourney"].to<JsonObject>();
+        addMVJMask(mvj);
+      }
+      err = deserializeJson(doc, s,
+                            DeserializationOption::Filter(filter),
+                            DeserializationOption::NestingLimit(80));
+    }
+  } else {
+    err = deserializeJson(doc, s, DeserializationOption::NestingLimit(80));
+  }
+  http_.end();
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: after parse, memUsage=%u, free heap=%u\n", (unsigned)doc.memoryUsage(), ESP.getFreeHeap());
+  if (err) {
+    DEBUG_PRINTF("DepartStrip: SiriSource::fetch: deserializeJson failed: %s\n", err.c_str());
+    return false;
+  }
+  return true;
+}
+
+size_t SiriSource::computeJsonCapacity(int contentLen) {
+  if (contentLen > 0) return (size_t)contentLen * 2;
+  // Unknown length: pick a slightly larger default to reduce NoMemory risk
+  // while the filter keeps actual usage low on most feeds.
+  return 20480; // 20 KB
+}
+
+JsonObject SiriSource::getSiriRoot(DynamicJsonDocument& doc, bool& usedTopLevelFallback) {
+  usedTopLevelFallback = false;
+  JsonObject siri = doc["Siri"].as<JsonObject>();
+  if (siri.isNull()) {
+    // Try treating top-level as the Siri container
+    if (doc["ServiceDelivery"].is<JsonObject>()) {
+      usedTopLevelFallback = true;
+      return doc.as<JsonObject>();
+    }
+  }
+  return siri;
+}
+
+bool SiriSource::buildModelFromSiri(JsonObject siri, std::time_t now, std::unique_ptr<DepartModel>& outModel) {
+  if (siri.isNull()) return false;
+  JsonObject sd = siri["ServiceDelivery"].as<JsonObject>();
+  time_t apiTs = 0;
+  parseRFC3339ToUTC(sd["ResponseTimestamp"] | (const char*)nullptr, apiTs);
+  if (!apiTs) apiTs = now;
+
+  JsonArray visits;
+  if (sd["StopMonitoringDelivery"].is<JsonArray>()) {
+    JsonObject del = sd["StopMonitoringDelivery"][0].as<JsonObject>();
+    visits = del["MonitoredStopVisit"].as<JsonArray>();
+  } else if (sd["StopMonitoringDelivery"].is<JsonObject>()) {
+    JsonObject del = sd["StopMonitoringDelivery"].as<JsonObject>();
+    visits = del["MonitoredStopVisit"].as<JsonArray>();
+  }
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: visits null=%d size=%u\n", visits.isNull(), (unsigned)(visits.isNull() ? 0 : visits.size()));
+  if (visits.isNull()) {
+    DEBUG_PRINTLN(F("DepartStrip: SiriSource::fetch: no MonitoredStopVisit array"));
+    return false;
+  }
+
+  DepartModel::Entry board;
+  board.key.reserve(agency_.length() + 1 + stopCode_.length());
+  board.key = agency_; board.key += ":"; board.key += stopCode_;
+  DepartModel::Entry::Batch batch;
+  batch.apiTs = apiTs;
+  batch.ourTs = time_now();
+
+  int totalVisits = 0, hadTime = 0, parsedTime = 0;
+  String firstStopName;
+  for (JsonObject v : visits) {
+    ++totalVisits;
+    JsonObject mvj = v["MonitoredVehicleJourney"].as<JsonObject>();
+    if (mvj.isNull()) continue;
+    JsonObject call = mvj["MonitoredCall"].as<JsonObject>();
+    if (call.isNull()) continue;
+    if (firstStopName.length() == 0) {
+      const char* nm = call["StopPointName"] | (const char*)nullptr;
+      if (nm && *nm) firstStopName = nm;
+    }
+
+    const char* tstr = call["ExpectedDepartureTime"] | call["ExpectedArrivalTime"] |
+                       call["AimedDepartureTime"] | call["AimedArrivalTime"] | (const char*)nullptr;
+    time_t depUtc = 0;
+    if (tstr) ++hadTime;
+    if (tstr && parseRFC3339ToUTC(tstr, depUtc)) {
+      ++parsedTime;
+      DepartModel::Entry::Item item; item.estDep = depUtc;
+      // LineRef may be nested or plain; handle both
+      if (mvj["LineRef"].is<JsonObject>()) item.lineRef = (const char*)(mvj["LineRef"]["value"] | "");
+      else item.lineRef = (const char*)(mvj["LineRef"] | "");
+      batch.items.push_back(item);
+    } else if (tstr && parsedTime < 3) {
+      // Log a few samples of bad timestamps
+      DEBUG_PRINTF("DepartStrip: SiriSource::fetch: failed to parse time '%s'\n", tstr);
+    }
+  }
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: visits=%d hadTime=%d parsed=%d items=%u\n", totalVisits, hadTime, parsedTime, (unsigned)batch.items.size());
+
+  if (batch.items.empty()) {
+    DEBUG_PRINTLN(F("DepartStrip: SiriSource::fetch: no items parsed"));
+    return false;
+  }
+
+  std::sort(batch.items.begin(), batch.items.end(), [](const DepartModel::Entry::Item& a, const DepartModel::Entry::Item& b){ return a.estDep < b.estDep; });
+
+  board.batch = std::move(batch);
+
+  std::unique_ptr<DepartModel> model(new DepartModel());
+  model->boards.push_back(std::move(board));
+  outModel = std::move(model);
+  if (firstStopName.length() > 0) lastStopName_ = firstStopName;
+  return true;
+}
+
+std::unique_ptr<DepartModel> SiriSource::fetch(std::time_t now) {
+  if (!enabled_) return nullptr;
+  if (now == 0) return nullptr;
+  if (now < nextFetch_) {
+    // Periodically log backoff status at roughly the source's update cadence
+    time_t interval = updateSecs_ > 0 ? updateSecs_ : 60;
+    if (lastBackoffLog_ == 0 || now - lastBackoffLog_ >= interval) {
+      lastBackoffLog_ = now;
+      long rem = (long)(nextFetch_ - now);
+      if (rem < 0) rem = 0;
+      String key = sourceKey();
+      if (backoffMult_ > 1) {
+        DEBUG_PRINTF("DepartStrip: SiriSource::fetch: backoff x%u %s, next in %lds\n",
+                     (unsigned)backoffMult_, key.c_str(), rem);
+      } else {
+        DEBUG_PRINTF("DepartStrip: SiriSource::fetch: waiting %s, next in %lds\n",
+                     key.c_str(), rem);
+      }
+    }
+    return nullptr;
+  }
+
+  String url = composeUrl(agency_, stopCode_);
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: URL: %s\n", url.c_str());
+  int len = 0;
+  if (!httpBegin(url, len)) {
+    // Schedule retry with exponential backoff (per source)
+    long delay = (long)updateSecs_ * (long)backoffMult_;
+    DEBUG_PRINTF("DepartStrip: SiriSource::fetch: scheduling backoff x%u %s for %lds (begin/HTTP error)\n",
+                 (unsigned)backoffMult_, sourceKey().c_str(), delay);
+    nextFetch_ = now + delay;
+    if (backoffMult_ < 16) backoffMult_ *= 2;
+    return nullptr;
+  }
+
+  size_t jsonSz = computeJsonCapacity(len);
+  DEBUG_PRINTF("DepartStrip: SiriSource::fetch: json capacity=%u, free heap=%u\n", (unsigned)jsonSz, ESP.getFreeHeap());
+  DynamicJsonDocument doc(jsonSz);
+  // Use wide filter when Content-Length available; narrow otherwise.
+  bool wideFilter = (len > 0);
+  if (!parseJsonFromHttp(doc, true, wideFilter)) {
+    long delay = (long)updateSecs_ * (long)backoffMult_;
+    DEBUG_PRINTF("DepartStrip: SiriSource::fetch: scheduling backoff x%u %s for %lds (parse error)\n",
+                 (unsigned)backoffMult_, sourceKey().c_str(), delay);
+    nextFetch_ = now + delay;
+    if (backoffMult_ < 16) backoffMult_ *= 2;
+    return nullptr;
+  }
+
+  bool usedTop = false;
+  JsonObject siri = getSiriRoot(doc, usedTop);
+  if (usedTop) DEBUG_PRINTLN(F("DepartStrip: SiriSource::fetch: using top-level as Siri container"));
+  if (siri.isNull()) {
+    DEBUG_PRINTLN(F("DepartStrip: SiriSource::fetch: missing Siri root"));
+    long delay = (long)updateSecs_ * (long)backoffMult_;
+    DEBUG_PRINTF("DepartStrip: SiriSource::fetch: scheduling backoff x%u %s for %lds (bad JSON shape)\n",
+                 (unsigned)backoffMult_, sourceKey().c_str(), delay);
+    nextFetch_ = now + delay;
+    if (backoffMult_ < 16) backoffMult_ *= 2;
+    return nullptr;
+  }
+
+  std::unique_ptr<DepartModel> model;
+  if (!buildModelFromSiri(siri, now, model)) {
+    nextFetch_ = now + updateSecs_;
+    backoffMult_ = 1;
+    return nullptr;
+  }
+
+  // Model summary logging handled in DepartModel::update()
+  nextFetch_ = now + updateSecs_;
+  backoffMult_ = 1;
+  return model;
+}
+
+void SiriSource::addToConfig(JsonObject& root) {
+  root["Enabled"] = enabled_;
+  root["UpdateSecs"] = updateSecs_;
+  root["TemplateUrl"] = baseUrl_;
+  root["ApiKey"] = apiKey_;
+  String key; key.reserve(agency_.length()+1+stopCode_.length());
+  key = agency_; key += ":"; key += stopCode_;
+  root["AgencyStopCode"] = key;
+}
+
+bool SiriSource::readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) {
+  bool ok = true;
+  bool prevEnabled = enabled_;
+  String prevAgency = agency_;
+  String prevStop = stopCode_;
+  String prevBase = baseUrl_;
+
+  ok &= getJsonValue(root["Enabled"], enabled_, enabled_);
+  ok &= getJsonValue(root["UpdateSecs"], updateSecs_, updateSecs_);
+  ok &= getJsonValue(root["TemplateUrl"], baseUrl_, baseUrl_);
+  ok &= getJsonValue(root["ApiKey"], apiKey_, apiKey_);
+  // Prefer combined Key ("AGENCY:StopCode"); fall back to legacy Agency/StopCode if not provided
+  String keyStr;
+  bool haveKey = getJsonValue(root["AgencyStopCode"], keyStr, (const char*)nullptr); if (!haveKey) haveKey = getJsonValue(root["Key"], keyStr, (const char*)nullptr);
+  if (haveKey && keyStr.length() > 0) {
+    int colon = keyStr.indexOf(':');
+    if (colon > 0) {
+      agency_ = keyStr.substring(0, colon);
+      stopCode_ = keyStr.substring(colon+1);
+    }
+  } else {
+    ok &= getJsonValue(root["Agency"], agency_, agency_);
+    ok &= getJsonValue(root["StopCode"], stopCode_, stopCode_);
+  }
+  // Update friendly config key to mirror views: SiriSource_AGENCY_StopCode
+  {
+    String sec = F("SiriSource_"); sec += agency_; sec += '_'; sec += stopCode_;
+    configKey_ = std::string(sec.c_str());
+  }
+
+  invalidate_history |= (agency_ != prevAgency) || (stopCode_ != prevStop) || (baseUrl_ != prevBase);
+  if (startup_complete && !prevEnabled && enabled_) reload(departstrip::util::time_now_utc());
+  return ok;
+}

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -450,6 +450,8 @@ bool SiriSource::readFromConfig(JsonObject& root, bool startup_complete, bool& i
     configKey_ = std::string(sec.c_str());
   }
 
+  if (updateSecs_ < 10) updateSecs_ = 10; // minimum 10s cadence
+
   invalidate_history |= (agency_ != prevAgency) || (stopCode_ != prevStop) || (baseUrl_ != prevBase);
   if (startup_complete && !prevEnabled && enabled_) reload(departstrip::util::time_now_utc());
   return ok;

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -116,8 +116,12 @@ bool SiriSource::parseRFC3339ToUTC(const char* s, time_t& outUtc) {
   } else if (*tz == '+' || *tz == '-') {
     tzSign = (*tz == '+') ? +1 : -1;
     int th=0, tmn=0;
-    // Expect "+HH:MM" or "-HH:MM"; leave tzH/tzM 0 if parse fails
-    if (sscanf(tz+1, "%2d:%2d", &th, &tmn) == 2) { tzH = th; tzM = tmn; }
+    // Expect "+HH:MM" or "-HH:MM" first; fallback to "+HHMM" or "-HHMM"
+    if (sscanf(tz+1, "%2d:%2d", &th, &tmn) == 2) {
+      tzH = th; tzM = tmn;
+    } else if (sscanf(tz+1, "%2d%2d", &th, &tmn) == 2) {
+      tzH = th; tzM = tmn;
+    }
   }
   int days = days_from_civil(Y, (unsigned)M, (unsigned)D);
   long sec_of_day = h*3600L + m*60L + sec;

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -290,7 +290,7 @@ bool SiriSource::buildModelFromSiri(JsonObject siri, std::time_t now, std::uniqu
   board.key = agency_; board.key += ":"; board.key += stopCode_;
   DepartModel::Entry::Batch batch;
   batch.apiTs = apiTs;
-  batch.ourTs = time_now();
+  batch.ourTs = now;
 
   int totalVisits = 0, hadTime = 0, parsedTime = 0;
   String firstStopName;

--- a/usermods/usermod_v2_departstrip/siri_source.cpp
+++ b/usermods/usermod_v2_departstrip/siri_source.cpp
@@ -187,10 +187,9 @@ bool SiriSource::httpBegin(const String& url, int& outLen) {
   httpActive_ = true;
   httpUsedSecure_ = usedSecure;
   // Try to mimic curl behavior to avoid gzip responses
-  http_.useHTTP10(true);
   http_.setUserAgent("curl/7.79.1");
-  http_.setReuse(false);
-  http_.addHeader("Connection", "close");
+  http_.setReuse(true);
+  http_.addHeader("Connection", "keep-alive", true, true);
   http_.addHeader("Accept", "*/*", true, true);
   http_.addHeader("Accept-Encoding", "identity", true, true);
   static const char* hdrs[] = {"Content-Type", "Content-Encoding", "Content-Length", "Transfer-Encoding", "RateLimit-Remaining"};

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -53,7 +53,7 @@ private:
   static bool parseRFC3339ToUTC(const char* s, time_t& outUtc);
   // Helpers to keep fetch() concise
   bool httpBegin(const String& url, int& outLen);
-  bool parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter = true, bool wideFilter = false);
+  bool parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter = true);
   static size_t computeJsonCapacity(int contentLen);
   JsonObject getSiriRoot(DynamicJsonDocument& doc, bool& usedTopLevelFallback);
   bool buildModelFromSiri(JsonObject siri, std::time_t now, std::unique_ptr<DepartModel>& outModel);

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -53,7 +53,7 @@ private:
   static bool parseRFC3339ToUTC(const char* s, time_t& outUtc);
   // Helpers to keep fetch() concise
   bool httpBegin(const String& url, int& outLen);
-  bool parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter = true);
+  bool parseJsonFromHttp(DynamicJsonDocument& doc);
   static size_t computeJsonCapacity(int contentLen);
   JsonObject getSiriRoot(DynamicJsonDocument& doc, bool& usedTopLevelFallback);
   bool buildModelFromSiri(JsonObject siri, std::time_t now, std::unique_ptr<DepartModel>& outModel);

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -17,7 +17,7 @@
 class SiriSource : public IDataSourceT<DepartModel> {
 private:
   bool     enabled_ = false;
-  uint16_t updateSecs_ = 60;
+  uint32_t updateSecs_ = 60;
   String   baseUrl_ = "";
   String   apiKey_   = "";
   String   agency_   = "";

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+#include "interfaces.h"
+#include "depart_model.h"
+#include "wled.h"
+#include <WiFiClient.h>
+#if defined(ARDUINO_ARCH_ESP8266)
+  #include <ESP8266HTTPClient.h>
+#else
+  #include <HTTPClient.h>
+#endif
+
+// SIRI StopMonitoring JSON source for DepartStrip.
+// Configurable per-agency/stop; can be instantiated multiple times.
+class SiriSource : public IDataSourceT<DepartModel> {
+private:
+  bool     enabled_ = false;
+  uint16_t updateSecs_ = 60;
+  String   baseUrl_ = "";
+  String   apiKey_   = "";
+  String   agency_   = "";
+  String   stopCode_ = "";
+  time_t   nextFetch_ = 0;
+  uint8_t  backoffMult_ = 1;
+  time_t   lastBackoffLog_ = 0;
+  WiFiClient client_;
+  HTTPClient http_;
+  std::string configKey_ = "siri_source";
+  String   lastStopName_;
+
+public:
+  explicit SiriSource(const char* key = "siri_source",
+                       const char* defAgency = nullptr,
+                       const char* defStopCode = nullptr,
+                       const char* defBaseUrl = nullptr);
+  std::unique_ptr<DepartModel> fetch(std::time_t now) override;
+  void reload(std::time_t now) override;
+  std::string name() const override { return configKey_; }
+  void appendConfigData(Print& s) override {}
+  const String& stopName() const { return lastStopName_; }
+  String sourceKey() const { String k(agency_); k += ':'; k += stopCode_; return k; }
+
+  const String& agency() const { return agency_; }
+
+  void addToConfig(JsonObject& root) override;
+  bool readFromConfig(JsonObject& root, bool startup_complete, bool& invalidate_history) override;
+  const char* configKey() const override { return configKey_.c_str(); }
+
+private:
+  String composeUrl(const String& agency, const String& stopCode) const;
+  static bool parseRFC3339ToUTC(const char* s, time_t& outUtc);
+  // Helpers to keep fetch() concise
+  bool httpBegin(const String& url, int& outLen);
+  bool parseJsonFromHttp(DynamicJsonDocument& doc, bool withFilter = true, bool wideFilter = false);
+  static size_t computeJsonCapacity(int contentLen);
+  JsonObject getSiriRoot(DynamicJsonDocument& doc, bool& usedTopLevelFallback);
+  bool buildModelFromSiri(JsonObject siri, std::time_t now, std::unique_ptr<DepartModel>& outModel);
+};

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -54,8 +54,10 @@ private:
   static bool parseRFC3339ToUTC(const char* s, time_t& outUtc);
   // Helpers to keep fetch() concise
   bool httpBegin(const String& url, int& outLen);
-  bool parseJsonFromHttp(DynamicJsonDocument& doc);
+  bool parseJsonFromHttp(JsonDocument& doc);
   static size_t computeJsonCapacity(int contentLen);
-  JsonObject getSiriRoot(DynamicJsonDocument& doc, bool& usedTopLevelFallback);
+  JsonObject getSiriRoot(JsonDocument& doc, bool& usedTopLevelFallback);
   bool buildModelFromSiri(JsonObject siri, std::time_t now, std::unique_ptr<DepartModel>& outModel);
+  static JsonDocument* acquireJsonDoc(size_t capacity, bool& fromPool);
+  static void releaseJsonDoc(JsonDocument* doc, bool fromPool);
 };

--- a/usermods/usermod_v2_departstrip/siri_source.h
+++ b/usermods/usermod_v2_departstrip/siri_source.h
@@ -40,7 +40,8 @@ public:
   std::string name() const override { return configKey_; }
   void appendConfigData(Print& s) override {}
   const String& stopName() const { return lastStopName_; }
-  String sourceKey() const { String k(agency_); k += ':'; k += stopCode_; return k; }
+  String sourceKey() const override { String k(agency_); k += ':'; k += stopCode_; return k; }
+  const char* sourceType() const override { return "siri"; }
 
   const String& agency() const { return agency_; }
 

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -131,37 +131,11 @@ void DepartStrip::addToConfig(JsonObject& root) {
       if (c > 0) { agency = key.substring(0, c); line = key.substring(c+1); }
       else { agency = key; line = String(); }
     }
-    static bool parseLeadingInt(const String& s, int& val, int& consumed) {
-      val = 0; consumed = 0; bool any = false;
-      for (unsigned i = 0; i < s.length(); ++i) {
-        char ch = s.charAt(i);
-        if (ch >= '0' && ch <= '9') { any = true; val = val*10 + (ch - '0'); ++consumed; }
-        else break;
-      }
-      return any;
-    }
-    static int cmpLine(const String& a, const String& b) {
-      int na=0, nb=0, ca=0, cb=0;
-      bool ha = parseLeadingInt(a, na, ca);
-      bool hb = parseLeadingInt(b, nb, cb);
-      if (ha && hb) {
-        if (na != nb) return (na < nb) ? -1 : 1;
-        String sa = a.substring(ca);
-        String sb = b.substring(cb);
-        int r = sa.compareTo(sb);
-        if (r != 0) return r < 0 ? -1 : 1;
-        return 0;
-      }
-      if (ha != hb) return ha ? -1 : 1; // numeric routes before non-numeric
-      int r = a.compareTo(b);
-      if (r != 0) return r < 0 ? -1 : 1;
-      return 0;
-    }
     static bool lt(const std::pair<String,uint32_t>& a, const std::pair<String,uint32_t>& b) {
       String aa, al, ba, bl; splitKey(a.first, aa, al); splitKey(b.first, ba, bl);
       int ar = aa.compareTo(ba);
       if (ar != 0) return ar < 0;
-      return cmpLine(al, bl) < 0;
+      return departstrip::util::cmpLineRefNatural(al, bl) < 0;
     }
   };
   std::sort(entries.begin(), entries.end(), Cmp::lt);

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -51,7 +51,14 @@ void DepartStrip::loop() {
   bool becameOn = (lastOff_ && !offMode);
   bool becameEnabled = (!lastEnabled_ && enabled_);
   if (becameOn || becameEnabled) {
-    if (now > 0) reloadSources(now);
+    bool didReload = false;
+    if (now > 0) {
+      reloadSources(now);
+      didReload = true;
+    }
+    if (didReload && bootEffectActive_) {
+      doneBooting();
+    }
   }
   lastOff_ = offMode;
   lastEnabled_ = enabled_;
@@ -385,11 +392,13 @@ void DepartStrip::showBooting() {
   seg.setColor(0, 0x404060);
   seg.setColor(1, 0x000000);
   seg.setColor(2, 0x303040);
+  bootEffectActive_ = true;
 }
 
 void DepartStrip::doneBooting() {
   Segment& seg = strip.getMainSegment();
   seg.setMode(0);
+  bootEffectActive_ = false;
 }
 
 void DepartStrip::reloadSources(std::time_t now) {

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -91,8 +91,6 @@ void DepartStrip::addToConfig(JsonObject& root) {
     sub["Delete"] = false;
   }
   // Placeholder to add new source right after existing sources
-  bool rebuiltSourcesUsed = false;
-  bool rebuiltViewsUsed = false;
   {
     JsonObject ns = top.createNestedObject("NewSource");
     ns["Enabled"] = false;

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -1,0 +1,427 @@
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <algorithm>
+
+#include "usermod_v2_departstrip.h"
+#include "interfaces.h"
+#include "util.h"
+
+#include "depart_model.h"
+#include "siri_source.h"
+#include "departure_view.h"
+
+const char CFG_NAME[] PROGMEM = "DepartStrip";
+const char CFG_ENABLED[] PROGMEM = "Enabled";
+
+static DepartStrip departstrip_usermod;
+REGISTER_USERMOD(departstrip_usermod);
+
+// Delay after boot (milliseconds) to allow disabling before heavy work
+static const uint32_t SAFETY_DELAY_MS = 10u * 1000u;
+
+DepartStrip::DepartStrip() {
+  sources_.reserve(4);
+  model_ = ::make_unique<DepartModel>();
+  views_.reserve(4);
+}
+
+void DepartStrip::setup() {
+  DEBUG_PRINTLN(F("DepartStrip: DepartStrip::setup: starting"));
+  uint32_t now_ms = millis();
+  safeToStart_ = now_ms + SAFETY_DELAY_MS;
+  if (enabled_) showBooting();
+  DEBUG_PRINTLN(F("DepartStrip: DepartStrip::setup: finished"));
+}
+
+void DepartStrip::loop() {
+  uint32_t now_ms = millis();
+  if (!edgeInit_) {
+    lastOff_ = offMode;
+    lastEnabled_ = enabled_;
+    edgeInit_ = true;
+  }
+
+  time_t const now = departstrip::util::time_now_utc();
+
+  if (now_ms < safeToStart_) return;
+
+  bool becameOn = (lastOff_ && !offMode);
+  bool becameEnabled = (!lastEnabled_ && enabled_);
+  if (becameOn || becameEnabled) {
+    if (now > 0) reloadSources(now);
+  }
+  lastOff_ = offMode;
+  lastEnabled_ = enabled_;
+
+  if (!enabled_ || offMode || strip.isUpdating()) return;
+
+  for (auto& src : sources_) {
+    if (auto data = src->fetch(now)) {
+      model_->update(now, std::move(*data));
+    }
+  }
+}
+
+void DepartStrip::handleOverlayDraw() {
+  if (!enabled_ || offMode) return;
+  time_t now = departstrip::util::time_now_utc();
+  for (auto& view : views_) {
+    view->view(now, *model_);
+  }
+}
+
+void DepartStrip::addToConfig(JsonObject& root) {
+  JsonObject top = root.createNestedObject(FPSTR(CFG_NAME));
+  top[FPSTR(CFG_ENABLED)] = enabled_;
+  // ColorMap: reset control rendered after ColorMap
+  // Emit sources sorted by their Key (AGENCY:StopCode) for stable order
+  struct SrcRef { String key; IDataSourceT<DepartModel>* ptr; };
+  std::vector<SrcRef> sorder; sorder.reserve(sources_.size());
+  for (auto& up : sources_) {
+    SiriSource* ss = static_cast<SiriSource*>(up.get());
+    String k = ss ? ss->sourceKey() : String();
+    sorder.push_back(SrcRef{k, up.get()});
+  }
+  std::sort(sorder.begin(), sorder.end(), [](const SrcRef& a, const SrcRef& b){ return a.key.compareTo(b.key) < 0; });
+  for (auto& r : sorder) {
+    IConfigurable* ic = static_cast<IConfigurable*>(r.ptr);
+    JsonObject sub = top.createNestedObject(ic->configKey());
+    ic->addToConfig(sub);
+    sub["Delete"] = false;
+  }
+  // Placeholder to add new source right after existing sources
+  bool rebuiltSourcesUsed = false;
+  bool rebuiltViewsUsed = false;
+  {
+    JsonObject ns = top.createNestedObject("NewSource");
+    ns["Enabled"] = false;
+    ns["UpdateSecs"] = 60;
+    ns["TemplateUrl"] = String(F(""));
+    ns["ApiKey"] = "";
+    ns["AgencyStopCode"] = ""; // format AGENCY:StopCode
+  }
+  // Then existing views (sorted by Key for stable order)
+  struct VwRef { String key; IDataViewT<DepartModel>* ptr; };
+  std::vector<VwRef> vorder; vorder.reserve(views_.size());
+  for (auto& up : views_) {
+    DepartureView* dv = static_cast<DepartureView*>(up.get());
+    String k = dv ? dv->viewKey() : String();
+    vorder.push_back(VwRef{k, up.get()});
+  }
+  std::sort(vorder.begin(), vorder.end(), [](const VwRef& a, const VwRef& b){ return a.key.compareTo(b.key) < 0; });
+  for (auto& r : vorder) {
+    IConfigurable* ic = static_cast<IConfigurable*>(r.ptr);
+    JsonObject sub = top.createNestedObject(ic->configKey());
+    ic->addToConfig(sub);
+    sub["Delete"] = false;
+  }
+  {
+    JsonObject nv = top.createNestedObject("NewView");
+    nv["SegmentId"] = -1;
+    nv["AgencyStopCodes"] = ""; // one or more, separated by comma/space; tokens may be AGENCY:StopCode or StopCode
+  }
+  // Emit global color map last so it appears at the bottom of the page
+  JsonObject cmap = top.createNestedObject("ColorMap");
+  // Sort entries by (agency, numeric route, suffix) for stable and natural display
+  std::vector<std::pair<String,uint32_t>> entries;
+  entries.reserve(DepartModel::colorMap().size());
+  for (const auto& ce : DepartModel::colorMap()) entries.emplace_back(ce.key, ce.rgb);
+  struct Cmp {
+    static void splitKey(const String& key, String& agency, String& line) {
+      int c = key.indexOf(':');
+      if (c > 0) { agency = key.substring(0, c); line = key.substring(c+1); }
+      else { agency = key; line = String(); }
+    }
+    static bool parseLeadingInt(const String& s, int& val, int& consumed) {
+      val = 0; consumed = 0; bool any = false;
+      for (unsigned i = 0; i < s.length(); ++i) {
+        char ch = s.charAt(i);
+        if (ch >= '0' && ch <= '9') { any = true; val = val*10 + (ch - '0'); ++consumed; }
+        else break;
+      }
+      return any;
+    }
+    static int cmpLine(const String& a, const String& b) {
+      int na=0, nb=0, ca=0, cb=0;
+      bool ha = parseLeadingInt(a, na, ca);
+      bool hb = parseLeadingInt(b, nb, cb);
+      if (ha && hb) {
+        if (na != nb) return (na < nb) ? -1 : 1;
+        String sa = a.substring(ca);
+        String sb = b.substring(cb);
+        int r = sa.compareTo(sb);
+        if (r != 0) return r < 0 ? -1 : 1;
+        return 0;
+      }
+      if (ha != hb) return ha ? -1 : 1; // numeric routes before non-numeric
+      int r = a.compareTo(b);
+      if (r != 0) return r < 0 ? -1 : 1;
+      return 0;
+    }
+    static bool lt(const std::pair<String,uint32_t>& a, const std::pair<String,uint32_t>& b) {
+      String aa, al, ba, bl; splitKey(a.first, aa, al); splitKey(b.first, ba, bl);
+      int ar = aa.compareTo(ba);
+      if (ar != 0) return ar < 0;
+      return cmpLine(al, bl) < 0;
+    }
+  };
+  std::sort(entries.begin(), entries.end(), Cmp::lt);
+  for (const auto& kv : entries) {
+    cmap[kv.first] = DepartModel::colorToString(kv.second);
+  }
+  top["ColorMapReset"] = false;      // user can set true to clear map on next read
+
+}
+
+void DepartStrip::appendConfigData(Print& s) {
+  for (auto& src : sources_) src->appendConfigData(s);
+  for (auto& vw : views_) vw->appendConfigData(s, model_.get());
+
+  // Per-source Stop name and current-route swatches (anchor below Delete)
+  for (auto& src : sources_) {
+    SiriSource* ss = static_cast<SiriSource*>(src.get());
+    if (!ss) continue;
+    String section = String(src->configKey());
+    String anchor = String(F("DepartStrip:")) + section + F(":Delete");
+
+    // Collect current lines seen for this stop from the model
+    String agency = ss->agency();
+    std::vector<String> lines;
+    if (model_) model_->currentLinesForBoard(ss->sourceKey(), lines);
+    std::vector<std::pair<String,uint32_t>> entries;
+    entries.reserve(lines.size());
+    for (const auto& line : lines) {
+      uint32_t rgb = 0x606060;
+      if (agency.length() > 0) DepartModel::getColorRGB(agency, line, rgb);
+      String fullKey = agency; fullKey += ":"; fullKey += line;
+      entries.emplace_back(fullKey, rgb);
+    }
+
+    // Build HTML suffix placed AFTER the field (3rd arg)
+    s.print(F("addInfo('")); s.print(anchor); s.print(F("',1,'"));
+    s.print(F("<div style=\\'margin-top:8px;text-align:center;\\'>"));
+    // Stop label (optional)
+    if (ss->stopName().length()) {
+      String nm = ss->stopName();
+      // Escape for HTML and JS single-quoted string context
+      nm.replace("<","&lt;"); nm.replace(">","&gt;");
+      nm.replace("\\","\\\\"); nm.replace("'","\\'");
+      s.print(F("<div style=\\'margin-bottom:4px;\\'><b>Stop:</b> ")); s.print(nm); s.print(F("</div>"));
+    }
+    if (!entries.empty()) {
+      s.print(F("<div style=\\'font-weight:600;margin-bottom:4px;\\'>Routes</div>"));
+      s.print(F("<div style=\\'display:flex;flex-wrap:wrap;gap:8px;justify-content:center;\\'>"));
+      for (const auto& kv : entries) {
+        String col = DepartModel::colorToString(kv.second);
+        s.print(F("<span style=\\'display:inline-flex;align-items:center;border:1px solid #888;padding:2px 6px;border-radius:4px;\\'>"));
+        s.print(F("<span style=\\'display:inline-block;width:14px;height:14px;margin-right:6px;background:"));
+        s.print(col);
+        s.print(F(";\\'></span><code>"));
+        int cpos = kv.first.indexOf(':');
+        if (cpos > 0) s.print(kv.first.substring(cpos+1)); else s.print(kv.first);
+        s.print(F("</code></span>"));
+      }
+      s.print(F("</div>"));
+    }
+    s.print(F("</div>"));
+    s.println(F("','');"));
+  }
+}
+
+bool DepartStrip::readFromConfig(JsonObject& root) {
+  JsonObject top = root[FPSTR(CFG_NAME)];
+  if (top.isNull()) return true;
+
+  bool ok = true;
+  bool invalidate_history = false;
+  bool startup_complete = false; // avoid fetch/reload during config save
+
+  ok &= getJsonValue(top[FPSTR(CFG_ENABLED)], enabled_, false);
+
+  // Handle color map reset (no versioning)
+  bool doReset = top["ColorMapReset"] | false;
+  if (doReset) {
+    DepartModel::clearColorMap();
+    skipColorMapLoad_ = true; // avoid re-adding from old config in this pass
+  } else {
+    skipColorMapLoad_ = false;
+  }
+
+  // Load optional color mapping overrides
+  if (!skipColorMapLoad_ && top["ColorMap"].is<JsonObject>()) {
+    JsonObject cmap = top["ColorMap"].as<JsonObject>();
+    for (JsonPair kv : cmap) {
+      const char* k = kv.key().c_str();
+      JsonVariant vj = kv.value();
+      String v = vj.as<String>();
+      if (!k || !*k) continue;
+      // Expect key format "AGENCY:LineRef"
+      String keyStr(k);
+      int colon = keyStr.indexOf(':');
+      if (colon <= 0) continue;
+      String agency = keyStr.substring(0, colon);
+      String line   = keyStr.substring(colon+1);
+      // Deletion semantics: empty, "-", or explicit null removes entry
+      if (vj.isNull() || v.length() == 0 || v == F("-") || v.equalsIgnoreCase(F("delete"))) {
+        DepartModel::removeColorKey(agency, line);
+        continue;
+      }
+      uint32_t rgb;
+      if (DepartModel::parseColorString(v, rgb)) {
+        DepartModel::setColorRGB(agency, line, rgb);
+      }
+    }
+  }
+
+  // If starting with no in-memory sources/views (e.g., fresh boot),
+  // rebuild them from any persisted sections under DepartStrip.
+  if (sources_.empty() && views_.empty()) {
+    for (JsonPair kv : top) {
+      const char* secName = kv.key().c_str();
+      if (!kv.value().is<JsonObject>() || !secName || !*secName) continue;
+      String sName(secName);
+      if (sName == F("NewSource") || sName == F("NewView") || sName == F("ColorMap")) continue;
+      JsonObject obj = kv.value().as<JsonObject>();
+      bool hasASC = obj.containsKey("AgencyStopCodes") || obj.containsKey("AgencyStopCode");
+      bool hasKey = obj.containsKey("Key");
+      bool isView = obj.containsKey("SegmentId") && (hasASC || hasKey);
+      bool isSource = (hasASC || hasKey) && !isView &&
+                      (obj.containsKey("UpdateSecs") || obj.containsKey("TemplateUrl") || obj.containsKey("BaseUrl") || obj.containsKey("ApiKey") ||
+                       obj.containsKey("Agency") || obj.containsKey("StopCode"));
+      if (isSource) {
+        auto snew = ::make_unique<SiriSource>(secName, nullptr, nullptr, nullptr);
+        bool dummy = false;
+        ok &= snew->readFromConfig(obj, startup_complete, dummy);
+        sources_.push_back(std::move(snew));
+      } else if (isView) {
+        String vkey = obj["AgencyStopCodes"] | obj["AgencyStopCode"] | obj["Key"] | "";
+        if (vkey.length() == 0) continue;
+        auto vnew = ::make_unique<DepartureView>(vkey);
+        bool dummy = false;
+        ok &= vnew->readFromConfig(obj, startup_complete, dummy);
+        views_.push_back(std::move(vnew));
+      }
+    }
+  }
+
+  // Handle deletion of existing sources
+  if (!sources_.empty()) {
+    std::vector<size_t> delIdx;
+    for (size_t i = 0; i < sources_.size(); ++i) {
+      auto& src = sources_[i];
+      JsonObject sub = top[src->configKey()];
+      if (!sub.isNull() && (bool)(sub["Delete"] | false)) delIdx.push_back(i);
+    }
+    for (size_t k = 0; k < delIdx.size(); ++k) {
+      size_t idx = delIdx[delIdx.size()-1-k];
+      sources_.erase(sources_.begin() + idx);
+    }
+  }
+  // Deduplicate sources by Key: keep first occurrence
+  if (!sources_.empty()) {
+    std::vector<size_t> delIdx;
+    std::vector<String> seen;
+    for (size_t i = 0; i < sources_.size(); ++i) {
+      SiriSource* ss = static_cast<SiriSource*>(sources_[i].get());
+      String k = ss ? ss->sourceKey() : String();
+      bool dup = false;
+      for (auto& sk : seen) if (sk == k) { dup = true; break; }
+      if (dup) delIdx.push_back(i); else seen.push_back(k);
+    }
+    for (size_t k = 0; k < delIdx.size(); ++k) {
+      size_t idx = delIdx[delIdx.size()-1-k];
+      sources_.erase(sources_.begin() + idx);
+    }
+  }
+  // Handle deletion of existing views
+  if (!views_.empty()) {
+    std::vector<size_t> delIdx;
+    for (size_t i = 0; i < views_.size(); ++i) {
+      auto& vw = views_[i];
+      JsonObject sub = top[vw->configKey()];
+      if (!sub.isNull() && (bool)(sub["Delete"] | false)) delIdx.push_back(i);
+    }
+    for (size_t k = 0; k < delIdx.size(); ++k) {
+      size_t idx = delIdx[delIdx.size()-1-k];
+      views_.erase(views_.begin() + idx);
+    }
+  }
+
+  // Read remaining sources and views
+  for (auto& src : sources_) {
+    JsonObject sub = top[src->configKey()];
+    ok &= src->readFromConfig(sub, startup_complete, invalidate_history);
+  }
+  for (auto& vw : views_) {
+    JsonObject sub = top[vw->configKey()];
+    ok &= vw->readFromConfig(sub, startup_complete, invalidate_history);
+  }
+
+  // Add new source if requested
+  if (top["NewSource"].is<JsonObject>()) {
+    JsonObject ns = top["NewSource"].as<JsonObject>();
+    String nsKey = ns["AgencyStopCode"] | ns["Key"] | "";
+    nsKey.trim();
+    if (nsKey.length() > 0) {
+      // avoid duplicate by Key
+      bool existsKey = false;
+      for (auto& s : sources_) {
+        SiriSource* ss = static_cast<SiriSource*>(s.get());
+        if (ss && ss->sourceKey() == nsKey) { existsKey = true; break; }
+      }
+      if (!existsKey) {
+        // Generate unique configKey like "siri_sourceN"
+        int next = 1;
+        auto exists = [&](const char* k){ String kk(k); for (auto& s : sources_) if (String(s->configKey()) == kk) return true; return false; };
+        String cfg;
+        do { cfg = String(F("siri_source")); cfg += next++; } while (exists(cfg.c_str()));
+        auto snew = ::make_unique<SiriSource>(cfg.c_str(), nullptr, nullptr, nullptr);
+        bool dummy = false;
+        ok &= snew->readFromConfig(ns, startup_complete, dummy);
+        sources_.push_back(std::move(snew));
+      } else {
+        DEBUG_PRINTF("DepartStrip: NewSource ignored, duplicate Key %s\n", nsKey.c_str());
+      }
+    }
+  }
+  // Add new view if requested
+  if (top["NewView"].is<JsonObject>()) {
+    JsonObject nv = top["NewView"].as<JsonObject>();
+    String key = nv["AgencyStopCodes"] | nv["AgencyStopCode"] | nv["Key"] | "";
+    key.trim();
+    if (key.length() > 0) {
+      auto vnew = ::make_unique<DepartureView>(key);
+      bool dummy = false;
+      ok &= vnew->readFromConfig(nv, startup_complete, dummy);
+      views_.push_back(std::move(vnew));
+    }
+  }
+
+  if (invalidate_history) {
+    model_->boards.clear();
+    if (startup_complete) reloadSources(departstrip::util::time_now_utc());
+  }
+
+  // Always report success to persist changes
+  return true;
+}
+
+void DepartStrip::showBooting() {
+  Segment& seg = strip.getMainSegment();
+  seg.setMode(28);
+  seg.speed = 200;
+  seg.setPalette(128);
+  seg.setColor(0, 0x404060);
+  seg.setColor(1, 0x000000);
+  seg.setColor(2, 0x303040);
+}
+
+void DepartStrip::doneBooting() {
+  Segment& seg = strip.getMainSegment();
+  seg.setMode(0);
+}
+
+void DepartStrip::reloadSources(std::time_t now) {
+  for (auto& src : sources_) src->reload(now);
+}

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -73,7 +73,13 @@ void DepartStrip::loop() {
 }
 
 void DepartStrip::handleOverlayDraw() {
-  if (!enabled_ || offMode) return;
+  if (!enabled_ || offMode) {
+    for (auto& view : views_) {
+      auto* dv = static_cast<DepartureView*>(view.get());
+      if (dv) dv->ensureUnfrozen();
+    }
+    return;
+  }
   time_t now = departstrip::util::time_now_utc();
   for (auto& view : views_) {
     view->view(now, *model_);

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -203,6 +203,7 @@ void DepartStrip::appendConfigData(Print& s) {
     if (ss->stopName().length()) {
       String nm = ss->stopName();
       // Escape for HTML and JS single-quoted string context
+      nm.replace("&","&amp;");
       nm.replace("<","&lt;"); nm.replace(">","&gt;");
       nm.replace("\\","\\\\"); nm.replace("'","\\'");
       s.print(F("<div style=\\'margin-bottom:4px;\\'><b>Stop:</b> ")); s.print(nm); s.print(F("</div>"));

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.cpp
@@ -13,6 +13,10 @@
 #include "gtfsrt_source.h"
 #include "departure_view.h"
 
+#ifndef DEPARTSTRIP_GIT_DESCRIBE
+#define DEPARTSTRIP_GIT_DESCRIBE "unknown"
+#endif
+
 const char CFG_NAME[] PROGMEM = "DepartStrip";
 const char CFG_ENABLED[] PROGMEM = "Enabled";
 
@@ -49,6 +53,7 @@ DepartStrip::DepartStrip() {
 
 void DepartStrip::setup() {
   DEBUG_PRINTLN(F("DepartStrip: DepartStrip::setup: starting"));
+  DEBUG_PRINTF("DepartStrip: version=%s\n", DEPARTSTRIP_GIT_DESCRIBE);
   uint32_t now_ms = millis();
   safeToStart_ = now_ms + SAFETY_DELAY_MS;
   // Initialize view window to default until config loads
@@ -111,6 +116,7 @@ void DepartStrip::addToConfig(JsonObject& root) {
   JsonObject top = root.createNestedObject(FPSTR(CFG_NAME));
   top[FPSTR(CFG_ENABLED)] = enabled_;
   top["DisplayMinutes"] = displayMinutes_;
+  top["Version"] = DEPARTSTRIP_GIT_DESCRIBE;
   // ColorMap: reset control rendered after ColorMap
   // Emit sources sorted by their Key (AGENCY:StopCode) for stable order
   struct SrcRef { String key; IDataSourceT<DepartModel>* ptr; };
@@ -184,6 +190,7 @@ void DepartStrip::addToConfig(JsonObject& root) {
 }
 
 void DepartStrip::appendConfigData(Print& s) {
+  s.println(F("(()=>{const NAME='DepartStrip:Version'; const input=document.querySelector(`input[name=\"${NAME}\"][type=\"text\"]`); if(!input||input.dataset.versionDecorated) return; input.dataset.versionDecorated='1'; const value=(input.value||'').trim()||'unknown'; input.readOnly=true; input.type='hidden'; let node=input.previousSibling; while(node&&node.nodeType===3){const trimmed=node.textContent.trim(); if(trimmed.length&&trimmed.toLowerCase()!=='text'){break;} const remove=node; node=node.previousSibling; remove.parentNode.removeChild(remove);} const badge=document.createElement('small'); badge.textContent=value; badge.style.marginLeft='0.5rem'; input.parentNode.insertBefore(badge, input.nextSibling);})();"));
   for (auto& src : sources_) src->appendConfigData(s);
   for (auto& vw : views_) vw->appendConfigData(s, model_.get());
 

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
@@ -20,6 +20,7 @@ private:
   bool edgeInit_ = false;
   bool lastOff_ = false;
   bool lastEnabled_ = false;
+  bool bootEffectActive_ = false;
 
   std::vector<std::unique_ptr<IDataSourceT<DepartModel>>> sources_;
   std::unique_ptr<DepartModel> model_;

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
@@ -15,6 +15,7 @@ class DepartureView;
 class DepartStrip : public Usermod {
 private:
   bool enabled_ = false;
+  uint16_t displayMinutes_ = 60; // usermod-wide view window in minutes
   uint32_t safeToStart_ = 0;
   bool edgeInit_ = false;
   bool lastOff_ = false;

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
@@ -1,0 +1,46 @@
+#pragma once
+#include <memory>
+#include <vector>
+
+#include "interfaces.h"
+#include "wled.h"
+
+#define DEPARTSTRIP_VERSION "0.0.1"
+#define USERMOD_ID_DEPARTSTRIP 561
+
+class DepartModel;
+class SiriSource;
+class DepartureView;
+
+class DepartStrip : public Usermod {
+private:
+  bool enabled_ = false;
+  uint32_t safeToStart_ = 0;
+  bool edgeInit_ = false;
+  bool lastOff_ = false;
+  bool lastEnabled_ = false;
+
+  std::vector<std::unique_ptr<IDataSourceT<DepartModel>>> sources_;
+  std::unique_ptr<DepartModel> model_;
+  std::vector<std::unique_ptr<IDataViewT<DepartModel>>> views_;
+  bool skipColorMapLoad_ = false; // one-shot: skip loading ColorMap after reset
+
+public:
+  DepartStrip();
+  ~DepartStrip() override = default;
+  void setup() override;
+  void loop() override;
+  void handleOverlayDraw() override;
+  void addToConfig(JsonObject &obj) override;
+  void appendConfigData(Print& s) override;
+  bool readFromConfig(JsonObject& obj) override;
+  uint16_t getId() override { return USERMOD_ID_DEPARTSTRIP; }
+
+  inline void enable(bool en) { enabled_ = en; }
+  inline bool isEnabled() { return enabled_; }
+
+protected:
+  void showBooting();
+  void doneBooting();
+  void reloadSources(std::time_t now);
+};

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
@@ -37,7 +37,7 @@ public:
   uint16_t getId() override { return USERMOD_ID_DEPARTSTRIP; }
 
   inline void enable(bool en) { enabled_ = en; }
-  inline bool isEnabled() { return enabled_; }
+  inline bool isEnabled() const { return enabled_; }
 
 protected:
   void showBooting();

--- a/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
+++ b/usermods/usermod_v2_departstrip/usermod_v2_departstrip.h
@@ -10,6 +10,7 @@
 
 class DepartModel;
 class SiriSource;
+class GtfsRtSource;
 class DepartureView;
 
 class DepartStrip : public Usermod {

--- a/usermods/usermod_v2_departstrip/util.cpp
+++ b/usermods/usermod_v2_departstrip/util.cpp
@@ -1,0 +1,27 @@
+#include "util.h"
+
+namespace departstrip { namespace util {
+
+// Same simple HSV to RGB helper used in bartdepart
+uint32_t hsv2rgb(float h, float s, float v) {
+  if (s <= 0.f) return RGBW32(v * 255, v * 255, v * 255, 0);
+  h = fmodf(h, 1.f); if (h < 0.f) h += 1.f;
+  float i = floorf(h * 6.f);
+  float f = h * 6.f - i;
+  float p = v * (1.f - s);
+  float q = v * (1.f - s * f);
+  float t = v * (1.f - s * (1.f - f));
+  float r=0,g=0,b=0;
+  switch(((int)i) % 6) {
+    case 0: r=v,g=t,b=p; break;
+    case 1: r=q,g=v,b=p; break;
+    case 2: r=p,g=v,b=t; break;
+    case 3: r=p,g=q,b=v; break;
+    case 4: r=t,g=p,b=v; break;
+    case 5: r=v,g=p,b=q; break;
+  }
+  return RGBW32((uint8_t)(r*255),(uint8_t)(g*255),(uint8_t)(b*255),0);
+}
+
+} } // namespace
+

--- a/usermods/usermod_v2_departstrip/util.cpp
+++ b/usermods/usermod_v2_departstrip/util.cpp
@@ -51,4 +51,14 @@ int cmpLineRefNatural(const String& a, const String& b) {
   return 0;
 }
 
+// Usermod-wide view window in minutes
+static uint16_t g_display_minutes = 60;
+uint16_t getDisplayMinutes() { return g_display_minutes; }
+void setDisplayMinutes(uint16_t minutes) {
+  // Clamp to a sane range to avoid degenerate behavior
+  if (minutes < 10) minutes = 10;        // minimum 10 minutes
+  if (minutes > 240) minutes = 240;      // maximum 4 hours
+  g_display_minutes = minutes;
+}
+
 } } // namespace

--- a/usermods/usermod_v2_departstrip/util.cpp
+++ b/usermods/usermod_v2_departstrip/util.cpp
@@ -23,5 +23,32 @@ uint32_t hsv2rgb(float h, float s, float v) {
   return RGBW32((uint8_t)(r*255),(uint8_t)(g*255),(uint8_t)(b*255),0);
 }
 
-} } // namespace
+static bool parseLeadingInt(const String& s, int& val, int& consumed) {
+  val = 0; consumed = 0; bool any = false;
+  for (unsigned i = 0; i < s.length(); ++i) {
+    char ch = s.charAt(i);
+    if (ch >= '0' && ch <= '9') { any = true; val = val*10 + (ch - '0'); ++consumed; }
+    else break;
+  }
+  return any;
+}
 
+int cmpLineRefNatural(const String& a, const String& b) {
+  int na=0, nb=0, ca=0, cb=0;
+  bool ha = parseLeadingInt(a, na, ca);
+  bool hb = parseLeadingInt(b, nb, cb);
+  if (ha && hb) {
+    if (na != nb) return (na < nb) ? -1 : 1;
+    String sa = a.substring(ca);
+    String sb = b.substring(cb);
+    int r = sa.compareTo(sb);
+    if (r != 0) return (r < 0) ? -1 : 1;
+    return 0;
+  }
+  if (ha != hb) return ha ? -1 : 1; // numeric routes before non-numeric
+  int r = a.compareTo(b);
+  if (r != 0) return (r < 0) ? -1 : 1;
+  return 0;
+}
+
+} } // namespace

--- a/usermods/usermod_v2_departstrip/util.cpp
+++ b/usermods/usermod_v2_departstrip/util.cpp
@@ -53,6 +53,48 @@ int cmpLineRefNatural(const String& a, const String& b) {
 
 // Usermod-wide view window in minutes
 static uint16_t g_display_minutes = 60;
+String formatLineLabel(const String& agency, const String& rawLine) {
+  String ag = agency;
+  ag.trim();
+  String line = rawLine;
+  line.trim();
+  if (ag.length() == 0) {
+    return line;
+  }
+  String agLower = ag;
+  agLower.toLowerCase();
+  String lineLower = line;
+  lineLower.toLowerCase();
+  bool hasPrefix = false;
+  if (lineLower.length() >= agLower.length()) {
+    hasPrefix = lineLower.startsWith(agLower);
+  }
+  if (hasPrefix) {
+    unsigned int pos = ag.length();
+    while (pos < line.length()) {
+      char c = line.charAt(pos);
+      if (c == ' ' || c == '\t' || c == '-' || c == '_' || c == ':' ) {
+        ++pos;
+        continue;
+      }
+      break;
+    }
+    String suffix = line.substring(pos);
+    suffix.trim();
+    if (suffix.length() == 0) return ag;
+    String out = ag;
+    out += ' ';
+    out += suffix;
+    return out;
+  }
+  if (line.length() == 0) return ag;
+  String out = ag;
+  out += ' ';
+  out += line;
+  return out;
+}
+
+
 uint16_t getDisplayMinutes() { return g_display_minutes; }
 void setDisplayMinutes(uint16_t minutes) {
   // Clamp to a sane range to avoid degenerate behavior

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "wled.h"
+#include <cmath>
+#include <cstdint>
+#include <ctime>
+
+namespace departstrip {
+namespace util {
+
+struct FreezeGuard {
+  Segment &seg;
+  bool prev;
+  explicit FreezeGuard(Segment &s, bool freezeNow = true) : seg(s), prev(s.freeze) {
+    seg.freeze = freezeNow;
+  }
+  ~FreezeGuard() { seg.freeze = prev; }
+  FreezeGuard(const FreezeGuard &) = delete;
+  FreezeGuard &operator=(const FreezeGuard &) = delete;
+};
+
+inline time_t time_now_utc() { return (time_t)toki.getTime().sec; }
+inline time_t time_now() { return time_now_utc(); }
+
+inline long current_offset() {
+  long off = (long)localTime - (long)toki.getTime().sec;
+  if (off < -54000 || off > 54000) off = 0;
+  return off;
+}
+
+inline void fmt_local(char *out, size_t n, time_t utc_ts,
+                      const char *fmt = "%m-%d %H:%M") {
+  const time_t local_sec = utc_ts + current_offset();
+  struct tm tmLocal;
+  gmtime_r(&local_sec, &tmLocal);
+  strftime(out, n, fmt, &tmLocal);
+}
+
+uint32_t hsv2rgb(float h, float s, float v);
+
+} // namespace util
+} // namespace departstrip

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -8,17 +8,6 @@
 namespace departstrip {
 namespace util {
 
-struct FreezeGuard {
-  Segment &seg;
-  bool prev;
-  explicit FreezeGuard(Segment &s, bool freezeNow = true) : seg(s), prev(s.freeze) {
-    seg.freeze = freezeNow;
-  }
-  ~FreezeGuard() noexcept { seg.freeze = prev; }
-  FreezeGuard(const FreezeGuard &) = delete;
-  FreezeGuard &operator=(const FreezeGuard &) = delete;
-};
-
 inline time_t time_now_utc() { return (time_t)toki.getTime().sec; }
 inline time_t time_now() { return time_now_utc(); }
 

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -14,7 +14,7 @@ struct FreezeGuard {
   explicit FreezeGuard(Segment &s, bool freezeNow = true) : seg(s), prev(s.freeze) {
     seg.freeze = freezeNow;
   }
-  ~FreezeGuard() { seg.freeze = prev; }
+  ~FreezeGuard() noexcept { seg.freeze = prev; }
   FreezeGuard(const FreezeGuard &) = delete;
   FreezeGuard &operator=(const FreezeGuard &) = delete;
 };

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -44,5 +44,10 @@ uint32_t hsv2rgb(float h, float s, float v);
 // lexicographically. Returns negative if a<b, zero if equal, positive if a>b.
 int cmpLineRefNatural(const String& a, const String& b);
 
+// Global display time scale for views (in minutes).
+// Default 60; configurable via usermod top-level setting.
+uint16_t getDisplayMinutes();
+void setDisplayMinutes(uint16_t minutes);
+
 } // namespace util
 } // namespace departstrip

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -39,5 +39,10 @@ inline void fmt_local(char *out, size_t n, time_t utc_ts,
 
 uint32_t hsv2rgb(float h, float s, float v);
 
+// Natural compare for route/line strings: compare by leading integer value
+// if present (e.g. "10" < "100" < "100A"), then by the remaining suffix
+// lexicographically. Returns negative if a<b, zero if equal, positive if a>b.
+int cmpLineRefNatural(const String& a, const String& b);
+
 } // namespace util
 } // namespace departstrip

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -22,9 +22,10 @@ struct FreezeGuard {
 inline time_t time_now_utc() { return (time_t)toki.getTime().sec; }
 inline time_t time_now() { return time_now_utc(); }
 
+static constexpr long kMaxOffsetSec = 15L * 3600L; // +/-15h safety clamp
 inline long current_offset() {
   long off = (long)localTime - (long)toki.getTime().sec;
-  if (off < -54000 || off > 54000) off = 0;
+  if (off < -kMaxOffsetSec || off > kMaxOffsetSec) off = 0;
   return off;
 }
 

--- a/usermods/usermod_v2_departstrip/util.h
+++ b/usermods/usermod_v2_departstrip/util.h
@@ -86,5 +86,9 @@ int cmpLineRefNatural(const String& a, const String& b);
 uint16_t getDisplayMinutes();
 void setDisplayMinutes(uint16_t minutes);
 
+// Combine agency and lineRef into a user-facing label while avoiding
+// duplicating the agency prefix if it is already present in the lineRef.
+String formatLineLabel(const String& agency, const String& rawLine);
+
 } // namespace util
 } // namespace departstrip


### PR DESCRIPTION
## DepartStrip

Render upcoming departures from SIRI StopMonitoring feeds on WLED LED segments.

SIRI stands for “Service Interface for Real Time Information” — a CEN/Transmodel family standard for exchanging real‑time public transport data. StopMonitoring is the SIRI service that returns predicted arrivals/departures at a stop.

### Feed Examples:

- 511.org StopMonitoring (Bay Area)
  - Endpoint: `http://api.511.org/transit/StopMonitoring?format=json&api_key=KEY&agency=AGENCY&stopCode=STOP`
  - Agencies include BART (`BA`), AC Transit (`AC`), and many others across the nine‑county region.

- MTA Bus Time StopMonitoring (NYC)
  - Endpoint: `http://bustime.mta.info/api/siri/stop-monitoring.json?key=KEY&OperatorRef=MTA&MonitoringRef=STOP`
  - Coverage: the New York City bus network (hundreds of routes
    including local, limited, SBS, and express).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DepartStrip usermod: configurable SIRI/CTA/GTFS-RT sources, runtime source/view management, LED-segment rendering of upcoming departures with time-based blending, cycling when multiple estimates, boot visuals, per-view config and counts.

- **New APIs / Interfaces**
  - Pluggable data-source/view interfaces, a merge-capable departures model, and per-line color map with get/set and persistence.

- **Utilities**
  - Natural numeric-aware line sorting, HSV→RGB helper, local time formatting, global display-minute control, and robust HTTP transport.

- **Documentation**
  - Detailed README and printable explainer templates/legends/FAQ.

- **Chores**
  - Module manifest and build/version script added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->