### PR TITLE
Add option to save unmodified presets in autosave usermod

### DIFF
--- a/usermods/usermod_v2_auto_save/usermod_v2_auto_save.cpp
+++ b/usermods/usermod_v2_auto_save/usermod_v2_auto_save.cpp
@@ -16,6 +16,10 @@
 // It can be configured to load auto saved preset at startup,
 // during the first `loop()`.
 //
+// By default it will not save the state if it matches an existing
+// preset (to not duplicate it). You can change this behaviour with
+// by setting AUTOSAVE_IGNORE_PRESETS=false
+//
 // AutoSaveUsermod is standalone, but if FourLineDisplayUsermod 
 // is installed, it will notify the user of the saved changes.
 
@@ -49,6 +53,12 @@ class AutoSaveUsermod : public Usermod {
     bool applyAutoSaveOnBoot = false;     // do we load auto-saved preset on boot?
     #endif
 
+    #ifdef AUTOSAVE_IGNORE_PRESETS
+    bool autoSaveIgnorePresets = AUTOSAVE_IGNORE_PRESETS;
+    #else
+    bool autoSaveIgnorePresets = true;     // ignore by default to not duplicate presets
+    #endif
+
     // If we've detected the need to auto save, this will be non zero.
     unsigned long autoSaveAfter = 0;
 
@@ -68,6 +78,7 @@ class AutoSaveUsermod : public Usermod {
     static const char _autoSaveAfterSec[];
     static const char _autoSavePreset[];
     static const char _autoSaveApplyOnBoot[];
+    static const char _autoSaveIgnorePresets[];
 
     void inline saveSettings() {
       char presetNameBuffer[PRESET_NAME_BUFFER_SIZE];
@@ -122,7 +133,7 @@ class AutoSaveUsermod : public Usermod {
     void loop() {
       static unsigned long lastRun = 0;
       unsigned long now = millis();
-      if (!autoSaveAfterSec || !enabled || currentPreset>0 || (strip.isUpdating() && now - lastRun < 240)) return;  // setting 0 as autosave seconds disables autosave
+      if (!autoSaveAfterSec || !enabled || (autoSaveIgnorePresets && currentPreset>0) || (strip.isUpdating() && now - lastRun < 240)) return;  // setting 0 as autosave seconds disables autosave
       uint8_t currentMode = strip.getMainSegment().mode;
       uint8_t currentPalette = strip.getMainSegment().palette;
 
@@ -219,10 +230,11 @@ class AutoSaveUsermod : public Usermod {
     void addToConfig(JsonObject& root) {
       // we add JSON object: {"Autosave": {"autoSaveAfterSec": 10, "autoSavePreset": 99}}
       JsonObject top = root.createNestedObject(FPSTR(_name)); // usermodname
-      top[FPSTR(_autoSaveEnabled)]     = enabled;
-      top[FPSTR(_autoSaveAfterSec)]    = autoSaveAfterSec;  // usermodparam
-      top[FPSTR(_autoSavePreset)]      = autoSavePreset;    // usermodparam
-      top[FPSTR(_autoSaveApplyOnBoot)] = applyAutoSaveOnBoot;
+      top[FPSTR(_autoSaveEnabled)]       = enabled;
+      top[FPSTR(_autoSaveAfterSec)]      = autoSaveAfterSec;  // usermodparam
+      top[FPSTR(_autoSavePreset)]        = autoSavePreset;    // usermodparam
+      top[FPSTR(_autoSaveApplyOnBoot)]   = applyAutoSaveOnBoot;
+      top[FPSTR(_autoSaveIgnorePresets)] = autoSaveIgnorePresets;
       DEBUG_PRINTLN(F("Autosave config saved."));
     }
 
@@ -245,12 +257,13 @@ class AutoSaveUsermod : public Usermod {
         return false;
       }
 
-      enabled             = top[FPSTR(_autoSaveEnabled)] | enabled;
-      autoSaveAfterSec    = top[FPSTR(_autoSaveAfterSec)] | autoSaveAfterSec;
-      autoSaveAfterSec    = (uint16_t) min(3600,max(10,(int)autoSaveAfterSec)); // bounds checking
-      autoSavePreset      = top[FPSTR(_autoSavePreset)] | autoSavePreset;
-      autoSavePreset      = (uint8_t) min(250,max(100,(int)autoSavePreset)); // bounds checking
-      applyAutoSaveOnBoot = top[FPSTR(_autoSaveApplyOnBoot)] | applyAutoSaveOnBoot;
+      enabled               = top[FPSTR(_autoSaveEnabled)] | enabled;
+      autoSaveAfterSec      = top[FPSTR(_autoSaveAfterSec)] | autoSaveAfterSec;
+      autoSaveAfterSec      = (uint16_t) min(3600,max(10,(int)autoSaveAfterSec)); // bounds checking
+      autoSavePreset        = top[FPSTR(_autoSavePreset)] | autoSavePreset;
+      autoSavePreset        = (uint8_t) min(250,max(100,(int)autoSavePreset)); // bounds checking
+      applyAutoSaveOnBoot   = top[FPSTR(_autoSaveApplyOnBoot)] | applyAutoSaveOnBoot;
+      autoSaveIgnorePresets = top[FPSTR(_autoSaveIgnorePresets)] | autoSaveIgnorePresets;
       DEBUG_PRINT(FPSTR(_name));
       DEBUG_PRINTLN(F(" config (re)loaded."));
 
@@ -268,11 +281,12 @@ class AutoSaveUsermod : public Usermod {
 };
 
 // strings to reduce flash memory usage (used more than twice)
-const char AutoSaveUsermod::_name[]                PROGMEM = "Autosave";
-const char AutoSaveUsermod::_autoSaveEnabled[]     PROGMEM = "enabled";
-const char AutoSaveUsermod::_autoSaveAfterSec[]    PROGMEM = "autoSaveAfterSec";
-const char AutoSaveUsermod::_autoSavePreset[]      PROGMEM = "autoSavePreset";
-const char AutoSaveUsermod::_autoSaveApplyOnBoot[] PROGMEM = "autoSaveApplyOnBoot";
+const char AutoSaveUsermod::_name[]                  PROGMEM = "Autosave";
+const char AutoSaveUsermod::_autoSaveEnabled[]       PROGMEM = "enabled";
+const char AutoSaveUsermod::_autoSaveAfterSec[]      PROGMEM = "autoSaveAfterSec";
+const char AutoSaveUsermod::_autoSavePreset[]        PROGMEM = "autoSavePreset";
+const char AutoSaveUsermod::_autoSaveApplyOnBoot[]   PROGMEM = "autoSaveApplyOnBoot";
+const char AutoSaveUsermod::_autoSaveIgnorePresets[] PROGMEM = "autoSaveIgnorePresets";
 
 static AutoSaveUsermod autosave;
 REGISTER_USERMOD(autosave);


### PR DESCRIPTION
The `usermod_v2_auto_save` deliberately will not save the current state if it is a preset without modifications. I think this totally depends on the use case and should be configurable.

My use case:
> Multiple presets that can be cycled through via a button. Whenever power is cut and restored, it should be in the state as it was before.

So I added an option `AUTOSAVE_IGNORE_PRESETS` which defaults to `true` which is the previous behavior.

<img width="324" height="271" alt="Screenshot 2025-12-09 at 18 24 40" src="https://github.com/user-attachments/assets/e248da8e-9caf-4e3e-99e2-e8a0812052ee" />

I'd like to argue that a default of `false` (meaning: also autosave if it is an already saved preset) might make more sense for the majority, but ofc that is an opinionated guess

I personally was confused why it would not save when cycling through my presets, could not find documentation on it - and ended up being educated by @softhack007 at https://github.com/wled/WLED/issues/3771, thanks for that!
> if you're running a preset without changes, then autosave will not save the settings (reason: you're running an unchanged preset and we don't want to make duplicates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved autosave creating duplicate presets when a preset is already active; autosave now skips saving in this scenario.

* **New Features**
  * Added a configurable option to control whether autosave ignores active presets (enabled by default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->