### PR TITLE
fix: correctly parse the path in getloc

### DIFF
--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -86,7 +86,7 @@ function getLoc() {
 		let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");
 		if (paths.length > 1) paths.pop(); // remove subpage (or "settings")
 		if (paths.length > 0 && paths[paths.length-1]=="settings") paths.pop(); // remove "settings"
-		if (paths.length > 1) {
+		if (paths.length > 0) {
 			locproto = l.protocol;
 			loc = true;
 			locip = l.hostname + (l.port ? ":" + l.port : "") + "/" + paths.join('/');

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -84,8 +84,14 @@ function getLoc() {
 		// detect reverse proxy
 		let path = l.pathname;
 		let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");
-		if (paths.length > 1) paths.pop(); // remove subpage (or "settings")
-		if (paths.length > 0 && paths[paths.length-1]=="settings") paths.pop(); // remove "settings"
+
+		// remove settings paths to get the base url
+		const settingsIndex = paths.lastIndexOf("settings");
+		const pathLength = paths.length;
+		if (settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2) {
+			paths = paths.slice(0, settingsIndex);
+		}
+
 		if (paths.length > 0) {
 			locproto = l.protocol;
 			loc = true;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -81,18 +81,10 @@ function getLoc() {
 			localStorage.setItem('locIp', locip);
 		}
 	} else {
-		// detect reverse proxy
-		let path = l.pathname;
-		let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");
-
-		// remove settings paths to get the base url
-		const settingsIndex = paths.lastIndexOf("settings");
-		if (settingsIndex > 0) paths = paths.slice(0, settingsIndex);
-
-		if (paths.length && paths[paths.length - 1].includes(".")) {
- 			// drop trailing file like index.htm
- 			paths.pop();
- 		}
+		// guess the base url if WLED is behind a reverse proxy		
+		let paths = l.pathname.split("/").slice(1); // first is always empty
+		let settingsIndex = paths.lastIndexOf("settings");
+		paths = paths.slice(0, settingsIndex); // if we don't have "settings", remove last entry (empty / or file)
 
 		if (paths.length > 0) {
 			locproto = l.protocol;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -89,11 +89,15 @@ function getLoc() {
 		const settingsIndex = paths.lastIndexOf("settings");
 		const pathLength = paths.length;
 		if (
-			settingsIndex != -1 &&
+			settingsIndex !== -1 &&
 			(settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2)
 		) {
 			paths = paths.slice(0, settingsIndex);
-		}
+		} else if (paths.length && paths[paths.length - 1].includes(".")) {
+ 			// drop trailing file like index.htm
+ 			paths.pop();
+ 		}
+
 
 		if (paths.length > 0) {
 			locproto = l.protocol;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -87,17 +87,12 @@ function getLoc() {
 
 		// remove settings paths to get the base url
 		const settingsIndex = paths.lastIndexOf("settings");
-		const pathLength = paths.length;
-		if (
-			settingsIndex !== -1 &&
-			(settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2)
-		) {
-			paths = paths.slice(0, settingsIndex);
-		} else if (paths.length && paths[paths.length - 1].includes(".")) {
+		if (settingsIndex > 0) paths = paths.slice(0, settingsIndex);
+
+		if (paths.length && paths[paths.length - 1].includes(".")) {
  			// drop trailing file like index.htm
  			paths.pop();
  		}
-
 
 		if (paths.length > 0) {
 			locproto = l.protocol;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -81,7 +81,7 @@ function getLoc() {
 			localStorage.setItem('locIp', locip);
 		}
 	} else {
-		// guess the base url if WLED is behind a reverse proxy		
+		// guess the base url if WLED is behind a reverse proxy
 		let paths = l.pathname.split("/").slice(1); // first is always empty
 		let settingsIndex = paths.lastIndexOf("settings");
 		paths = paths.slice(0, settingsIndex); // if we don't have "settings", remove last entry (empty / or file)

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -88,7 +88,10 @@ function getLoc() {
 		// remove settings paths to get the base url
 		const settingsIndex = paths.lastIndexOf("settings");
 		const pathLength = paths.length;
-		if (settingsIndex != -1 && (settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2)) {
+		if (
+			settingsIndex != -1 &&
+			(settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2)
+		) {
 			paths = paths.slice(0, settingsIndex);
 		}
 

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -88,7 +88,7 @@ function getLoc() {
 		// remove settings paths to get the base url
 		const settingsIndex = paths.lastIndexOf("settings");
 		const pathLength = paths.length;
-		if (settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2) {
+		if (settingsIndex != -1 && (settingsIndex === pathLength - 1 || settingsIndex === pathLength - 2)) {
 			paths = paths.slice(0, settingsIndex);
 		}
 


### PR DESCRIPTION
If you put WLED behind a reverse proxy, `getLoc` will ignore the reverse proxy if it is only one subpath (for example, if I had WLED on `/lights/`, `getLoc` would not find the subpath, and settings pages would not load).

Instead of blindly trimming the last path, this change has getLoc trim anything after `/settings/`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable base URL detection for apps served behind reverse proxies or subpaths.
  * Correct handling of URLs with trailing "settings" segments and file-like segments, preventing broken links or missing assets.
  * Works correctly for single-segment paths and instances without a "settings" section.

* **Refactor**
  * Simplified and more robust path parsing to improve navigation and asset loading across varied deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->