### PR TITLE
Fix reverse proxying in Settings

### DIFF
--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -118,7 +118,7 @@ function getLoc() {
 		let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");
 		if (paths.length > 1) paths.pop(); // remove subpage (or "settings")
 		if (paths.length > 0 && paths[paths.length-1]=="settings") paths.pop(); // remove "settings"
-		if (paths.length > 1) {
+		if (paths.length > 0) {
 			locproto = l.protocol;
 			loc = true;
 			locip = l.hostname + (l.port ? ":" + l.port : "") + "/" + paths.join('/');


### PR DESCRIPTION
getLoc has an off-by-one where reverse proxy path gets parsed wrong if it's routed on the top-level path.

I have WLED in `domain.com/wled/`. On settings page we compute:
```js
let path = l.pathname; // `/wled/settings`
let paths = path.slice(1,path.endsWith('/')?-1:undefined).split("/");   // [ "wled", "settings" ]
if (paths.length > 1) paths.pop(); // [ "wled" ]
if (paths.length > 0 && paths[paths.length-1]=="settings") paths.pop(); // No change

// paths.length == 1 so this isn't taken
if (paths.length > 0) {
	locproto = l.protocol;
	loc = true;
	locip = l.hostname + (l.port ? ":" + l.port : "") + "/" + paths.join('/');
}
```
This then breaks the computation for the "s.js" path.

If I have WLED in `domain.com/w/led/` the above `paths.length > 0` is taken as expected and settings work.

This PR fixes the off-by-one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path handling for reverse-proxy configurations to enable localization settings to work with single-segment paths, in addition to the previously supported multi-segment paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->