### PR TITLE
set unused segments to black

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -466,7 +466,7 @@ void Segment::setGeometry(uint16_t i1, uint16_t i2, uint8_t grp, uint8_t spc, ui
   #endif
 
   m12 = constrain(m12, 0, 7);
-  if (stop && (spc > 0 || m12 != map1D2D)) fill(BLACK);
+  if (stop) fill(BLACK); // turn off LEDs in segment before changing geometry
   if (m12 != map1D2D) map1D2D = m12;
 /*
   if (boundsUnchanged


### PR DESCRIPTION
0.15.1 introduced a new behaviour on how "empty space" is treated. While it is technically correct, it is not user friendly and is a breaking change: all previous versions behaved differently and so does 0.16.

What this change does is to set any unused pixels to black instead of keeping the last value.