### PR TITLE
Add support for the GLEDOPTO GL-C-618WL Ethernet Config

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -366,21 +366,22 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        13
+#define WLED_NUM_ETH_TYPES        14
 
-#define WLED_ETH_NONE              0
-#define WLED_ETH_WT32_ETH01        1
-#define WLED_ETH_ESP32_POE         2
-#define WLED_ETH_WESP32            3
-#define WLED_ETH_QUINLED           4
-#define WLED_ETH_TWILIGHTLORD      5
-#define WLED_ETH_ESP32DEUX         6
-#define WLED_ETH_ESP32ETHKITVE     7
-#define WLED_ETH_QUINLED_OCTA      8
-#define WLED_ETH_ABCWLEDV43ETH     9
-#define WLED_ETH_SERG74           10
-#define WLED_ETH_ESP32_POE_WROVER 11
-#define WLED_ETH_LILYGO_T_POE_PRO 12
+#define WLED_ETH_NONE               0
+#define WLED_ETH_WT32_ETH01         1
+#define WLED_ETH_ESP32_POE          2
+#define WLED_ETH_WESP32             3
+#define WLED_ETH_QUINLED            4
+#define WLED_ETH_TWILIGHTLORD       5
+#define WLED_ETH_ESP32DEUX          6
+#define WLED_ETH_ESP32ETHKITVE      7
+#define WLED_ETH_QUINLED_OCTA       8
+#define WLED_ETH_ABCWLEDV43ETH      9
+#define WLED_ETH_SERG74            10
+#define WLED_ETH_ESP32_POE_WROVER  11
+#define WLED_ETH_LILYGO_T_POE_PRO  12
+#define WLED_ETH_GLEDOPTO_GLC618WL 13
 
 //Hue error codes
 #define HUE_ERROR_INACTIVE        0

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -270,6 +270,7 @@ Static subnet mask:<br>
 				<option value="5">TwilightLord-ESP32</option>
 				<option value="3">WESP32</option>
 				<option value="1">WT32-ETH01</option>
+				<option value="13">GLEDOPTO GL-C-618WL</option>
 			</select><br><br>
 		</div>
 		<hr>

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -144,6 +144,16 @@ const ethernet_settings ethernetBoards[] = {
     18,			              // eth_mdio,
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO0_OUT	// eth_clk_mode
+  },
+
+  // GLEDOPTO GL-C-618WL
+  {
+    1,                    // eth_address, 
+    5,                    // eth_power, 
+    23,                   // eth_mdc, 
+    33,                   // eth_mdio, 
+    ETH_PHY_LAN8720,      // eth_type,
+    ETH_CLOCK_GPIO0_IN	  // eth_clk_mode
   }
 };
 


### PR DESCRIPTION
The GLEDOPTO GL-C-618WL seems to have another unique Ethernet Pinout/Config.

This commit adds the support for this ethernet config and therefore makes the board work fully.

The device in question: https://gledopto.com/h-pd-64.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GLEDOPTO GL-C-618WL Ethernet device with updated network configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->