### PR TITLE
add "awm" JSON command to set temporary auto white mode

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1000,7 +1000,8 @@ void Segment::refreshLightCapabilities() const {
         if (!strip.cctFromRgb && bus->hasCCT())                   capabilities |= SEG_CAPABILITY_CCT;
         if (strip.correctWB && (bus->hasRGB() || bus->hasCCT()))  capabilities |= SEG_CAPABILITY_CCT; //white balance correction (CCT slider)
         if (bus->hasWhite()) {
-          unsigned aWM = Bus::getGlobalAWMode() == AW_GLOBAL_DISABLED ? bus->getAutoWhiteMode() : Bus::getGlobalAWMode();
+          // get auto white mode: priority is global -> temp global -> per bus
+          unsigned aWM = Bus::getGlobalAWMode() == AW_GLOBAL_DISABLED? (Bus::getTempAWMode() == AW_GLOBAL_DISABLED ? bus->getAutoWhiteMode() : Bus::getTempAWMode()) : Bus::getGlobalAWMode();
           bool whiteSlider = (aWM == RGBW_MODE_DUAL || aWM == RGBW_MODE_MANUAL_ONLY); // white slider allowed
           // if auto white calculation from RGB is active (Accurate/Brighter), force RGB controls even if there are no RGB busses
           if (!whiteSlider) capabilities |= SEG_CAPABILITY_RGB;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -144,6 +144,7 @@ void Bus::calculateCCT(uint32_t c, uint8_t &ww, uint8_t &cw) {
 uint32_t Bus::autoWhiteCalc(uint32_t c) const {
   unsigned aWM = _autoWhiteMode;
   if (_gAWM < AW_GLOBAL_DISABLED) aWM = _gAWM;
+  else if (_tempAWM < AW_GLOBAL_DISABLED) aWM = _tempAWM; // temporary global AWM active
   if (aWM == RGBW_MODE_MANUAL_ONLY) return c;
   unsigned w = W(c);
   //ignore auto-white calculation if w>0 and mode DUAL (DUAL behaves as BRIGHTER if w==0)
@@ -1444,6 +1445,7 @@ bool PolyBus::_useParallelI2S = false;
 int16_t Bus::_cct = -1;
 uint8_t Bus::_cctBlend = 0; // 0 - 127
 uint8_t Bus::_gAWM = 255;
+uint8_t Bus::_tempAWM = 255;
 
 uint16_t BusDigital::_milliAmpsTotal = 0;
 

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -198,6 +198,8 @@ class Bus {
     static inline int16_t  getCCT()                   { return _cct; }
     static inline void     setGlobalAWMode(uint8_t m) { if (m < 5) _gAWM = m; else _gAWM = AW_GLOBAL_DISABLED; }
     static inline uint8_t  getGlobalAWMode()          { return _gAWM; }
+    static inline void     setTempAWMode(uint8_t m)   { if (m < 5) _tempAWM = m; else _tempAWM = AW_GLOBAL_DISABLED; }
+    static inline uint8_t  getTempAWMode()            { return _tempAWM; }
     static inline void     setCCT(int16_t cct)        { _cct = cct; }
     static inline uint8_t  getCCTBlend()              { return (_cctBlend * 100 + 64) / 127; } // returns 0-100, 100% = 127. +64 for rounding
     static inline void     setCCTBlend(uint8_t b) {        // input is 0-100
@@ -224,7 +226,8 @@ class Bus {
       bool _hasWhite;//     : 1;
       bool _hasCCT;//       : 1;
     //} __attribute__ ((packed));
-    static uint8_t _gAWM;
+    static uint8_t _gAWM;    // global auto white mode
+    static uint8_t _tempAWM; // temporary global auto white mode, set by JSON API, overriden by _gAWM
     // _cct has the following meanings (see calculateCCT() & BusManager::setSegmentCCT()):
     //    -1 means to extract approximate CCT value in K from RGB (in calcualteCCT())
     //    [0,255] is the exact CCT value where 0 means warm and 255 cold

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -454,6 +454,11 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
       exitRealtime();
     }
   }
+  if (root.containsKey("awm")) {
+    uint8_t awm = root["awm"] | AW_GLOBAL_DISABLED;
+    Bus::setTempAWMode(awm);
+    strip.getMainSegment().refreshLightCapabilities(); // update sliders
+  }
 
   int it = 0;
   JsonVariant segVar = root["seg"];


### PR DESCRIPTION
this allows presets or external commands to change the AWM on-the-fly. The value is applied temporary until revoked and not saved in config.

only active if global AWM is not enabled

Same logic as in config:
- 0 = 0 Manual
- 1 = 1 Brighter
- 2 = 2 Accurate
- 3 = 3 Dual
- 4 = Max
- 5 or larger = disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary auto-white mode override capability that can be controlled via API state updates.
  * Updated auto-white mode selection priority to consider global, temporary, and per-bus settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->