### PR TITLE
Bumping ESPAsyncWebServer.git version to 2.4.2 to fix failing build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -180,7 +180,7 @@ lib_deps =
     fastled/FastLED @ 3.6.0
     IRremoteESP8266 @ 2.8.2
     makuna/NeoPixelBus @ 2.7.5
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ 2.2.1
+    https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.2.1
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For compatible OLED display uncomment following


### PR DESCRIPTION
Addresses the issue reported in #5171 ; this is based on the `v0.14.4` tag which does not have a corresponding branch, so this PR would need to be cherry-picked by the upstream maintainers I think, or similar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated how the ESPAsyncWebServer dependency is referenced in build configuration; the resolved version remains 2.2.1. No changes to runtime behavior, API, error handling, or other dependencies.
  * No end-user visible functional changes; builds/configuration bookkeeping only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->