### PR TITLE
Added support for LSC Smart connect led strips

### DIFF
--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -174,7 +174,8 @@ class Bus {
     static constexpr bool hasWhite(uint8_t type) {
       return  (type >= TYPE_WS2812_1CH && type <= TYPE_WS2812_WWA) ||
               type == TYPE_SK6812_RGBW || type == TYPE_TM1814 || type == TYPE_UCS8904 ||
-              type == TYPE_FW1906 || type == TYPE_WS2805 || type == TYPE_SM16825 ||        // digital types with white channel
+              type == TYPE_FW1906 || type == TYPE_WS2805 || type == TYPE_SM16825 ||
+              type == TYPE_SM16703_DUAL ||                                                   // digital types with white channel
               (type > TYPE_ONOFF && type <= TYPE_ANALOG_5CH && type != TYPE_ANALOG_3CH) || // analog types with white channel
               type == TYPE_NET_DDP_RGBW || type == TYPE_NET_ARTNET_RGBW;                   // network types with white channel
     }
@@ -182,7 +183,7 @@ class Bus {
       return  type == TYPE_WS2812_2CH_X3 || type == TYPE_WS2812_WWA ||
               type == TYPE_ANALOG_2CH    || type == TYPE_ANALOG_5CH ||
               type == TYPE_FW1906        || type == TYPE_WS2805     ||
-              type == TYPE_SM16825;
+              type == TYPE_SM16825       || type == TYPE_SM16703_DUAL;
     }
     static constexpr bool  isTypeValid(uint8_t type)  { return (type > 15 && type < 128); }
     static constexpr bool  isDigital(uint8_t type)    { return (type >= TYPE_DIGITAL_MIN && type <= TYPE_DIGITAL_MAX) || is2Pin(type); }

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1315,6 +1315,7 @@ class PolyBus {
         case TYPE_WS2812_2CH_X3:
         case TYPE_WS2812_RGB:
         case TYPE_WS2812_WWA:
+        case TYPE_SM16703_DUAL:
           return I_8266_U0_NEO_3 + offset;
         case TYPE_SK6812_RGBW:
           return I_8266_U0_NEO_4 + offset;
@@ -1378,6 +1379,7 @@ class PolyBus {
         case TYPE_WS2812_2CH_X3:
         case TYPE_WS2812_RGB:
         case TYPE_WS2812_WWA:
+        case TYPE_SM16703_DUAL:
           return I_32_RN_NEO_3 + offset;
         case TYPE_SK6812_RGBW:
           return I_32_RN_NEO_4 + offset;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -305,6 +305,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define TYPE_WS2805              32            //RGB + WW + CW
 #define TYPE_TM1914              33            //RGB
 #define TYPE_SM16825             34            //RGB + WW + CW
+#define TYPE_SM16703_DUAL        35            //dual SM16703: RGB chip + WW/CW chip (B unused)
 #define TYPE_DIGITAL_MAX         39            // last usable digital type
 //"Analog" types (40-47)
 #define TYPE_ONOFF               40            //binary output (relays etc.; NOT PWM)


### PR DESCRIPTION
Support is added for LSC Smart Connect led strips which are sold at ACTION stores around Europe. These strips are special because they use dual SM16703 chips, the first is used for controlling a RGB LED, the second is used for WW and CW. For controlling the strip this gives 6 channels in a row: G,R,B,WW,CW,N/C which means the 3th channel of the second SM16703 chip is not used.

Recommitted because CodeRabbit found that the skipping LED function calculation was not yet up to date with the usage of 2 IC`s

- Firmware was built using these files and tested on Wemo D1 mini.
- In the UI the strip is called “SM16703 RGB+CCT (2x)”
- Product: https://www.action.com/nl-nl/p/3218153/lsc-smart-connect-ledstrip/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SM16703 dual-chip LEDs (RGB + independent WW/CW per logical pixel) in the LED type selector.
  * UI-configurable WW/CW channel ordering for the new dual-chip type.

* **Bug Fixes**
  * Corrected initial pixel clearing and pixel-mapping so dual-chip pixels initialize and update reliably.

* **Behavior**
  * Automatic brightness limiting now accounts for both RGB and white channels for accurate dimming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->