### PR TITLE
use same approach for ledmap as is done in gap file

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2005,13 +2005,12 @@ bool WS2812FX::deserializeMap(unsigned n) {
 
   d_free(customMappingTable);
   customMappingTable = static_cast<uint16_t*>(d_malloc(sizeof(uint16_t)*getLengthTotal())); // prefer DRAM for speed
-  // fill with empty in case we don't fill the entire matrix
-  unsigned matrixSize = Segment::maxWidth * Segment::maxHeight;
-  for (unsigned i = 0; i<matrixSize; i++) customMappingTable[i] = 0xFFFFU;
-  for (unsigned i = matrixSize; i<getLengthTotal(); i++) customMappingTable[i] = i; // trailing LEDs for ledmap (after matrix) if it exist
 
   if (customMappingTable) {
     DEBUG_PRINTF_P(PSTR("ledmap allocated: %uB\n"), sizeof(uint16_t)*getLengthTotal());
+    unsigned matrixSize = Segment::maxWidth * Segment::maxHeight;
+    for (unsigned i = 0; i<matrixSize; i++) customMappingTable[i] = 0xFFFFU;          // fill with empty in case we don't fill the entire matrix
+    for (unsigned i = matrixSize; i<getLengthTotal(); i++) customMappingTable[i] = i; // trailing LEDs for ledmap (after matrix) if it exist
     File f = WLED_FS.open(fileName, "r");
     f.find("\"map\":[");
     while (f.available()) { // f.position() < f.size() - 1

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2005,6 +2005,10 @@ bool WS2812FX::deserializeMap(unsigned n) {
 
   d_free(customMappingTable);
   customMappingTable = static_cast<uint16_t*>(d_malloc(sizeof(uint16_t)*getLengthTotal())); // prefer DRAM for speed
+  // fill with empty in case we don't fill the entire matrix
+  unsigned matrixSize = Segment::maxWidth * Segment::maxHeight;
+  for (unsigned i = 0; i<matrixSize; i++) customMappingTable[i] = 0xFFFFU;
+  for (unsigned i = matrixSize; i<getLengthTotal(); i++) customMappingTable[i] = i; // trailing LEDs for ledmap (after matrix) if it exist
 
   if (customMappingTable) {
     DEBUG_PRINTF_P(PSTR("ledmap allocated: %uB\n"), sizeof(uint16_t)*getLengthTotal());


### PR DESCRIPTION
- fixes ledmap containing garbage values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LED mapping initialization so empty matrix entries are explicitly marked and trailing LEDs default to identity mapping. This prevents uninitialized or incorrect LED mappings after loading a custom map, improving display consistency and preventing unexpected LED behavior when using partial or smaller mapping configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->