### PR TITLE
Revert "Add old version check to OTA update"

### DIFF
--- a/wled00/wled_metadata.h
+++ b/wled00/wled_metadata.h
@@ -26,7 +26,6 @@ typedef struct {
     char wled_version[WLED_VERSION_MAX_LEN];
     char release_name[WLED_RELEASE_NAME_MAX_LEN]; // Release name (null-terminated)    
     uint32_t hash;               // Structure sanity check
-    uint8_t safe_update_version[3]; // Indicates version it's known to be safe to install this update from: major, minor, patch
 } __attribute__((packed)) wled_metadata_t;
 
 


### PR DESCRIPTION
Reverts wled/WLED#5057

This merge breaks OTA updates from older nightlies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented stricter firmware compatibility validation during OTA updates, ensuring firmware versions meet precise compatibility requirements.
  * Updated error messages to provide clearer feedback when firmware compatibility issues are encountered.

* **Chores**
  * Simplified firmware validation logic by removing legacy compatibility checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->