### PR TITLE
Random colors via JSON API in Segment object like "col":["r","r","r"] #4996

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -205,7 +205,7 @@ static bool deserializeSegment(JsonObject elem, byte it, byte presetId = 0)
         // JSON "col" array can contain the following values for each of segment's colors (primary, background, custom):
         // "col":[int|string|object|array, int|string|object|array, int|string|object|array]
         //   int = Kelvin temperature or 0 for black
-        //   string = hex representation of [WW]RRGGBB
+        //   string = hex representation of [WW]RRGGBB or "r" for random color
         //   object = individual channel control {"r":0,"g":127,"b":255,"w":255}, each being optional (valid to send {})
         //   array = direct channel values [r,g,b,w] (w element being optional)
         int rgbw[] = {0,0,0,0};


### PR DESCRIPTION
Resolves my feature fequest
https://github.com/wled/WLED/issues/4996

Dear Developers,

this pull request adds the option to set Random colors via JSON API in Segment object like col=["r","r","r"].
As an alternative to setting the colors to the fix values.
Similar to the already impleneted "r" for palette pal and effect fx.

Why? Many people scoll through all effects and palettes using a playlist with one random effect and palette. But some effects use the 1 to 3 colors instead of the palette, so for them the colors can not be set randomly.

Best regards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-segment color settings via the JSON API now accept the single-character string "r" to assign a random RGBW color. This complements existing color formats (Kelvin, hex, object/array) and enables quick, dynamic color selection without specifying exact values, making it easier to request randomized segment colors through the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->