### PR TITLE
Fixes ethernet initialisation of static IP settings and modified some debug info

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -49,13 +49,6 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   //long vid = doc[F("vid")]; // 2010020
 
-#ifdef WLED_USE_ETHERNET
-  JsonObject ethernet = doc[F("eth")];
-  CJSON(ethernetType, ethernet["type"]);
-  // NOTE: Ethernet configuration takes priority over other use of pins
-  initEthernet();
-#endif
-
   JsonObject id = doc["id"];
   getStringFromJson(cmDNS, id[F("mdns")], 33);
   getStringFromJson(serverDescription, id[F("name")], 33);
@@ -124,6 +117,14 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
       CJSON(dnsAddress[i], dns[i]);
     }
   }
+
+  // https://github.com/wled/WLED/issues/5247
+#ifdef WLED_USE_ETHERNET
+  JsonObject ethernet = doc[F("eth")];
+  CJSON(ethernetType, ethernet["type"]);
+  // NOTE: Ethernet configuration takes priority over other use of pins
+  initEthernet();
+#endif
 
   JsonObject ap = doc["ap"];
   getStringFromJson(apSSID, ap[F("ssid")], 33);

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -239,7 +239,7 @@ bool initEthernet()
                 (eth_phy_type_t)   es.eth_type,
                 (eth_clock_mode_t) es.eth_clk_mode
                 )) {
-    DEBUG_PRINTLN(F("initC: ETH.begin() failed"));
+    DEBUG_PRINTLN(F("initE: ETH.begin() failed"));
     // de-allocate the allocated pins
     for (managed_pin_type mpt : pinsToAllocate) {
       PinManager::deallocatePin(mpt.pin, PinOwner::Ethernet);
@@ -247,8 +247,15 @@ bool initEthernet()
     return false;
   }
 
+  // https://github.com/wled/WLED/issues/5247
+  if (multiWiFi[0].staticIP != (uint32_t)0x00000000 && multiWiFi[0].staticGW != (uint32_t)0x00000000) {
+    ETH.config(multiWiFi[0].staticIP, multiWiFi[0].staticGW, multiWiFi[0].staticSN, dnsAddress);
+  } else {
+    ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+  }
+
   successfullyConfiguredEthernet = true;
-  DEBUG_PRINTLN(F("initC: *** Ethernet successfully configured! ***"));
+  DEBUG_PRINTLN(F("initE: *** Ethernet successfully configured! ***"));
   return true;
 }
 #endif
@@ -405,11 +412,6 @@ void WiFiEvent(WiFiEvent_t event)
       DEBUG_PRINTLN(F("ETH-E: Connected"));
       if (!apActive) {
         WiFi.disconnect(true); // disable WiFi entirely
-      }
-      if (multiWiFi[0].staticIP != (uint32_t)0x00000000 && multiWiFi[0].staticGW != (uint32_t)0x00000000) {
-        ETH.config(multiWiFi[0].staticIP, multiWiFi[0].staticGW, multiWiFi[0].staticSN, dnsAddress);
-      } else {
-        ETH.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
       }
       // convert the "serverDescription" into a valid DNS hostname (alphanumeric)
       char hostname[64];


### PR DESCRIPTION
**Summary**
https://github.com/wled/WLED/issues/5247

The static IP configuration happened too late in the ethernet initialization sequence.
The ETH.config() call from the event handler was moved to just after ETH.begin().

Additionally, initEthernet() was called before config deserialization was complete.
The initEthernet() was moved later in the config deserialization to ensure static IP and DNS configuration is completed prior to ethernet initialisation.

**Testing performed**
Build with default_envs = esp32_eth (no platformio_override.ini used)
WiFi Setup already exists (AP SSID customised, static IP set with custom DNS server address and AP opens set to 'No Connection after boot')
 
Tests done with and without DHCP being enabled on the Ethernet network. Expected behaviour seen regardless of DHCP or static IP Address usage.
 
No Ethernet connected
- Upload firmware build with fixes to board with existing WiFi Setup
- WiFi AP started (AP SSID customised name observed)
- WiFi AP tested and connected OK (4.3.2.1) - WiFi Setup config retained and loaded
- Connected Ethernet, connection event registered
- WiFi AP stopped and Access point disabled
- UI accessible via Ethernet and the defined static IP
 
Ethernet connected
- Power cycled board with existing WiFi Setup
- Ethernet connection registered
- WiFi AP stopped and Access point disabled
- UI accessible via Ethernet and the defined static IP
- WiFi Setup config retained and loaded
 
- Disconnected ethernet
- Ethernet disconnection event registered
- WiFi AP started (AP SSID customised name observed)
- WiFi AP tested and connected OK (4.3.2.1)
 
Removed all config files via http://4.3.2.1/edit
- Rebooted board
- WiFi AP started (AP SSID default name observed)
- WiFi AP tested and connected OK (4.3.2.1)
- WiFi Setup defaults observed
- Static IP address, gateway and DNS set
- Ethernet type set to QuinLED-Dig-Octa & T-ETH-POE
- WiFi Setup saved
- Confirmed that WiFiSetup changes were retained
 
- Connected Ethernet, connection event registered
- WiFi AP stopped and Access point disabled
- UI accessible via Ethernet and the defined static IP
 
- Rebooted board with ethernet connected
- UI accessible via Ethernet and the defined static IP
 
Erased flash via esptool
- Ethernet connected
- Uploaded firmware build with fixes
- WiFi AP started (AP SSID default name observed)
- WiFi AP tested and connected OK (4.3.2.1)
- WiFi Setup defaults observed
- Ethernet connection down due to Ethernet Type being set to 'None' by default.
- Static IP address, gateway, DNS and AP SSID customised name set
- Ethernet type set to QuinLED-Dig-Octa & T-ETH-POE
- WiFi Setup saved
- Ethernet connection registered
- WiFi AP stopped and Access point disabled
- UI accessible via Ethernet and the defined static IP
- WiFi Setup config retained and loaded
 
- Disconnected ethernet
- Ethernet disconnection event registered
- WiFi AP started (AP SSID customised name observed)
- WiFi AP tested and connected OK (4.3.2.1)
