### PR TITLE
Safe uid generation

### DIFF
--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -1207,6 +1207,7 @@ String generateDeviceFingerprint() {
 // Returns: original SHA1 + last 2 chars of double-hashed SHA1 (42 chars total)
 String getDeviceId() {
   static String cachedDeviceId = "";
+  if (cachedDeviceId.length() > 0) return cachedDeviceId;
   // The device string is deterministic as it needs to be consistent for the same device, even after a full flash erase
   // MAC is salted with other consistent device info to avoid rainbow table attacks.
   // If the MAC address is known by malicious actors, they could precompute SHA1 hashes to impersonate devices,


### PR DESCRIPTION
instead of using Strings, this generates a 64bit unique ID from the MAC address, salted with unique chip information:
- ESP8266 uses flash chip ID, flash chip size and flash vendor ID
- ESP32 variants use full silicon revision plus ADC calibration data

The 64bit fingerprint is then converted to a string and hashed. I tested the `generateDeviceFingerprint()`  function on all platforms with various ESPs and always got consistent, unique outputs.

edit 
forgot the important bit: no more use of "potentially dangerous" direct access of efuses, only standard IDF calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Device identification now uses a stronger hardware-based fingerprint across supported boards for more consistent unique IDs.
  * Removed legacy low-level hardware dump usage from the ID flow, simplifying and modernizing identification.
  * Expected impact: more reliable, consistent device IDs and reduced dependence on deprecated hardware reads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->