### PR TITLE
adding dynamic update of LED type dropdown

### DIFF
--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -458,7 +458,7 @@
 				var cn = `<div class="iST">
 <hr class="sml">
 ${i+1}:
-<select name="LT${s}" onchange="UI(true)"></select><br>
+<select name="LT${s}" onchange="updateTypeDropdowns();UI(true)"></select><br>
 <div id="abl${s}">
 mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 <option value="55" selected>55mA (typ. 5V WS281x)</option>
@@ -518,6 +518,7 @@ mA/LED: <select name="LAsel${s}" onchange="enLA(this,'${s}');UI();">
 				sel.value = sel.querySelector('option[data-type="N"]').value;
 				updateTypeDropdowns(); // update valid bus options including this new one
 				sel.selectedIndex = sel.querySelector('option:not(:disabled)').index;
+				updateTypeDropdowns(); // update again for the newly selected type
 			}
 			if (n==-1) {
 				o[--i].remove();--i;


### PR DESCRIPTION
removing restriction to only allow changing of last bus by dynamically updating the dropdown menus

@blazoncek is this a valid fix or did I misunderstand the issue?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * LED type dropdowns now dynamically recalculate and restrict options based on current bus usage and type limits to prevent incompatible selections.
  * Recalculation runs during UI initialization and whenever LED configuration changes, ensuring consistent enforcement across all selectors.
  * Centralized update logic preserves valid selections when adding or changing LEDs for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->