### PR TITLE
FX.cpp: Update "colorful" for flexibility in # of colors from palette 

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1023,6 +1023,10 @@ void mode_colorful(void) {
         uint32_t iCol = RGBW32(c.r, c.g, c.b, 0);
         if (numColors == 0 || (iCol && iCol != cols[numColors-1])) cols[numColors++] = iCol;
       }
+      if (numColors == 0) {
+        numColors = 1;
+        cols[0] = RGBW32(0, 0, 0);
+      }
     }
   } else { //default Red - Amber - Green - Blue
     numColors = (numColors > 0 && numColors < 4) ? numColors : 4; //1 to 4, default 4
@@ -1050,7 +1054,7 @@ void mode_colorful(void) {
     for (unsigned j = 0; j < numColors; j++) SEGMENT.setPixelColor(i + j, cols[SEGENV.aux0 + j]);
   }
 }
-static const char _data_FX_MODE_COLORFUL[] PROGMEM = "Colorful@!,Colors (pastels/default/color slots),,,# of colors (0=auto);1,2,3;!;;c3=4";
+static const char _data_FX_MODE_COLORFUL[] PROGMEM = "Colorful@!,Color scheme,,,# of colors;1,2,3;!;;c3=4";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1003,28 +1003,37 @@ static const char _data_FX_MODE_CHASE_RAINBOW_WHITE[] PROGMEM = "Rainbow Runner@
 
 
 /*
- * Red - Amber - Green - Blue lights running
+ * Running discrete colored lights (default Red - Amber - Green - Blue)
  */
 void mode_colorful(void) {
-  unsigned numColors = 4; //3, 4, or 5
-  uint32_t cols[9]{0x00FF0000,0x00EEBB00,0x0000EE00,0x000077CC};
+  unsigned numColors = (SEGMENT.custom3 > 16) ? 16 : SEGMENT.custom3; //defaults to 4, max of 16
+  uint32_t cols[31]{0x00FF0000,0x00EEBB00,0x0000EE00,0x000077CC};
   if (SEGMENT.intensity > 160 || SEGMENT.palette) { //palette or color
-    if (!SEGMENT.palette) {
-      numColors = 3;
-      for (size_t i = 0; i < 3; i++) cols[i] = SEGCOLOR(i);
-    } else {
-      unsigned fac = 80;
-      if (SEGMENT.palette == 52) {numColors = 5; fac = 61;} //C9 2 has 5 colors
+    if (!SEGMENT.palette) { //use color slots 1, 2, and/or 3
+      numColors = (numColors > 0 && numColors < 3) ? numColors : 3; //1 to 3, default 3
+      for (size_t i = 0; i < numColors; i++) cols[i] = SEGCOLOR(i);
+    } else if (numColors > 0) { //get numColors of colors from palette
+      unsigned fac = numColors > 1 ? (int)(255/(numColors - 1)) : 0;
       for (size_t i = 0; i < numColors; i++) {
-        cols[i] = SEGMENT.color_from_palette(i*fac, false, true, 255);
+        cols[i] = SEGMENT.color_from_palette(i*fac, false, false, 255);
+      }
+    } else { //get all non-repeating colors from palette (up to 16)
+      cols[0] = RGBW32(SEGPALETTE[0].r, SEGPALETTE[0].g, SEGPALETTE[0].b, 0);
+      numColors = 1;
+      for (size_t i = 1; i < 16; ++i) {
+        uint32_t iCol = RGBW32(SEGPALETTE[i].r, SEGPALETTE[i].g, SEGPALETTE[i].b, 0);
+        if (iCol && (iCol != cols[numColors-1])) cols[numColors++] = iCol;
       }
     }
-  } else if (SEGMENT.intensity < 80) //pastel (easter) colors
-  {
-    cols[0] = 0x00FF8040;
-    cols[1] = 0x00E5D241;
-    cols[2] = 0x0077FF77;
-    cols[3] = 0x0077F0F0;
+  } else { //default Red - Amber - Green - Blue
+    numColors = (numColors > 0 && numColors < 4) ? numColors : 4; //1 to 4, default 4
+    if (SEGMENT.intensity < 80) //pastel (easter) colors
+    {
+      cols[0] = 0x00FF8040;
+      cols[1] = 0x00E5D241;
+      cols[2] = 0x0077FF77;
+      cols[3] = 0x0077F0F0;
+    }
   }
   for (size_t i = numColors; i < numColors*2 -1U; i++) cols[i] = cols[i-numColors];
 
@@ -1042,7 +1051,7 @@ void mode_colorful(void) {
     for (unsigned j = 0; j < numColors; j++) SEGMENT.setPixelColor(i + j, cols[SEGENV.aux0 + j]);
   }
 }
-static const char _data_FX_MODE_COLORFUL[] PROGMEM = "Colorful@!,Saturation;1,2,3;!";
+static const char _data_FX_MODE_COLORFUL[] PROGMEM = "Colorful@!,Colors (pastels/default/color slots),,,# of colors (0=auto);1,2,3;!;;c3=4";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1024,8 +1024,8 @@ void mode_colorful(void) {
         if (numColors == 0 || (iCol && iCol != cols[numColors-1])) cols[numColors++] = iCol;
       }
       if (numColors == 0) {
-        numColors = 1;
-        cols[0] = RGBW32(0, 0, 0);
+        numColors++;
+        cols[0] = RGBW32(0, 0, 0, 0);
       }
     }
   } else { //default Red - Amber - Green - Blue

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1018,11 +1018,10 @@ void mode_colorful(void) {
         cols[i] = SEGMENT.color_from_palette(i*fac, false, false, 255);
       }
     } else { //get all non-repeating colors from palette (up to 16)
-      cols[0] = RGBW32(SEGPALETTE[0].r, SEGPALETTE[0].g, SEGPALETTE[0].b, 0);
-      numColors = 1;
-      for (size_t i = 1; i < 16; ++i) {
-        uint32_t iCol = RGBW32(SEGPALETTE[i].r, SEGPALETTE[i].g, SEGPALETTE[i].b, 0);
-        if (iCol && (iCol != cols[numColors-1])) cols[numColors++] = iCol;
+      for (uint8_t i = 0; i < 16; ++i) {
+        CRGB c = SEGPALETTE[i];
+        uint32_t iCol = RGBW32(c.r, c.g, c.b, 0);
+        if (numColors == 0 || (iCol && iCol != cols[numColors-1])) cols[numColors++] = iCol;
       }
     }
   } else { //default Red - Amber - Green - Blue

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1051,7 +1051,9 @@ void mode_colorful(void) {
 
   for (unsigned i = 0; i < SEGLEN; i+= numColors)
   {
-    for (unsigned j = 0; j < numColors; j++) SEGMENT.setPixelColor(i + j, cols[SEGENV.aux0 + j]);
+    for (unsigned j = 0; j < numColors  && (i + j) < SEGLEN; j++){
+      SEGMENT.setPixelColor(i + j, cols[SEGENV.aux0 + j]);
+    }
   }
 }
 static const char _data_FX_MODE_COLORFUL[] PROGMEM = "Colorful@!,Color scheme,,,# of colors;1,2,3;!;;c3=4";


### PR DESCRIPTION
Instead of hard-coding the "Colorful" effect to have an override to use 5 colors for C9_2, add a slider to manually specify the number of colors to select from the palette, and if that slider is set to 0, automatically detect the number of colors in the palette (up to 16). This allows it to be used with custom palettes with more than 4 colors.

Also, change description of saturation slider to indicate its actual function (switching between "easter" colors, default colors, and the three color slots). I wasn't even aware that "saturation" could allow using the color slots until I looked at the source code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Colorful mode now supports up to 16 configurable colors (including an auto/0 option), with palette sampling and a non-repeating color selection.
  * Rendering was updated to apply colors in fixed blocks across the strip while safely wrapping at strip end; low-intensity behavior remains pastel/default.

* **Documentation**
  * Updated the mode’s on-screen metadata to show **Color scheme** and **# of colors**, including the new default configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->