### PR TITLE
Add segment checkmarks to `differs()` check

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -51,6 +51,9 @@ namespace {
     if (a.custom1 != b.custom1)     d |= SEG_DIFFERS_FX;
     if (a.custom2 != b.custom2)     d |= SEG_DIFFERS_FX;
     if (a.custom3 != b.custom3)     d |= SEG_DIFFERS_FX;
+    if (a.check1 != b.check1)       d |= SEG_DIFFERS_FX;
+    if (a.check2 != b.check2)       d |= SEG_DIFFERS_FX;
+    if (a.check3 != b.check3)       d |= SEG_DIFFERS_FX;
     if (a.startY != b.startY)       d |= SEG_DIFFERS_BOUNDS;
     if (a.stopY != b.stopY)         d |= SEG_DIFFERS_BOUNDS;
 


### PR DESCRIPTION
When changing segment's sliders, `differs()`, in json.cpp, will return changed state. However it will not do the same if checkmarks are changed.
This PR solves the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal change detection mechanisms for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->