### PR TITLE
Lava Lamp FX in the user_fx usermod

### DIFF
--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -275,7 +275,7 @@ uint16_t mode_2D_lavalamp(void) {
       }
     }
 
-    // Keep blobs alive forever - no fading
+    // Keep blobs alive forever (no fading) - maybe change in the future?
     p->life = 255;
     
     // Get color
@@ -286,17 +286,11 @@ uint16_t mode_2D_lavalamp(void) {
       color = SEGMENT.color_from_palette(p->hue, false, true, 0);   // Palette mode
     }
     
-    // Extract RGB
-    uint8_t w = W(color);
-    uint8_t r = R(color);
-    uint8_t g = G(color);
-    uint8_t b = B(color);
-
-    // Apply life/opacity
-    w = (w * p->life) >> 8;
-    r = (r * p->life) >> 8;
-    g = (g * p->life) >> 8;
-    b = (b * p->life) >> 8;
+    // Extract RGB and apply life/opacity
+    uint8_t w = (W(color) * p->life) >> 8;
+    uint8_t r = (R(color) * p->life) >> 8;
+    uint8_t g = (G(color) * p->life) >> 8;
+    uint8_t b = (B(color) * p->life) >> 8;
 
     // Draw blob with soft edges (gaussian-like falloff)
     for (int dy = -(int)p->size; dy <= (int)p->size; dy++) {
@@ -318,17 +312,9 @@ uint16_t mode_2D_lavalamp(void) {
 
             // Additive blending for organic merging
             uint32_t existing = SEGMENT.getPixelColorXY(px, py);
-            uint8_t ew = (existing >> 24) & 0xFF;
-            uint8_t er = (existing >> 16) & 0xFF;
-            uint8_t eg = (existing >> 8) & 0xFF;
-            uint8_t eb = existing & 0xFF;
-
-            ew = qadd8(ew, bw);
-            er = qadd8(er, br);
-            eg = qadd8(eg, bg);
-            eb = qadd8(eb, bb);
-            
-            SEGMENT.setPixelColorXY(px, py, RGBW32(er, eg, eb, ew));
+            uint32_t newColor = RGBW32(br, bg, bb, bw);
+            uint32_t blended = color_add(existing, newColor);
+            SEGMENT.setPixelColorXY(px, py, blended);
           }
         }
       }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -152,7 +152,7 @@ uint16_t mode_2D_lavalamp(void) {
     for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
       if (lavaParticles[i].active) {
         // Assign new random size within the new range
-        lavaParticles[i].size = minSize + random16((int)(newRange)) / 1.0f;
+        lavaParticles[i].size = minSize + (float)random16((int)(newRange));
         // Ensure minimum size
         if (lavaParticles[i].size < minSize) lavaParticles[i].size = minSize;
       }
@@ -166,7 +166,7 @@ uint16_t mode_2D_lavalamp(void) {
       // Spawn in the middle 60% of the width
       float centerStart = cols * 0.20f;
       float centerWidth = cols * 0.60f;
-      lavaParticles[i].x = centerStart + random16((int)(centerWidth)) / 1.0f;
+      lavaParticles[i].x = centerStart + (float)random16((int)(centerWidth));
       lavaParticles[i].y = rows - 1;
       lavaParticles[i].vx = (random16(7) - 3) / 250.0f;
       
@@ -179,7 +179,7 @@ uint16_t mode_2D_lavalamp(void) {
       float minSize = cols * 0.15f; // Minimum 15% of width
       float maxSize = cols * 0.4f;  // Maximum 40% of width
       float sizeRange = (maxSize - minSize) * (sizeControl / 255.0f);
-      lavaParticles[i].size = minSize + random16((int)(sizeRange)) / 1.0f;
+      lavaParticles[i].size = minSize + (float)random16((int)(sizeRange));
 
       lavaParticles[i].hue = hw_random8();
       lavaParticles[i].life = 255;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -95,11 +95,17 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 
 
 /*
- * Lava Lamp 2D effect
- *  Uses particles to simulate rising blobs of "lava"
- *  Particles slowly rise, merge to create organic flowing shapes, and then fall to the bottom to start again
- *  Created by Bob Loeffler using claude.ai
- */
+/  Lava Lamp 2D effect
+*  Uses particles to simulate rising blobs of "lava"
+*  Particles slowly rise, merge to create organic flowing shapes, and then fall to the bottom to start again
+*  Created by Bob Loeffler using claude.ai
+*  The first slider sets the speed of the rising and falling blobs
+*  The second slider sets the number of active blobs
+*  The third slider sets the size range of the blobs
+*  The first checkbox sets the color mode (color wheel or palette)
+*  The second checkbox sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)
+*/
+
 #define MAX_LAVA_PARTICLES 50
 
 typedef struct LavaParticle {
@@ -159,7 +165,7 @@ uint16_t mode_2D_lavalamp(void) {
 
   // Spawn new particles at the bottom near the center
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
-    if (!lavaParticles[i].active && random8() < 32) { // Always spawn when slot available
+    if (!lavaParticles[i].active && hw_random8() < 32) { // Always spawn when slot available
       // Spawn in the middle 60% of the width
       float centerStart = cols * 0.20f;
       float centerWidth = cols * 0.60f;
@@ -178,7 +184,7 @@ uint16_t mode_2D_lavalamp(void) {
       float sizeRange = (maxSize - minSize) * (sizeControl / 255.0f);
       lavaParticles[i].size = minSize + random16((int)(sizeRange * 10)) / 10.0f;
 
-      lavaParticles[i].hue = SEGMENT.check1 ? random8() : random16(256);
+      lavaParticles[i].hue = SEGMENT.check1 ? hw_random8() : random16(256);
       lavaParticles[i].life = 255;
       lavaParticles[i].active = true;
       break;
@@ -325,7 +331,7 @@ uint16_t mode_2D_lavalamp(void) {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@Speed,# of blobs,Blob size,,,Color mode,Attract;;!;2;ix=64,o2=1,pal=47";
+static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@Speed,# of blobs,Blob size,,,Color mode,Attract;;!;2;sx=64,ix=64,o2=1,pal=47";
 #undef MAX_LAVA_PARTICLES
 
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -117,15 +117,15 @@ typedef struct LavaParticle {
   bool active;          // will not be displayed if false
 } LavaParticle;
 
-static uint16_t mode_2D_lavalamp(void) {
-  if (!strip.isMatrix || !SEGMENT.is2D()) FX_FALLBACK_STATIC;; // not a 2D set-up
+static void mode_2D_lavalamp(void) {
+  if (!strip.isMatrix || !SEGMENT.is2D()) FX_FALLBACK_STATIC; // not a 2D set-up
   
   const uint16_t cols = SEG_W;
   const uint16_t rows = SEG_H;
   
   // Allocate per-segment storage
   constexpr size_t MAX_LAVA_PARTICLES = 35;  // increasing this value could cause slowness for large matrices
-  if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) FX_FALLBACK_STATIC;;
+  if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) FX_FALLBACK_STATIC;
   LavaParticle* lavaParticles = reinterpret_cast<LavaParticle*>(SEGENV.data);
 
   // Initialize particles on first call

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -287,15 +287,17 @@ uint16_t mode_2D_lavalamp(void) {
     }
     
     // Extract RGB
-    uint8_t r = (color >> 16) & 0xFF;
-    uint8_t g = (color >> 8) & 0xFF;
-    uint8_t b = color & 0xFF;
-    
+    uint8_t w = W(color);
+    uint8_t r = R(color);
+    uint8_t g = G(color);
+    uint8_t b = B(color);
+
     // Apply life/opacity
+    w = (w * p->life) >> 8;
     r = (r * p->life) >> 8;
     g = (g * p->life) >> 8;
     b = (b * p->life) >> 8;
-    
+
     // Draw blob with soft edges (gaussian-like falloff)
     for (int dy = -(int)p->size; dy <= (int)p->size; dy++) {
       for (int dx = -(int)p->size; dx <= (int)p->size; dx++) {
@@ -309,21 +311,24 @@ uint16_t mode_2D_lavalamp(void) {
             float intensity = 1.0f - (dist / p->size);
             intensity = intensity * intensity; // Square for smoother falloff
             
+            uint8_t bw = w * intensity;
             uint8_t br = r * intensity;
             uint8_t bg = g * intensity;
             uint8_t bb = b * intensity;
-            
+
             // Additive blending for organic merging
             uint32_t existing = SEGMENT.getPixelColorXY(px, py);
+            uint8_t ew = (existing >> 24) & 0xFF;
             uint8_t er = (existing >> 16) & 0xFF;
             uint8_t eg = (existing >> 8) & 0xFF;
             uint8_t eb = existing & 0xFF;
-            
+
+            ew = qadd8(ew, bw);
             er = qadd8(er, br);
             eg = qadd8(eg, bg);
             eb = qadd8(eb, bb);
             
-            SEGMENT.setPixelColorXY(px, py, RGBW32(er, eg, eb, 0));
+            SEGMENT.setPixelColorXY(px, py, RGBW32(er, eg, eb, ew));
           }
         }
       }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -2,10 +2,6 @@
 
 // for information how FX metadata strings work see https://kno.wled.ge/interfaces/json-api/#effect-metadata
 
-// paletteBlend: 0 - wrap when moving, 1 - always wrap, 2 - never wrap, 3 - none (undefined)
-#define PALETTE_SOLID_WRAP   (strip.paletteBlend == 1 || strip.paletteBlend == 3)
-#define PALETTE_MOVING_WRAP !(strip.paletteBlend == 2 || (strip.paletteBlend == 0 && SEGMENT.speed == 0))
-
 // static effect, used if an effect fails to initialize
 static uint16_t mode_static(void) {
   SEGMENT.fill(SEGCOLOR(0));
@@ -197,6 +193,7 @@ uint16_t mode_2D_lavalamp(void) {
   
   // Update and draw particles
   int activeCount = 0;
+  unsigned long currentMillis = millis();
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
     if (!lavaParticles[i].active) continue;
     activeCount++;
@@ -240,7 +237,7 @@ uint16_t mode_2D_lavalamp(void) {
     }
 
     // Horizontal oscillation (makes it more organic)
-    p->vx += sin((millis() / 1000.0f + i) * 0.5f) * 0.002f; // Reduced oscillation
+    p->vx += sin((currentMillis / 1000.0f + i) * 0.5f) * 0.002f; // Reduced oscillation
     p->vx *= 0.92f; // Stronger damping for less drift
     
     // Bounce off sides (don't affect vertical velocity)

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -98,7 +98,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 
 /*
 /  Lava Lamp 2D effect
-*   Uses particles to simulate rising blobs of "lava"
+*   Uses particles to simulate rising blobs of "lava" or wax
 *   Particles slowly rise, merge to create organic flowing shapes, and then fall to the bottom to start again
 *   Created by Bob Loeffler using claude.ai
 *   The first slider sets the number of active blobs
@@ -170,8 +170,6 @@ static void mode_2D_lavalamp(void) {
   const float spawnXStart = cols * 0.20f;
   const float spawnXWidth = cols * 0.60f;
   int spawnX = max(1, (int)(spawnXWidth));
-
-  //float speedFactor = (SEGMENT.speed + 5) / 255.0f;     // (SEGMENT.speed + 30) / 100.0f; // 0.3 to 2.85 range
 
   // Spawn new particles at the bottom near the center
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
@@ -384,7 +382,7 @@ static void mode_2D_lavalamp(void) {
     }
   }
 }
-static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,Horz Damping,,Color mode,Attract;;!;2;ix=64,o2=1,pal=47";
+static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,Color mode,Attract;;!;2;ix=64,c2=192,o2=1,pal=47";
 
 
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -119,7 +119,7 @@ uint16_t mode_2D_lavalamp(void) {
   const uint16_t rows = SEGMENT.virtualHeight();
   
   // Allocate per-segment storage
-  constexpr size_t MAX_LAVA_PARTICLES = 50;
+  constexpr size_t MAX_LAVA_PARTICLES = 35;
   if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) return mode_static();
   LavaParticle* lavaParticles = reinterpret_cast<LavaParticle*>(SEGENV.data);
 
@@ -225,7 +225,7 @@ uint16_t mode_2D_lavalamp(void) {
         float dy = other->y - p->y;
 
         // Apply weak horizontal attraction only
-        float attractRange = (p->size + other->size) * 1.0f;
+        float attractRange = p->size + other->size;
         float distSq = dx*dx + dy*dy;
         float attractRangeSq = attractRange * attractRange;
         if (distSq > 0 && distSq < attractRangeSq) {
@@ -292,6 +292,7 @@ uint16_t mode_2D_lavalamp(void) {
 
     // Draw blob with soft edges (gaussian-like falloff)
     float sizeSq = p->size * p->size;
+    float invSize = 1.0f / p->size;
     for (int dy = -(int)p->size; dy <= (int)p->size; dy++) {
       for (int dx = -(int)p->size; dx <= (int)p->size; dx++) {
         int px = (int)(p->x + dx);
@@ -301,7 +302,7 @@ uint16_t mode_2D_lavalamp(void) {
           float distSq = dx*dx + dy*dy;
           if (distSq < sizeSq) {
             // Soft falloff
-            float intensity = 1.0f - sqrt(distSq) / p->size;
+            float intensity = 1.0f - sqrt(distSq) * invSize;
             intensity = intensity * intensity; // Square for smoother falloff
             
             uint8_t bw = w * intensity;
@@ -322,7 +323,7 @@ uint16_t mode_2D_lavalamp(void) {
 
   return FRAMETIME;
 }
-static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@Speed,# of blobs,Blob size,,,Color mode,Attract;;!;2;sx=64,ix=64,o2=1,pal=47";
+static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@Speed,# of blobs,Blob size,,,Color mode,Attract;;!;2;ix=64,o2=1,pal=47";
 
 
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -162,7 +162,7 @@ uint16_t mode_2D_lavalamp(void) {
 
   // Spawn new particles at the bottom near the center
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
-    if (!lavaParticles[i].active && hw_random8() < 32) { // Always spawn when slot available
+    if (!lavaParticles[i].active && hw_random8() < 32) { // sporadically spawn when slot available
       // Spawn in the middle 60% of the width
       float centerStart = cols * 0.20f;
       float centerWidth = cols * 0.60f;
@@ -193,7 +193,7 @@ uint16_t mode_2D_lavalamp(void) {
   
   // Update and draw particles
   int activeCount = 0;
-  unsigned long currentMillis = millis();
+  unsigned long currentMillis = strip.now;
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
     if (!lavaParticles[i].active) continue;
     activeCount++;
@@ -292,7 +292,6 @@ uint16_t mode_2D_lavalamp(void) {
 
     // Draw blob with soft edges (gaussian-like falloff)
     float sizeSq = p->size * p->size;
-    float invSize = 1.0f / p->size;
     for (int dy = -(int)p->size; dy <= (int)p->size; dy++) {
       for (int dx = -(int)p->size; dx <= (int)p->size; dx++) {
         int px = (int)(p->x + dx);
@@ -301,8 +300,8 @@ uint16_t mode_2D_lavalamp(void) {
         if (px >= 0 && px < cols && py >= 0 && py < rows) {
           float distSq = dx*dx + dy*dy;
           if (distSq < sizeSq) {
-            // Soft falloff
-            float intensity = 1.0f - sqrt(distSq) * invSize;
+            // Soft falloff using squared distance (faster)
+            float intensity = 1.0f - (distSq / sizeSq);
             intensity = intensity * intensity; // Square for smoother falloff
             
             uint8_t bw = w * intensity;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -115,14 +115,14 @@ typedef struct LavaParticle {
   bool active;          // will not be displayed if false
 } LavaParticle;
 
-uint16_t mode_2D_lavalamp(void) {
+static uint16_t mode_2D_lavalamp(void) {
   if (!strip.isMatrix || !SEGMENT.is2D()) return mode_static(); // not a 2D set-up
   
   const uint16_t cols = SEGMENT.virtualWidth();
   const uint16_t rows = SEGMENT.virtualHeight();
   
   // Allocate per-segment storage
-  constexpr size_t MAX_LAVA_PARTICLES = 35;
+  constexpr size_t MAX_LAVA_PARTICLES = 35;  // increasing this value could cause slowness for large matrices
   if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) return mode_static();
   LavaParticle* lavaParticles = reinterpret_cast<LavaParticle*>(SEGENV.data);
 
@@ -155,7 +155,8 @@ uint16_t mode_2D_lavalamp(void) {
     for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
       if (lavaParticles[i].active) {
         // Assign new random size within the new range
-        lavaParticles[i].size = minSize + (float)random16((int)(newRange));
+        int rangeInt = max(1, (int)(newRange));
+        lavaParticles[i].size = minSize + (float)random16(rangeInt);
         // Ensure minimum size
         if (lavaParticles[i].size < minSize) lavaParticles[i].size = minSize;
       }
@@ -169,7 +170,8 @@ uint16_t mode_2D_lavalamp(void) {
       // Spawn in the middle 60% of the width
       float centerStart = cols * 0.20f;
       float centerWidth = cols * 0.60f;
-      lavaParticles[i].x = centerStart + (float)random16((int)(centerWidth));
+      int cwInt = max(1, (int)(centerWidth));
+      lavaParticles[i].x = centerStart + (float)random16(cwInt);
       lavaParticles[i].y = rows - 1;
       lavaParticles[i].vx = (random16(7) - 3) / 250.0f;
       
@@ -182,7 +184,8 @@ uint16_t mode_2D_lavalamp(void) {
       float minSize = cols * 0.15f; // Minimum 15% of width
       float maxSize = cols * 0.4f;  // Maximum 40% of width
       float sizeRange = (maxSize - minSize) * (sizeControl / 255.0f);
-      lavaParticles[i].size = minSize + (float)random16((int)(sizeRange));
+      int rangeInt = max(1, (int)(sizeRange));
+      lavaParticles[i].size = minSize + (float)random16(rangeInt);
 
       lavaParticles[i].hue = hw_random8();
       lavaParticles[i].life = 255;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -104,6 +104,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 *  The third slider sets the size range of the blobs
 *  The first checkbox sets the color mode (color wheel or palette)
 *  The second checkbox sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)
+*  aux0 keeps track of the blob size changes
 */
 
 typedef struct LavaParticle {
@@ -142,7 +143,7 @@ uint16_t mode_2D_lavalamp(void) {
   if (numParticles > MAX_LAVA_PARTICLES) numParticles = MAX_LAVA_PARTICLES;
   
   // Track size slider changes
-  static uint8_t lastSizeControl = 128;
+  uint8_t lastSizeControl = SEGENV.aux0;
   uint8_t currentSizeControl = SEGMENT.custom1;
   bool sizeChanged = (currentSizeControl != lastSizeControl);
 
@@ -160,7 +161,7 @@ uint16_t mode_2D_lavalamp(void) {
         if (lavaParticles[i].size < minSize) lavaParticles[i].size = minSize;
       }
     }
-    lastSizeControl = currentSizeControl;
+    SEGENV.aux0 = currentSizeControl;
   }
 
   // Spawn new particles at the bottom near the center

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -2,6 +2,9 @@
 
 // for information how FX metadata strings work see https://kno.wled.ge/interfaces/json-api/#effect-metadata
 
+// paletteBlend: 0 - wrap when moving, 1 - always wrap, 2 - never wrap, 3 - none (undefined)
+#define PALETTE_SOLID_WRAP   (strip.paletteBlend == 1 || strip.paletteBlend == 3)
+
 // static effect, used if an effect fails to initialize
 static uint16_t mode_static(void) {
   SEGMENT.fill(SEGCOLOR(0));
@@ -281,7 +284,7 @@ uint16_t mode_2D_lavalamp(void) {
     if (SEGMENT.check1) {
       color = SEGMENT.color_wheel(p->hue);  // Random colors mode
     } else {
-      color = SEGMENT.color_from_palette(p->hue, false, true, 0);   // Palette mode
+      color = SEGMENT.color_from_palette(p->hue, true, PALETTE_SOLID_WRAP, 0);   // Palette mode
     }
     
     // Extract RGB and apply life/opacity

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -218,7 +218,7 @@ uint16_t mode_2D_lavalamp(void) {
         
         LavaParticle *other = &lavaParticles[j];
         
-        // Only attract if moving in opposite vertical directions
+        // Skip attraction if moving in same vertical direction (both up or both down)
         if ((p->vy < 0 && other->vy < 0) || (p->vy > 0 && other->vy > 0)) continue;
         
         float dx = other->x - p->x;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -6,10 +6,11 @@
 #define PALETTE_SOLID_WRAP   (strip.paletteBlend == 1 || strip.paletteBlend == 3)
 
 // static effect, used if an effect fails to initialize
-static uint16_t mode_static(void) {
+static void mode_static(void) {
   SEGMENT.fill(SEGCOLOR(0));
-  return strip.isOffRefreshRequired() ? FRAMETIME : 350;
 }
+
+#define FX_FALLBACK_STATIC { mode_static(); return; }
 
 // If you define configuration options in your class and need to reference them in your effect function, add them here.
 // If you only need to use them in your class you can define them as class members instead.
@@ -20,9 +21,9 @@ static uint16_t mode_static(void) {
 /////////////////////////
 
 // Diffusion Fire: fire effect intended for 2D setups smaller than 16x16
-static uint16_t mode_diffusionfire(void) {
+static void mode_diffusionfire(void) {
   if (!strip.isMatrix || !SEGMENT.is2D())
-    return mode_static();  // not a 2D set-up
+    FX_FALLBACK_STATIC;  // not a 2D set-up
 
   const int cols = SEG_W;
   const int rows = SEG_H;
@@ -36,7 +37,7 @@ static uint16_t mode_diffusionfire(void) {
 
 unsigned dataSize = cols * rows;  // SEGLEN (virtual length) is equivalent to vWidth()*vHeight() for 2D
   if (!SEGENV.allocateData(dataSize))
-    return mode_static();  // allocation failed
+    FX_FALLBACK_STATIC;  // allocation failed
 
   if (SEGENV.call == 0) {
     SEGMENT.fill(BLACK);
@@ -91,7 +92,6 @@ unsigned dataSize = cols * rows;  // SEGLEN (virtual length) is equivalent to vW
       }
     }
   }
-  return FRAMETIME;
 }
 static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spark rate,Diffusion Speed,Turbulence,,Use palette;;Color;;2;pal=35";
 
@@ -118,14 +118,14 @@ typedef struct LavaParticle {
 } LavaParticle;
 
 static uint16_t mode_2D_lavalamp(void) {
-  if (!strip.isMatrix || !SEGMENT.is2D()) return mode_static(); // not a 2D set-up
+  if (!strip.isMatrix || !SEGMENT.is2D()) FX_FALLBACK_STATIC;; // not a 2D set-up
   
   const uint16_t cols = SEG_W;
   const uint16_t rows = SEG_H;
   
   // Allocate per-segment storage
   constexpr size_t MAX_LAVA_PARTICLES = 35;  // increasing this value could cause slowness for large matrices
-  if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) return mode_static();
+  if (!SEGENV.allocateData(sizeof(LavaParticle) * MAX_LAVA_PARTICLES)) FX_FALLBACK_STATIC;;
   LavaParticle* lavaParticles = reinterpret_cast<LavaParticle*>(SEGENV.data);
 
   // Initialize particles on first call
@@ -366,8 +366,6 @@ static uint16_t mode_2D_lavalamp(void) {
       }
     }
   }
-
-  return FRAMETIME;
 }
 static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@Speed,# of blobs,Blob size,,,Color mode,Attract;;!;2;ix=64,o2=1,pal=47";
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -111,7 +111,6 @@ typedef struct LavaParticle {
   float vx, vy;         // Velocity
   float size;           // Blob size
   uint8_t hue;          // Color
-  uint8_t life;         // Lifetime/opacity - currently set at 255 below. Possibly will allow diff values in the future.
   bool active;          // will not be displayed if false
 } LavaParticle;
 
@@ -186,7 +185,6 @@ static uint16_t mode_2D_lavalamp(void) {
       if (lavaParticles[i].size > MAX_BLOB_RADIUS) lavaParticles[i].size = MAX_BLOB_RADIUS;
 
       lavaParticles[i].hue = hw_random8();
-      lavaParticles[i].life = 255;  // TODO: currently doesn't change, but might change this behavior in the future
       lavaParticles[i].active = true;
       break;
     }
@@ -276,9 +274,6 @@ static uint16_t mode_2D_lavalamp(void) {
         if (p->vy > -0.10f) p->vy = -0.10f;
       }
     }
-
-    // Keep blobs alive forever (no fading) - maybe change in the future?
-    p->life = 255;
     
     // Get color
     uint32_t color;
@@ -289,10 +284,10 @@ static uint16_t mode_2D_lavalamp(void) {
     }
     
     // Extract RGB and apply life/opacity
-    uint8_t w = (W(color) * p->life) >> 8;
-    uint8_t r = (R(color) * p->life) >> 8;
-    uint8_t g = (G(color) * p->life) >> 8;
-    uint8_t b = (B(color) * p->life) >> 8;
+    uint8_t w = (W(color) * 255) >> 8;
+    uint8_t r = (R(color) * 255) >> 8;
+    uint8_t g = (G(color) * 255) >> 8;
+    uint8_t b = (B(color) * 255) >> 8;
 
     // Draw blob with soft edges (gaussian-like falloff)
     float sizeSq = p->size * p->size;

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -549,17 +549,17 @@ static void mode_2D_magma(void) {
   float gravity = map(SEGMENT.custom2, 0, 255, 5, 20) / 100.0f;
   
   // Number of particles (lava bombs)
-  uint8_t particleCount = map(SEGMENT.custom1, 0, 255, 2, MAGMA_MAX_PARTICLES);
-  particleCount = constrain(particleCount, 2, MAGMA_MAX_PARTICLES);
+  uint8_t particleCount = map(SEGMENT.custom1, 0, 255, 0, MAGMA_MAX_PARTICLES);
+  particleCount = constrain(particleCount, 0, MAGMA_MAX_PARTICLES);
 
   // Draw lava bombs in front of magma (or behind it)
   if (SEGMENT.check2) {
     drawMagma(width, height, ff_y, ff_z, shiftHue);
     SEGMENT.fadeToBlackBy(70);    // Dim the entire display to create trailing effect
-    drawLavaBombs(width, height, particleData, gravity, particleCount);
+    if (particleCount > 0) drawLavaBombs(width, height, particleData, gravity, particleCount);
   }
   else {
-    drawLavaBombs(width, height, particleData, gravity, particleCount);
+    if (particleCount > 0) drawLavaBombs(width, height, particleData, gravity, particleCount);
     SEGMENT.fadeToBlackBy(70);    // Dim the entire display to create trailing effect
     drawMagma(width, height, ff_y, ff_z, shiftHue);
   }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -104,9 +104,8 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 *   The first slider sets the number of active blobs
 *   The second slider sets the size range of the blobs
 *   The third slider sets the damping value for horizontal blob movement
-*   The first checkbox sets the color mode (color wheel or palette)
-*   The second checkbox sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)
-*   The third checkbox sets whether we preserve the color ratio when displaying pixels that are in 2 or more overlapping blobs
+*   The Attract checkbox sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)
+*   The Keep Color Ratio checkbox sets whether we preserve the color ratio when displaying pixels that are in 2 or more overlapping blobs
 *   aux0 keeps track of the blob size value
 *   aux1 keeps track of the number of blobs
 */
@@ -246,9 +245,8 @@ static void mode_2D_lavalamp(void) {
     }
 
     // Horizontal oscillation (makes it more organic)
-    float damping= map(SEGMENT.custom2, 0, 255, 87, 97) / 100.0f;
+    float damping= map(SEGMENT.custom2, 0, 255, 97, 87) / 100.0f;
     p->vx += sin((currentMillis / 1000.0f + i) * 0.5f) * 0.002f; // Reduced oscillation
-    //p->vx *= 0.92f; // Stronger damping for less drift
     p->vx *= damping; // damping for more or less horizontal drift
 
     // Bounce off sides (don't affect vertical velocity)
@@ -335,11 +333,7 @@ static void mode_2D_lavalamp(void) {
 
     // Get color
     uint32_t color;
-    if (SEGMENT.check1) {
-      color = SEGMENT.color_wheel(p->hue);  // Random colors mode
-    } else {
-      color = SEGMENT.color_from_palette(p->hue, true, PALETTE_SOLID_WRAP, 0);   // Palette mode
-    }
+    color = SEGMENT.color_from_palette(p->hue, true, PALETTE_SOLID_WRAP, 0);
     
     // Extract RGB and apply life/opacity
     uint8_t w = (W(color) * 255) >> 8;
@@ -385,7 +379,7 @@ static void mode_2D_lavalamp(void) {
     }
   }
 }
-static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,Color mode,Attract,Keep Color Ratio;;!;2;ix=64,c2=192,o2=1,pal=47";
+static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,,Attract,Keep Color Ratio;;!;2;ix=64,c2=192,o2=1,o3=1,pal=47";
 
 
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -172,6 +172,8 @@ static void mode_2D_lavalamp(void) {
   const float spawnXWidth = cols * 0.60f;
   int spawnX = max(1, (int)(spawnXWidth));
 
+  bool preserveColorRatio = SEGMENT.check3;
+
   // Spawn new particles at the bottom near the center
   for (int i = 0; i < MAX_LAVA_PARTICLES; i++) {
     if (!lavaParticles[i].active && hw_random8() < 32) { // spawn when slot available
@@ -377,7 +379,6 @@ static void mode_2D_lavalamp(void) {
 
           uint32_t existing = SEGMENT.getPixelColorXY(px, py);
           uint32_t newColor = RGBW32(br, bg, bb, bw);
-          bool preserveColorRatio = SEGMENT.check3;
           SEGMENT.setPixelColorXY(px, py, color_add(existing, newColor, preserveColorRatio ? true : false));
         }
       }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -106,6 +106,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 *   The third slider sets the damping value for horizontal blob movement
 *   The first checkbox sets the color mode (color wheel or palette)
 *   The second checkbox sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)
+*   The third checkbox sets whether we preserve the color ratio when displaying pixels that are in 2 or more overlapping blobs
 *   aux0 keeps track of the blob size value
 *   aux1 keeps track of the number of blobs
 */
@@ -376,13 +377,14 @@ static void mode_2D_lavalamp(void) {
 
           uint32_t existing = SEGMENT.getPixelColorXY(px, py);
           uint32_t newColor = RGBW32(br, bg, bb, bw);
-          SEGMENT.setPixelColorXY(px, py, color_add(existing, newColor));
+          bool preserveColorRatio = SEGMENT.check3;
+          SEGMENT.setPixelColorXY(px, py, color_add(existing, newColor, preserveColorRatio ? true : false));
         }
       }
     }
   }
 }
-static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,Color mode,Attract;;!;2;ix=64,c2=192,o2=1,pal=47";
+static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,Color mode,Attract,Keep Color Ratio;;!;2;ix=64,c2=192,o2=1,pal=47";
 
 
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -380,6 +380,9 @@ static void mode_2D_lavalamp(void) {
   }
 }
 static const char _data_FX_MODE_2D_LAVALAMP[] PROGMEM = "Lava Lamp@,# of blobs,Blob size,H. Damping,,,Attract,Keep Color Ratio;;!;2;ix=64,c2=192,o2=1,o3=1,pal=47";
+
+
+/*
 /  Morse Code by Bob Loeffler
 *   Adapted from code by automaticaddison.com and then optimized by claude.ai
 *   aux0 is the pattern offset for scrolling
@@ -629,7 +632,6 @@ static void mode_morsecode(void) {
   }
 }
 static const char _data_FX_MODE_MORSECODE[] PROGMEM = "Morse Code@Speed,,,,Color mode,Color by Word,Punctuation,EndOfMessage;;!;1;sx=192,c3=8,o1=1,o2=1";
-
 
 
 /////////////////////


### PR DESCRIPTION
This PR will add the Lava Lamp effect into the new user_fx usermod instead of FX.cpp

*  Lava Lamp 2D by Bob Loeffler 2025
*    Created by Bob Loeffler using claude.ai   Idea from https://github.com/wled/WLED/issues/1927
*    Uses particles to simulate rising blobs of "lava".  Particles slowly rise, merge to create organic flowing shapes, and then fall to the bottom to start again.
*    First slider sets the speed of the rising and falling blobs
*    Second slider sets the number of active blobs
*    Third slider sets the size range of the blobs
*    Checkbox1 sets the color mode (color wheel or palette)
*    Checkbox2 sets the attraction of blobs (checked will make the blobs attract other close blobs horizontally)

Example video:

https://github.com/user-attachments/assets/0b6383e1-040a-47b5-98ca-dbc0dd03c06e

^-- The LED matrix was too bright and washed out the colors due to cell phone camera overexposure.  In person it looks MUCH better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a 2D "Lava Lamp" visual effect for matrix displays: particle-based blobs with soft additive blending, vertical motion and trailing fade.
  * New user controls: speed, number of blobs, blob size, color mode (palette or color wheel) and optional horizontal attraction.
  * Per-segment support and automatic activation only on 2D setups; included in the effects list for easy selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->