### PR TITLE
0.15 - Fix bin file output names

### DIFF
--- a/pio-scripts/output_bins.py
+++ b/pio-scripts/output_bins.py
@@ -2,6 +2,7 @@ Import('env')
 import os
 import shutil
 import gzip
+import json
 
 OUTPUT_DIR = "build_output{}".format(os.path.sep)
 #OUTPUT_DIR = os.path.join("build_output")
@@ -22,7 +23,8 @@ def create_release(source):
     release_name_def = _get_cpp_define_value(env, "WLED_RELEASE_NAME")
     if release_name_def:
         release_name = release_name_def.replace("\\\"", "")
-        version = _get_cpp_define_value(env, "WLED_VERSION")
+        with open("package.json", "r") as package:
+            version = json.load(package)["version"]        
         release_file = os.path.join(OUTPUT_DIR, "release", f"WLED_{version}_{release_name}.bin")
         release_gz_file = release_file + ".gz"
         print(f"Copying {source} to {release_file}")

--- a/pio-scripts/set_metadata.py
+++ b/pio-scripts/set_metadata.py
@@ -76,15 +76,13 @@ def get_github_repo():
         # Any other unexpected error
         return None
 
-PACKAGE_FILE = "package.json"
-
-def get_version():
-    try:
-        with open(PACKAGE_FILE, "r") as package:
-            return json.load(package)["version"]
-    except (FileNotFoundError, KeyError, json.JSONDecodeError):
-        return None
-
+# WLED version is managed by package.json; this is picked up in several places
+# - It's integrated in to the UI code
+# - Here, for wled_metadata.cpp
+# - The output_bins script
+# We always take it from package.json to ensure consistency
+with open("package.json", "r") as package:
+    WLED_VERSION = json.load(package)["version"]
 
 def has_def(cppdefs, name):
     """ Returns true if a given name is set in a CPPDEFINES collection """
@@ -104,10 +102,7 @@ def add_wled_metadata_flags(env, node):
         if repo:
             cdefs.append(("WLED_REPO", f"\\\"{repo}\\\""))
 
-    if not has_def(cdefs, "WLED_VERSION"):
-        version = get_version()
-        if version:
-            cdefs.append(("WLED_VERSION", version))
+    cdefs.append(("WLED_VERSION", WLED_VERSION))
 
     # This transforms the node in to a Builder; it cannot be modified again
     return env.Object(


### PR DESCRIPTION
Always use package.json for WLED_VERSION.  Ensures consistency between UI and metadata; fixes release bin names.

This commit is on the branch for #4998 but didn't make it in time for being merged to 0_15_x.