### PR TITLE
Morse Code FX in the user_fx usermod

### DIFF
--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -91,9 +91,12 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 
 /*
 /  Scrolling Morse Code by Bob Loeffler
-*   With help from code by automaticaddison.com and then a pass through claude.ai
+*   Adapted from code by automaticaddison.com and then optimized by claude.ai
 *   aux0 is the pattern offset for scrolling
 *   aux1 is the total pattern length
+*   the sx slider selects the scrolling speed
+*   check1 selects the color mode
+*   we get the text from the SEGMENT.name and convert it to morse code
 */
 
 // Build morse pattern into a buffer
@@ -129,7 +132,7 @@ static uint16_t mode_morsecode(void) {
 
   // A-Z in Morse Code
   static const char * letters[] PROGMEM = {".-", "-...", "-.-.", "-..", ".", "..-.", "--.", "....", "..", ".---", "-.-", ".-..", "--",
-                     "-.", "---", ".--.", "--.-", ".-.", "...", "-", "..-", "...-", ".--", "-..-", "-.--", "--.."};
+                                           "-.", "---", ".--.", "--.-", ".-.", "...", "-", "..-", "...-", ".--", "-..-", "-.--", "--.."};
   // 0-9 in Morse Code
   static const char * numbers[] PROGMEM = {"-----", ".----", "..---", "...--", "....-", ".....", "-....", "--...", "---..", "----."};
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -4,7 +4,6 @@
 
 // paletteBlend: 0 - wrap when moving, 1 - always wrap, 2 - never wrap, 3 - none (undefined)
 #define PALETTE_SOLID_WRAP   (strip.paletteBlend == 1 || strip.paletteBlend == 3)
-#define PALETTE_MOVING_WRAP !(strip.paletteBlend == 2 || (strip.paletteBlend == 0 && SEGMENT.speed == 0))
 
 // static effect, used if an effect fails to initialize
 static uint16_t mode_static(void) {

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -151,6 +151,19 @@ static uint16_t mode_morsecode(void) {
   // 0-9 in Morse Code
   static const char * numbers[] = {"-----", ".----", "..---", "...--", "....-", ".....", "-....", "--...", "---..", "----."};
 
+  // Punctuation in Morse Code
+  struct PunctuationMapping {
+    char character;
+    const char* code;
+  };
+
+  static const PunctuationMapping punctuation[] = {
+    {'.', ".-.-.-"}, {',', "--..--"}, {'?', "..--.."}, 
+    {':', "---..."}, {'-', "-....-"}, {'!', "-.-.--"},
+    {'&', ".-..."}, {'@', ".--.-."}, {')', "-.--.-"},
+    {'(', "-.--."}, {'/', "-..-."}, {'\'', ".----."}
+  };
+
   // Get the text to display
   char text[WLED_MAX_SEGNAME_LEN+1] = {'\0'};
   size_t len = 0;
@@ -207,19 +220,11 @@ static uint16_t mode_morsecode(void) {
       // Check for punctuation
       else if (SEGMENT.check2) {
         const char *punctuationCode = nullptr;
-        switch (*c) {
-          case '.': punctuationCode = ".-.-.-"; break;
-          case ',': punctuationCode = "--..--"; break;
-          case '?': punctuationCode = "..--.."; break;
-          case ':': punctuationCode = "---..."; break;
-          case '-': punctuationCode = "-....-"; break;
-          case '!': punctuationCode = "-.-.--"; break;
-          case '&': punctuationCode = ".-..."; break;
-          case '@': punctuationCode = ".--.-."; break;
-          case ')': punctuationCode = "-.--.-"; break;
-          case '(': punctuationCode = "-.--."; break;
-          case '/': punctuationCode = "-..-."; break;
-          case '\'': punctuationCode = ".----."; break;  // apostrophe character must be escaped with a \ character
+        for (const auto& p : punctuation) {
+          if (*c == p.character) {
+            punctuationCode = p.code;
+            break;
+          }
         }
         if (punctuationCode) {
           build_morsecode_pattern(punctuationCode, morsecodePattern, patternLength, MORSECODE_MAX_PATTERN_SIZE);

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -268,7 +268,7 @@ class UserFxUsermod : public Usermod {
  public:
   void setup() override {
     strip.addEffect(255, &mode_diffusionfire, _data_FX_MODE_DIFFUSIONFIRE);
-    strip.addEffect(255, &mode_morsecode, _data_FX_MODE_PS_MORSECODE);
+    strip.addEffect(255, &mode_morsecode, _data_FX_MODE_MORSECODE);
 
     ////////////////////////////////////////
     //  add your effect function(s) here  //

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -108,6 +108,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 *    - there are 3 spaces between each letter or number
 *    - there are 7 spaces between each word
 */
+
 // Build morse pattern into a buffer
 void build_morsecode_pattern(const char *morse_code, bool *pattern, int &index) {
   const char *c = morse_code;
@@ -257,6 +258,7 @@ static uint16_t mode_morsecode(void) {
   return FRAMETIME;
 }
 static const char _data_FX_MODE_MORSECODE[] PROGMEM = "Morse Code@Speed,,,,,Color mode,Punctuation,EndOfMessage;;!;1;sx=128,o1=1,o2=1";
+
 
 
 /////////////////////

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -100,7 +100,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 /  Scrolling Morse Code by Bob Loeffler
 *   Adapted from code by automaticaddison.com and then optimized by claude.ai
 *   aux0 is the pattern offset for scrolling
-*   aux1 saves settings: check3 (1 bit), check3 (1 bit), text hash (4 bits) and pattern length (10 bits)
+*   aux1 saves settings: check2 (1 bit), check3 (1 bit), text hash (4 bits) and pattern length (10 bits)
 *   The first slider (sx) selects the scrolling speed
 *   The second slider selects the color mode (lower half selects color wheel, upper half selects color palettes)
 *   Checkbox1 displays all letters in a word with the same color
@@ -206,9 +206,9 @@ static void mode_morsecode(void) {
     *p = toupper(*p);
   }
 
-  // Allocate per-segment storage for pattern (1024 bits = 128 bytes) + word index array (1024 bytes) + word count (1 byte)
-  constexpr size_t MORSECODE_MAX_PATTERN_SIZE = 1024;
-  constexpr size_t MORSECODE_PATTERN_BYTES = MORSECODE_MAX_PATTERN_SIZE / 8; // 128 bytes
+  // Allocate per-segment storage for pattern (1023 bits = 127 bytes) + word index array (1024 bytes) + word count (1 byte)
+  constexpr size_t MORSECODE_MAX_PATTERN_SIZE = 1023;
+  constexpr size_t MORSECODE_PATTERN_BYTES = MORSECODE_MAX_PATTERN_SIZE / 8; // 127 bytes
   constexpr size_t MORSECODE_WORD_INDEX_BYTES = MORSECODE_MAX_PATTERN_SIZE; // 1 byte per bit position
   constexpr size_t MORSECODE_WORD_COUNT_BYTES = 1; // 1 byte for word count
   if (!SEGENV.allocateData(MORSECODE_PATTERN_BYTES + MORSECODE_WORD_INDEX_BYTES + MORSECODE_WORD_COUNT_BYTES)) FX_FALLBACK_STATIC;;
@@ -302,7 +302,7 @@ static void mode_morsecode(void) {
   // if pattern is empty for some reason, display black background only
   if (patternLength == 0) {
     SEGMENT.fill(BLACK);
-    FX_FALLBACK_STATIC;
+    return;
   }
 
   // Update offset to make the morse code scroll

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -270,6 +270,12 @@ static uint16_t mode_morsecode(void) {
     SEGENV.aux0 = 0;
   }
 
+  // if pattern is empty for some reason, display black background only
+  if (patternLength == 0) {
+    SEGMENT.fill(BLACK);
+    return FRAMETIME;
+  }
+
   // Update offset to make the morse code scroll
   // Use step for scroll timing only
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed)*3;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -115,9 +115,9 @@ void build_morsecode_pattern(const char *morse_code, bool *pattern, int &index, 
   
   // Build the dots and dashes into pattern array
   while (*c != '\0') {
-    if (index >= maxSize - 4) return; // Reserve space for spacing
     // it's a dot which is 1 pixel
     if (*c == '.') {
+      if (index >= maxSize - 1) return; // Reserve space for spacing
       pattern[index++] = true;
     }
     else { // Must be a dash which is 3 pixels
@@ -128,14 +128,17 @@ void build_morsecode_pattern(const char *morse_code, bool *pattern, int &index, 
     }
     
     // 1 space between parts of a letter/number
+    if (index >= maxSize) return;
     pattern[index++] = false;
     c++;
   }
     
   // 3 spaces between two letters
-  if (index >= maxSize - 3) return;
+  if (index >= maxSize - 2) return;
   pattern[index++] = false;
+  if (index >= maxSize - 1) return;
   pattern[index++] = false;
+  if (index >= maxSize) return;
   pattern[index++] = false;
 }
 
@@ -185,6 +188,7 @@ static uint16_t mode_morsecode(void) {
 
     // Build complete morse code pattern
     for (char *c = text; *c; c++) {
+      if (patternLength >= MORSECODE_MAX_PATTERN_SIZE - 10) break; // Reserve space for trailing pattern
       // Check for letters
       if (*c >= 'A' && *c <= 'Z') {
         build_morsecode_pattern(letters[*c - 'A'], morsecodePattern, patternLength, MORSECODE_MAX_PATTERN_SIZE);
@@ -196,6 +200,7 @@ static uint16_t mode_morsecode(void) {
       // Check for a space between words
       else if (*c == ' ') {
         for (int x = 0; x < 4; x++) {   // 7 spaces after the morse code pattern (3 after the last character and now 4 more)
+          if (patternLength >= MORSECODE_MAX_PATTERN_SIZE) break;
           morsecodePattern[patternLength++] = false;
         }
       }
@@ -228,6 +233,7 @@ static uint16_t mode_morsecode(void) {
     }
 
     for (int x = 0; x < 7; x++) {   // 10 spaces after the last pattern (3 after the last character and now 7 more)
+      if (patternLength >= MORSECODE_MAX_PATTERN_SIZE) break;
       morsecodePattern[patternLength++] = false;
     }
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -97,7 +97,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 
 
 /*
-/  Scrolling Morse Code by Bob Loeffler
+/  Morse Code by Bob Loeffler
 *   Adapted from code by automaticaddison.com and then optimized by claude.ai
 *   aux0 is the pattern offset for scrolling
 *   aux1 saves settings: check2 (1 bit), check3 (1 bit), text hash (4 bits) and pattern length (10 bits)
@@ -121,7 +121,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 #define GET_BIT8(arr, i) (((arr)[(i) >> 3] & (1 << ((i) & 7))) != 0)
 
 // Build morse code pattern into a buffer
-void build_morsecode_pattern(const char *morse_code, uint8_t *pattern, uint8_t *wordIndex, uint16_t &index, uint8_t currentWord, int maxSize) {
+static void build_morsecode_pattern(const char *morse_code, uint8_t *pattern, uint8_t *wordIndex, uint16_t &index, uint8_t currentWord, int maxSize) {
   const char *c = morse_code;
   
   // Build the dots and dashes into pattern array
@@ -208,10 +208,10 @@ static void mode_morsecode(void) {
 
   // Allocate per-segment storage for pattern (1023 bits = 127 bytes) + word index array (1024 bytes) + word count (1 byte)
   constexpr size_t MORSECODE_MAX_PATTERN_SIZE = 1023;
-  constexpr size_t MORSECODE_PATTERN_BYTES = MORSECODE_MAX_PATTERN_SIZE / 8; // 127 bytes
+  constexpr size_t MORSECODE_PATTERN_BYTES = (MORSECODE_MAX_PATTERN_SIZE + 7) / 8; // 128 bytes
   constexpr size_t MORSECODE_WORD_INDEX_BYTES = MORSECODE_MAX_PATTERN_SIZE; // 1 byte per bit position
   constexpr size_t MORSECODE_WORD_COUNT_BYTES = 1; // 1 byte for word count
-  if (!SEGENV.allocateData(MORSECODE_PATTERN_BYTES + MORSECODE_WORD_INDEX_BYTES + MORSECODE_WORD_COUNT_BYTES)) FX_FALLBACK_STATIC;;
+  if (!SEGENV.allocateData(MORSECODE_PATTERN_BYTES + MORSECODE_WORD_INDEX_BYTES + MORSECODE_WORD_COUNT_BYTES)) FX_FALLBACK_STATIC;
   uint8_t* morsecodePattern = reinterpret_cast<uint8_t*>(SEGENV.data);
   uint8_t* wordIndexArray = reinterpret_cast<uint8_t*>(SEGENV.data + MORSECODE_PATTERN_BYTES);
   uint8_t* wordCountPtr = reinterpret_cast<uint8_t*>(SEGENV.data + MORSECODE_PATTERN_BYTES + MORSECODE_WORD_INDEX_BYTES);


### PR DESCRIPTION
This PR will add the Morse Code effect into the new user_fx usermod instead of FX.cpp

*  Scrolling Morse Code by Bob Loeffler 2025
*    Adapted from code by automaticaddison.com and then optimized by claude.ai
*    aux0 is the pattern offset for scrolling
*    aux1 is the total pattern length
*    First slider selects the scrolling speed
*    Checkbox1 selects the color mode
*    Checkbox2 displays punctuation or not
*    Checkbox3 displays the End-of-message code or not
*    We get the text from SEGMENT.name and convert it to morse code
*    Morse Code rules:
*    - there is one space between each part of a letter/number/punctuation
*    - there are 3 spaces between each letter or number
*    - there are 7 spaces between each word

Example video:

https://github.com/user-attachments/assets/578f1572-7294-4d42-872a-7d0b727aa675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scrolling Morse Code effect that displays segment text (defaults to "I Love WLED!") in uppercase.
  * Per-segment pattern buffering, caching and automatic rebuilds when text or settings change.
  * Per-segment speed and auxiliary controls for scrolling behavior.
  * Supports palette-based or color-wheel coloring with improved palette wrapping; clears background before rendering.
  * Optional punctuation and end-of-message markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->