### PR TITLE
Fix blank area issue with Twinkle

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -672,7 +672,7 @@ uint16_t mode_twinkle(void) {
     if (SEGENV.aux0 >= maxOn)
     {
       SEGENV.aux0 = 0;
-      SEGENV.aux1 = hw_random16(); //new seed for our PRNG (16-bit for better coverage)
+      SEGENV.aux1 = hw_random(); //new seed for our PRNG
     }
     SEGENV.aux0++;
     SEGENV.step = it;


### PR DESCRIPTION
There was an issue with my setup where the first ~100 lights in my ~500 light string would not twinkle and would stay as the background color.

This fixes that issue on my setup.

AI seems to think that because the `hw_random` method creates a 32 bit number, when it's combined and truncated, it somehow leaves out a portion of the segment when the segment size is much smaller than 2^32.
Switching to a 16 bit random number fixed it. I'm not sure why, but I've built and tested it, and it works as expected with the same segments as the previously broken one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted the Twinkle effect’s internal random generation to a consistent 16-bit source, improving stability and visual variety of sparkle patterns.
  * Slight changes to random sequencing may subtly alter existing Twinkle animations’ appearance; no action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->