### PR TITLE
fix FX checkmark sync

### DIFF
--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -334,8 +334,8 @@ static void parseNotifyPacket(const uint8_t *udpIn) {
           selseg.custom2 = udpIn[30+ofs];
           selseg.custom3 = udpIn[31+ofs] & 0x1F;
           selseg.check1  = (udpIn[31+ofs]>>5) & 0x1;
-          selseg.check1  = (udpIn[31+ofs]>>6) & 0x1;
-          selseg.check1  = (udpIn[31+ofs]>>7) & 0x1;
+          selseg.check2  = (udpIn[31+ofs]>>6) & 0x1;
+          selseg.check3  = (udpIn[31+ofs]>>7) & 0x1;
         }
       }
       if (receiveSegmentBounds) {


### PR DESCRIPTION
this fixes an ancient copy-paste bug that apparently went under the radar for years. The rabbit found it.
@softhack007 this bug is even present in MM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed per-segment slider flags parsing in UDP notification packets. Previously, flags were incorrectly overwritten; they are now properly distributed and processed, ensuring segment controls respond correctly to remote commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->