### PR TITLE
Do not replace legacy FX with new PS FX

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -120,6 +120,7 @@ build_flags =
   -D DECODE_SAMSUNG=true
   -D DECODE_LG=true
   -DWLED_USE_MY_CONFIG
+  -D WLED_PS_DONT_REPLACE_FX ; PS replacement FX are purely a flash memory saving feature, do not replace classic FX until we run out of flash
 
 build_unflags =
 


### PR DESCRIPTION
as discussed, we should keep legacy functions and FX if possible. Since PS replacements is purely a flash saving matter we should not enforce progress to users until the need for reducing flash size arises.

What this PR does is enable the `WLED_PS_DONT_REPLACE_FX` flag on all builds, keeping all legacy FX.

edit: flash cost is 8k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new build configuration flag to provide an option for controlling effects behavior during firmware compilation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->