### PR TITLE
Fix FX checkmark sync

### DIFF
--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -335,8 +335,8 @@ void parseNotifyPacket(uint8_t *udpIn) {
           selseg.custom2 = udpIn[30+ofs];
           selseg.custom3 = udpIn[31+ofs] & 0x1F;
           selseg.check1  = (udpIn[31+ofs]>>5) & 0x1;
-          selseg.check1  = (udpIn[31+ofs]>>6) & 0x1;
-          selseg.check1  = (udpIn[31+ofs]>>7) & 0x1;
+          selseg.check2  = (udpIn[31+ofs]>>6) & 0x1;
+          selseg.check3  = (udpIn[31+ofs]>>7) & 0x1;
         }
       }
       if (receiveSegmentBounds) {


### PR DESCRIPTION
this fixes an ancient copy-paste bug that apparently went under the radar for years. The rabbit found it.