### PR TITLE
adding legacy support for "edit?list=/" command, fix indentation

### DIFF
--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -27,6 +27,7 @@ static const char s_accessdenied[]   PROGMEM = "Access Denied";
 static const char s_not_found[]      PROGMEM = "Not found";
 static const char s_wsec[]           PROGMEM = "wsec.json";
 static const char s_func[]           PROGMEM = "func";
+static const char s_list[]           PROGMEM = "list";
 static const char s_path[]           PROGMEM = "path";
 static const char s_cache_control[]  PROGMEM = "Cache-Control";
 static const char s_no_store[]       PROGMEM = "no-store";
@@ -226,14 +227,18 @@ void createEditHandler() {
       return;
     }
     const String& func = request->arg(FPSTR(s_func));
+    bool legacyList = false;
+    if (request->hasArg(FPSTR(s_list))) {
+      legacyList = true; // support for '?list=/'
+    }
 
-    if(func.length() == 0) {
+    if(func.length() == 0 && !legacyList) {
       // default: serve the editor page
       handleStaticContent(request, FPSTR(_edit_htm), 200, FPSTR(CONTENT_TYPE_HTML), PAGE_edit, PAGE_edit_length);
       return;
     }
 
-    if (func == "list") {
+    if (func == FPSTR(s_list) || legacyList) {
       bool first = true;
       AsyncResponseStream* response = request->beginResponseStream(FPSTR(CONTENT_TYPE_JSON));
       response->addHeader(FPSTR(s_cache_control), FPSTR(s_no_store));
@@ -243,15 +248,15 @@ void createEditHandler() {
       File rootdir = WLED_FS.open("/", "r");
       File rootfile = rootdir.openNextFile();
       while (rootfile) {
-          String name = rootfile.name();
-          if (name.indexOf(FPSTR(s_wsec)) >= 0) {
-            rootfile = rootdir.openNextFile(); // skip wsec.json
-            continue;
-          }
-          if (!first) response->write(',');
-          first = false;
-          response->printf_P(PSTR("{\"name\":\"%s\",\"type\":\"file\",\"size\":%u}"), name.c_str(), rootfile.size());
-          rootfile = rootdir.openNextFile();
+        String name = rootfile.name();
+        if (name.indexOf(FPSTR(s_wsec)) >= 0) {
+          rootfile = rootdir.openNextFile(); // skip wsec.json
+          continue;
+        }
+        if (!first) response->write(',');
+        first = false;
+        response->printf_P(PSTR("{\"name\":\"%s\",\"type\":\"file\",\"size\":%u}"), name.c_str(), rootfile.size());
+        rootfile = rootdir.openNextFile();
       }
       rootfile.close();
       rootdir.close();


### PR DESCRIPTION
command is used in pxmagic tool, maybe others.
since people may have the tool manually installed already, updating to 0.16 will break it so adding legacy support for this command is needed. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for legacy file list query patterns to improve backward compatibility with existing API requests.

* **Improvements**
  * Enhanced control flow for the editor handler to properly accommodate legacy and current query methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->