### PR TITLE
Ants FX in the user_fx usermod

### DIFF
--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -285,6 +285,7 @@ static void mode_ants(void) {
 static const char _data_FX_MODE_ANTS[] PROGMEM = "Ants@Ant speed,# of ants,Ant size,Blur,,Gathering food,Smear,Pass by;!,!,!;!;1;sx=192,ix=255,c1=32,c2=0,o1=1,o3=1";
 
 
+/*
 /  Morse Code by Bob Loeffler
 *   Adapted from code by automaticaddison.com and then optimized by claude.ai
 *   aux0 is the pattern offset for scrolling
@@ -534,7 +535,6 @@ static void mode_morsecode(void) {
   }
 }
 static const char _data_FX_MODE_MORSECODE[] PROGMEM = "Morse Code@Speed,,,,Color mode,Color by Word,Punctuation,EndOfMessage;;!;1;sx=192,c3=8,o1=1,o2=1";
-
 
 
 /////////////////////


### PR DESCRIPTION
This PR will add the Ants effect into the new user_fx usermod instead of FX.cpp

*  Ants by Bob Loeffler 2025
*    First slider is for the ants' speed.
*    Second slider is for the # of ants.
*    Third slider is for the Ants' size.
*    Fourth slider (custom2) is for blurring the LEDs in the segment.
*    Checkbox1 is for Gathering food (enabled if you want the ants to gather food, disabled if they are just walking).
*    -  We will switch directions when they get to the beginning or end of the segment when gathering food.
*    -  When gathering food, the Pass By option will automatically be enabled so they can drop off their food easier (and look for more food).
*    Checkbox2 is for Overlay mode (enabled is Overlay, disabled is no overlay)
*    Checkbox3 is for whether the ants will bump into each other (disabled) or just pass by each other (enabled)

https://github.com/user-attachments/assets/e42883bd-fc0c-4b23-9ea8-d5993e78615a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Ants" visual effect: animated ants move along LED segments with food-gathering, optional collisions, and smear/blur trails.
* **Configurable**
  * Exposed sliders/options for number of ants, speed, size, blur/smear, boundary behavior (bounce or wrap), pass-by, and palette-based coloring.
* **Visual Improvements**
  * Per-ant state, time-based movement, per-pixel rendering, and smoother trails for richer animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->