### PR TITLE
Remove OTA metadata structure version block

### DIFF
--- a/wled00/wled_metadata.cpp
+++ b/wled00/wled_metadata.cpp
@@ -96,13 +96,6 @@ bool findWledMetadata(const uint8_t* binaryData, size_t dataSize, wled_metadata_
         wled_metadata_t candidate;
         memcpy(&candidate, binaryData + offset, sizeof(candidate));
 
-        // Found potential match, validate version
-        if (candidate.desc_version > WLED_CUSTOM_DESC_VERSION) {
-          DEBUG_PRINTF_P(PSTR("Found WLED structure at offset %u but version mismatch: %u\n"), 
-                        offset, candidate.desc_version);
-          continue;
-        }
-        
         // Validate hash using runtime function
         uint32_t expected_hash = djb2_hash_runtime(candidate.release_name);
         if (candidate.hash != expected_hash) {


### PR DESCRIPTION
0.15 backport of the OTA version check fix from #5213, on the off chance we have an OTA version 3 before 0.16 launches.