### PR TITLE
Add support for TM1815

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -933,7 +933,7 @@ class WS2812FX {
     inline bool isUpdating() const           { return !BusManager::canAllShow(); } // return true if the strip is being sent pixel updates
     inline bool isServicing() const          { return _isServicing; }           // returns true if strip.service() is executing
     inline bool hasWhiteChannel() const      { return _hasWhiteChannel; }       // returns true if strip contains separate white chanel
-    inline bool isOffRefreshRequired() const { return _isOffRefreshRequired; }  // returns true if strip requires regular updates (i.e. TM1814 chipset)
+    inline bool isOffRefreshRequired() const { return _isOffRefreshRequired; }  // returns true if strip requires regular updates (i.e. TM1814/TM1815 chipset)
     inline bool isSuspended() const          { return _suspend; }               // returns true if strip.service() execution is suspended
     inline bool needsUpdate() const          { return _triggered; }             // returns true if strip received a trigger() request
 

--- a/wled00/bus_customNPBtiming.h
+++ b/wled00/bus_customNPBtiming.h
@@ -97,12 +97,13 @@ public:
   #endif
   // ESP32 I2S Methods
   #if !defined(CONFIG_IDF_TARGET_ESP32C3)
+    #if defined(CONFIG_IDF_TARGET_ESP32S3)
+    typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
+    #else // ESP32 classic & S2
     typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusZero,  NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s0Tm1815Method;
     typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusOne,   NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s1Tm1815Method;
     typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s0Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s0X8Tm1815Method; // used by S2
     typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s1Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s1X8Tm1815Method; // used by classic ESP32
-    #if defined(CONFIG_IDF_TARGET_ESP32S3)
-    typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
     #endif
     // I2S Aliases
     #if defined(CONFIG_IDF_TARGET_ESP32S3)

--- a/wled00/bus_customNPBtiming.h
+++ b/wled00/bus_customNPBtiming.h
@@ -30,51 +30,51 @@
 class NeoEsp32RmtSpeedTm1815 : public NeoEsp32RmtInvertedSpeedBase
 {
 public:
-    const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(740, 1780);
-    const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(1440, 1060);
-    const static DRAM_ATTR uint16_t RmtDurationReset = FromNs(200000); // 200us
+  const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(740, 1780);
+  const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(1440, 1060);
+  const static DRAM_ATTR uint16_t RmtDurationReset = FromNs(200000); // 200us
 
-    static void IRAM_ATTR Translate(const void* src,
-        rmt_item32_t* dest,
-        size_t src_size,
-        size_t wanted_num,
-        size_t* translated_size,
-        size_t* item_num);
-};
-
-void NeoEsp32RmtSpeedTm1815::Translate(const void* src,
+  static void IRAM_ATTR Translate(const void* src,
     rmt_item32_t* dest,
     size_t src_size,
     size_t wanted_num,
     size_t* translated_size,
-    size_t* item_num)
+    size_t* item_num);
+};
+
+void NeoEsp32RmtSpeedTm1815::Translate(const void* src,
+  rmt_item32_t* dest,
+  size_t src_size,
+  size_t wanted_num,
+  size_t* translated_size,
+  size_t* item_num)
 {
-    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
-        RmtBit0, RmtBit1, RmtDurationReset);
+  _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+    RmtBit0, RmtBit1, RmtDurationReset);
 }
 #else // ESP8266
 class NeoEspBitBangSpeedTm1815
 {
 public:
-    const static uint32_t T0H = (F_CPU / 5833332 - CYCLES_LOOPTEST); // 0.7us
-    const static uint32_t T1H = (F_CPU / 3333332 - CYCLES_LOOPTEST); // 1.5us
-    const static uint32_t Period = (F_CPU / 1600000 - CYCLES_LOOPTEST); // 2.5us per bit
+  const static uint32_t T0H = (F_CPU / 5833332 - CYCLES_LOOPTEST); // 0.7us
+  const static uint32_t T1H = (F_CPU / 3333332 - CYCLES_LOOPTEST); // 1.5us
+  const static uint32_t Period = (F_CPU / 1600000 - CYCLES_LOOPTEST); // 2.5us per bit
 
-    static const uint32_t ResetTimeUs = 200;
-    const static uint32_t TLatch = (F_CPU / 20000 - CYCLES_LOOPTEST); // 200us, be generous
+  static const uint32_t ResetTimeUs = 200;
+  const static uint32_t TLatch = (F_CPU / 20000 - CYCLES_LOOPTEST); // 200us, be generous
 };
 
 class NeoEsp8266UartSpeedTm1815 // values taken from "400kHz" speed bus but extended reset time (just like TM1814 does with 800kHz timings)
 {
 public:
-    static const uint32_t ByteSendTimeUs = 20; // us it takes to send a single pixel element at 400khz speed
-    static const uint32_t UartBaud = 1600000; // 400mhz, 4 serial bytes per NeoByte
-    static const uint32_t ResetTimeUs = 200; // us between data send bursts to reset for next update
+  static const uint32_t ByteSendTimeUs = 20; // us it takes to send a single pixel element at 400khz speed
+  static const uint32_t UartBaud = 1600000;  // 400khz output, 4 serial bytes per NeoByte
+  static const uint32_t ResetTimeUs = 200;   // use between data send bursts to reset for next update
 };
 
 class NeoWrgbTm1815Feature :
-    public Neo4ByteFeature<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>,
-    public NeoElementsTm1814Settings<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>
+  public Neo4ByteFeature<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>,
+  public NeoElementsTm1814Settings<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>
 {
 };
 #endif
@@ -98,20 +98,22 @@ public:
   // ESP32 I2S Methods
   #if !defined(CONFIG_IDF_TARGET_ESP32C3)
     #if defined(CONFIG_IDF_TARGET_ESP32S3)
-    typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
+      typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
     #else // ESP32 classic & S2
-    typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusZero,  NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s0Tm1815Method;
-    typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusOne,   NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s1Tm1815Method;
-    typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s0Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s0X8Tm1815Method; // used by S2
-    typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s1Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s1X8Tm1815Method; // used by classic ESP32
+      typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusZero,  NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s0Tm1815Method;
+      typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s0Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s0X8Tm1815Method; // used by S2, not used by classic ESP32
+      #if defined(CONFIG_IDF_TARGET_ESP32)
+      typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusOne,   NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s1Tm1815Method;
+      typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s1Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s1X8Tm1815Method; // available on classic ESP32 only
+      #endif
     #endif
     // I2S Aliases
     #if defined(CONFIG_IDF_TARGET_ESP32S3)
-    typedef NeoEsp32LcdX8Tm1815Method    X8Tm1815Method;
+      typedef NeoEsp32LcdX8Tm1815Method    X8Tm1815Method;
     #elif defined(CONFIG_IDF_TARGET_ESP32S2)
-    typedef NeoEsp32I2s0X8Tm1815Method   X8Tm1815Method;
+      typedef NeoEsp32I2s0X8Tm1815Method   X8Tm1815Method;
     #else // ESP32 classic
-    typedef NeoEsp32I2s1X8Tm1815Method   X8Tm1815Method;
+      typedef NeoEsp32I2s1X8Tm1815Method   X8Tm1815Method;
     #endif
   #endif // !CONFIG_IDF_TARGET_ESP32C3
 #else // ESP8266

--- a/wled00/bus_customNPBtiming.h
+++ b/wled00/bus_customNPBtiming.h
@@ -1,0 +1,129 @@
+/*
+ * Custom NeoPixelBus timing definitions for WLED
+ */
+
+#pragma once
+#ifndef BusCustomNPBtiming_h
+#define BusCustomNPBtiming_h
+
+#include <Arduino.h>
+#include "NeoPixelBus.h"
+
+#define WLED_USE_SHARED_RMT
+
+#ifdef ESP32
+// RMT driver selection
+#if !defined(WLED_USE_SHARED_RMT)  && !defined(__riscv)
+#include <NeoEsp32RmtHIMethod.h>
+//#define NeoEsp32RmtMethod(x) NeoEsp32RmtHIN ## x ## Method
+#define USE_NEOPIXELBUS_RMT_HI
+#else
+#include "internal/methods/NeoEsp32RmtMethod.h" // needed for custom RMT types
+//#define NeoEsp32RmtMethod(x) NeoEsp32RmtN ## x ## Method
+#endif
+
+////////////////////////////////
+// TM1815 timing definitions  //
+////////////////////////////////
+
+// TM1815 is exactly half the speed of TM1814, other features are identical so can use TM1814 as a base class
+// normal timing pulses are inverted compared to WS281x (low pulse timing, high idle/reset)
+
+// RMT timing
+class NeoEsp32RmtSpeedTm1815 : public NeoEsp32RmtInvertedSpeedBase
+{
+public:
+    const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(740, 1780);
+    const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(1440, 1060);
+    const static DRAM_ATTR uint16_t RmtDurationReset = FromNs(200000); // 200us
+
+    static void IRAM_ATTR Translate(const void* src,
+        rmt_item32_t* dest,
+        size_t src_size,
+        size_t wanted_num,
+        size_t* translated_size,
+        size_t* item_num);
+};
+
+void NeoEsp32RmtSpeedTm1815::Translate(const void* src,
+    rmt_item32_t* dest,
+    size_t src_size,
+    size_t wanted_num,
+    size_t* translated_size,
+    size_t* item_num)
+{
+    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
+        RmtBit0, RmtBit1, RmtDurationReset);
+}
+
+#else // ESP8266
+class NeoEspBitBangSpeedTm1815
+{
+public:
+    const static uint32_t T0H = (F_CPU / 5833332 - CYCLES_LOOPTEST); // 0.7us
+    const static uint32_t T1H = (F_CPU / 3333332 - CYCLES_LOOPTEST); // 1.5us
+    const static uint32_t Period = (F_CPU / 1600000 - CYCLES_LOOPTEST); // 2.5us per bit
+
+    static const uint32_t ResetTimeUs = 200;
+    const static uint32_t TLatch = (F_CPU / 20000 - CYCLES_LOOPTEST); // 200us, be generous
+};
+
+class NeoEsp8266UartSpeedTm1815 // values taken from "400kHz" speed bus but extended reset time (just like TM1814 does with 800kHz timings)
+{
+public:
+    static const uint32_t ByteSendTimeUs = 20; // us it takes to send a single pixel element at 400khz speed
+    static const uint32_t UartBaud = 1600000; // 400mhz, 4 serial bytes per NeoByte
+    static const uint32_t ResetTimeUs = 200; // us between data send bursts to reset for next update
+};
+
+class NeoWrgbTm1815Feature :
+    public Neo4ByteFeature<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>,
+    public NeoElementsTm1814Settings<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>
+{
+};
+#endif
+
+// I2S / DMA custom timing
+class NeoBitsSpeedTm1815 : public NeoBitsSpeedBase
+{
+public:
+  const static uint16_t BitSendTimeNs = 2500;
+  const static uint16_t ResetTimeUs = 200;
+};
+
+// TM1815 methods
+#ifdef ESP32
+  // ESP32 RMT Methods
+  #ifdef USE_NEOPIXELBUS_RMT_HI
+    typedef NeoEsp32RmtHIMethodBase<NeoEsp32RmtSpeedTm1815, NeoEsp32RmtChannelN> NeoEsp32RmtHINTm1815Method;
+  #else
+    typedef NeoEsp32RmtMethodBase<NeoEsp32RmtSpeedTm1815, NeoEsp32RmtChannelN> NeoEsp32RmtNTm1815Method;
+  #endif
+
+  // ESP32 I2S Methods
+  #if !defined(CONFIG_IDF_TARGET_ESP32C3)
+    typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusZero,  NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s0Tm1815Method;
+    typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2sBusOne,   NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s1Tm1815Method;
+    typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s0Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s0X8Tm1815Method; // used by S2
+    typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2s1Mux8Bus, NeoBitsInverted>                     NeoEsp32I2s1X8Tm1815Method; // used by classic ESP32
+    #if defined(CONFIG_IDF_TARGET_ESP32S3)
+    typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
+    #endif
+    // I2S Aliases
+    #if defined(CONFIG_IDF_TARGET_ESP32S3)
+    typedef NeoEsp32LcdX8Tm1815Method    X8Tm1815Method;
+    #elif defined(CONFIG_IDF_TARGET_ESP32S2)
+    typedef NeoEsp32I2s0X8Tm1815Method   X8Tm1815Method;
+    #else // ESP32 classic
+    typedef NeoEsp32I2s1X8Tm1815Method   X8Tm1815Method;
+    #endif
+  #endif // !CONFIG_IDF_TARGET_ESP32C3
+
+  #else // ESP8266
+    typedef NeoEsp8266UartMethodBase<NeoEsp8266UartSpeedTm1815, NeoEsp8266Uart<UartFeature0, NeoEsp8266UartContext>, NeoEsp8266UartInverted> NeoEsp8266Uart0Tm1815Method;
+    typedef NeoEsp8266UartMethodBase<NeoEsp8266UartSpeedTm1815, NeoEsp8266Uart<UartFeature1, NeoEsp8266UartContext>, NeoEsp8266UartInverted> NeoEsp8266Uart1Tm1815Method;
+    typedef NeoEsp8266DmaMethodBase<NeoEsp8266I2sCadence<NeoEsp8266DmaInvertedPattern>,NeoBitsSpeedTm1815> NeoEsp8266DmaTm1815Method;
+    typedef NeoEspBitBangMethodBase<NeoEspBitBangSpeedTm1815, NeoEspInverted, true> NeoEsp8266BitBangTm1815Method;
+#endif
+
+#endif // BusCustomNPBtiming_h

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -159,7 +159,7 @@ uint32_t Bus::autoWhiteCalc(uint32_t c) const {
 
 
 BusDigital::BusDigital(const BusConfig &bc, uint8_t nr)
-: Bus(bc.type, bc.start, bc.autoWhite, bc.count, bc.reversed, (bc.refreshReq || bc.type == TYPE_TM1814))
+: Bus(bc.type, bc.start, bc.autoWhite, bc.count, bc.reversed, (bc.refreshReq || bc.type == (TYPE_TM1814 || TYPE_TM1815))) // TM1814/15 need refresh or they fall-back to a "demo mode"
 , _skip(bc.skipAmount) //sacrificial pixels
 , _colorOrder(bc.colorOrder)
 , _milliAmpsPerLed(bc.milliAmpsPerLed)
@@ -372,6 +372,7 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
     {TYPE_WS2812_RGB,    "D",  PSTR("WS281x")},
     {TYPE_SK6812_RGBW,   "D",  PSTR("SK6812/WS2814 RGBW")},
     {TYPE_TM1814,        "D",  PSTR("TM1814")},
+    {TYPE_TM1815,        "D",  PSTR("TM1815")},
     {TYPE_WS2811_400KHZ, "D",  PSTR("400kHz")},
     {TYPE_TM1829,        "D",  PSTR("TM1829")},
     {TYPE_UCS8903,       "D",  PSTR("UCS8903")},

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -159,7 +159,7 @@ uint32_t Bus::autoWhiteCalc(uint32_t c) const {
 
 
 BusDigital::BusDigital(const BusConfig &bc, uint8_t nr)
-: Bus(bc.type, bc.start, bc.autoWhite, bc.count, bc.reversed, (bc.refreshReq || bc.type == (TYPE_TM1814 || TYPE_TM1815))) // TM1814/15 need refresh or they fall-back to a "demo mode"
+: Bus(bc.type, bc.start, bc.autoWhite, bc.count, bc.reversed, (bc.refreshReq || bc.type == TYPE_TM1814 || bc.type == TYPE_TM1815)) // TM1814/15 need refresh or they fall-back to a "demo mode"
 , _skip(bc.skipAmount) //sacrificial pixels
 , _colorOrder(bc.colorOrder)
 , _milliAmpsPerLed(bc.milliAmpsPerLed)

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -173,8 +173,9 @@ class Bus {
     }
     static constexpr bool hasWhite(uint8_t type) {
       return  (type >= TYPE_WS2812_1CH && type <= TYPE_WS2812_WWA) ||
-              type == TYPE_SK6812_RGBW || type == TYPE_TM1814 || type == TYPE_UCS8904 ||
-              type == TYPE_FW1906 || type == TYPE_WS2805 || type == TYPE_SM16825 ||        // digital types with white channel
+              type == TYPE_SK6812_RGBW || type == TYPE_TM1814 || type == TYPE_TM1815 ||
+              type == TYPE_UCS8904 || type == TYPE_FW1906 || type == TYPE_WS2805 ||
+              type == TYPE_SM16825 ||                                                      // digital types with white channel
               (type > TYPE_ONOFF && type <= TYPE_ANALOG_5CH && type != TYPE_ANALOG_3CH) || // analog types with white channel
               type == TYPE_NET_DDP_RGBW || type == TYPE_NET_ARTNET_RGBW;                   // network types with white channel
     }
@@ -192,7 +193,7 @@ class Bus {
     static constexpr bool  isVirtual(uint8_t type)    { return (type >= TYPE_VIRTUAL_MIN && type <= TYPE_VIRTUAL_MAX); }
     static constexpr bool  isHub75(uint8_t type)      { return (type >= TYPE_HUB75MATRIX_MIN && type <= TYPE_HUB75MATRIX_MAX); }
     static constexpr bool  is16bit(uint8_t type)      { return type == TYPE_UCS8903 || type == TYPE_UCS8904 || type == TYPE_SM16825; }
-    static constexpr bool  mustRefresh(uint8_t type)  { return type == TYPE_TM1814; }
+    static constexpr bool  mustRefresh(uint8_t type)  { return type == TYPE_TM1814 || type == TYPE_TM1815; }
     static constexpr int   numPWMPins(uint8_t type)   { return (type - 40); }
 
     static inline int16_t  getCCT()                   { return _cct; }

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -485,7 +485,7 @@ class PolyBus {
   static void beginTM1814(void* busPtr) {
     T tm1814_strip = static_cast<T>(busPtr);
     tm1814_strip->Begin();
-    // Max current for each LED (22.5 mA).
+    // Max current for each LED (22.5 mA): max is 38mA, 22.5 was chosen as a safe value, see #1905
     tm1814_strip->SetPixelSettings(NeoTm1814Settings(/*R*/225, /*G*/225, /*B*/225, /*W*/225));
   }
 

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -4,6 +4,7 @@
 
 //#define NPB_CONF_4STEP_CADENCE
 #include "NeoPixelBus.h"
+#include "bus_customNPBtiming.h"
 
 //Hardware SPI Pins
 #define P_8266_HS_MOSI 13
@@ -147,112 +148,11 @@
 #if !defined(WLED_USE_SHARED_RMT)  && !defined(__riscv)
 #include <NeoEsp32RmtHIMethod.h>
 #define NeoEsp32RmtMethod(x) NeoEsp32RmtHIN ## x ## Method
-#define USE_NEOPIXELBUS_RMT_HI
 #else
 #include "internal/methods/NeoEsp32RmtMethod.h" // needed for custom RMT types
 #define NeoEsp32RmtMethod(x) NeoEsp32RmtN ## x ## Method
 #endif
-
-// special types and classes not officially supported by NPB
-
-// TM1815 is exactly half the speed of TM1814, normal is inverted signal compared to WS281x (low pulse timing, high idle/reset)
-//RMT timing
-class NeoEsp32RmtSpeedTm1815 : public NeoEsp32RmtInvertedSpeedBase
-{
-public:
-    const static DRAM_ATTR uint32_t RmtBit0 = Item32Val(740, 1780);
-    const static DRAM_ATTR uint32_t RmtBit1 = Item32Val(1440, 1060);
-    const static DRAM_ATTR uint16_t RmtDurationReset = FromNs(200000); // 200us
-
-    static void IRAM_ATTR Translate(const void* src,
-        rmt_item32_t* dest,
-        size_t src_size,
-        size_t wanted_num,
-        size_t* translated_size,
-        size_t* item_num);
-};
-
-void NeoEsp32RmtSpeedTm1815::Translate(const void* src,
-    rmt_item32_t* dest,
-    size_t src_size,
-    size_t wanted_num,
-    size_t* translated_size,
-    size_t* item_num)
-{
-    _translate(src, dest, src_size, wanted_num, translated_size, item_num,
-        RmtBit0, RmtBit1, RmtDurationReset);
-}
-
-#else // ESP8266
-// Tm1815 normal is inverted signal
-class NeoEspBitBangSpeedTm1815
-{
-public:
-    const static uint32_t T0H = (F_CPU / 5833332 - CYCLES_LOOPTEST); // 0.7us
-    const static uint32_t T1H = (F_CPU / 3333332 - CYCLES_LOOPTEST); // 1.5us
-    const static uint32_t Period = (F_CPU / 1600000 - CYCLES_LOOPTEST); // 2.5us per bit
-
-    static const uint32_t ResetTimeUs = 200;
-    const static uint32_t TLatch = (F_CPU / 20000 - CYCLES_LOOPTEST); // 200us, be generous
-};
-
-class NeoEsp8266UartSpeedTm1815 // values taken from "400kHz" speed bus but extended reset time (just like TM1814 does with 800kHz timings)
-{
-public:
-    static const uint32_t ByteSendTimeUs = 20; // us it takes to send a single pixel element at 400khz speed
-    static const uint32_t UartBaud = 1600000; // 400mhz, 4 serial bytes per NeoByte
-    static const uint32_t ResetTimeUs = 200; // us between data send bursts to reset for next update
-};
-
-class NeoWrgbTm1815Feature :
-    public Neo4ByteFeature<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>,
-    public NeoElementsTm1814Settings<ColorIndexW, ColorIndexR, ColorIndexG, ColorIndexB>
-{
-};
 #endif
-
-// I2S / DMA custom timing
-class NeoBitsSpeedTm1815 : public NeoBitsSpeedBase
-{
-public:
-    const static uint16_t BitSendTimeNs = 2500;
-    const static uint16_t ResetTimeUs = 200;
-};
-
-// special non-native I2S NPB methods
-#ifdef ESP32
-// ESP32 RMT Methods
-#ifdef USE_NEOPIXELBUS_RMT_HI
-typedef NeoEsp32RmtHIMethodBase<NeoEsp32RmtSpeedTm1815, NeoEsp32RmtChannelN> NeoEsp32RmtHINTm1815Method;
-#else
-typedef NeoEsp32RmtMethodBase<NeoEsp32RmtSpeedTm1815, NeoEsp32RmtChannelN> NeoEsp32RmtNTm1815Method;
-#endif
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
-// ESP32 I2S Methods
-typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2sBusZero, NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s0Tm1815Method;
-typedef NeoEsp32I2sMethodBase<NeoBitsSpeedTm1815, NeoEsp32I2sBusOne, NeoBitsInverted, NeoEsp32I2sCadence> NeoEsp32I2s1Tm1815Method;
-typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2s0Mux8Bus, NeoBitsInverted>    NeoEsp32I2s0X8Tm1815Method; // user for S2
-typedef NeoEsp32I2sXMethodBase<NeoBitsSpeedTm1815,  NeoEsp32I2s1Mux8Bus, NeoBitsInverted>    NeoEsp32I2s1X8Tm1815Method; // use for classic ESP32 (not defined for S2, can be defined for S3 but is not used)
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
-typedef NeoEsp32LcdXMethodBase<NeoBitsSpeedTm1815,   NeoEsp32LcdMux8Bus, NeoBitsInverted> NeoEsp32LcdX8Tm1815Method; // S3 only
-#endif
-// I2S Aliases
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
-typedef NeoEsp32LcdX8Tm1815Method    X8Tm1815Method;
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)
-typedef NeoEsp32I2s0X8Tm1815Method   X8Tm1815Method;
-#else // ESP32 classic
-typedef NeoEsp32I2s1X8Tm1815Method   X8Tm1815Method;
-#endif
-#endif // !CONFIG_IDF_TARGET_ESP32C3
-#else // ESP8266
-
-typedef NeoEsp8266UartMethodBase<NeoEsp8266UartSpeedTm1815, NeoEsp8266Uart<UartFeature0, NeoEsp8266UartContext>, NeoEsp8266UartInverted> NeoEsp8266Uart0Tm1815Method;
-typedef NeoEsp8266UartMethodBase<NeoEsp8266UartSpeedTm1815, NeoEsp8266Uart<UartFeature1, NeoEsp8266UartContext>, NeoEsp8266UartInverted> NeoEsp8266Uart1Tm1815Method;
-typedef NeoEsp8266DmaMethodBase<NeoEsp8266I2sCadence<NeoEsp8266DmaInvertedPattern>,NeoBitsSpeedTm1815> NeoEsp8266DmaTm1815Method;
-typedef NeoEspBitBangMethodBase<NeoEspBitBangSpeedTm1815, NeoEspInverted, true> NeoEsp8266BitBangTm1815Method;
-
-#endif // ESP32
 
 // In the following NeoGammaNullMethod can be replaced with NeoGammaWLEDMethod to perform Gamma correction implicitly
 // unfortunately that may apply Gamma correction to pre-calculated palettes which is undesired

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -156,6 +156,7 @@
 // special types and classes not officially supported by NPB
 
 // TM1815 is exactly half the speed of TM1814, normal is inverted signal compared to WS281x (low pulse timing, high idle/reset)
+//RMT timing
 class NeoEsp32RmtSpeedTm1815 : public NeoEsp32RmtInvertedSpeedBase
 {
 public:
@@ -181,15 +182,8 @@ void NeoEsp32RmtSpeedTm1815::Translate(const void* src,
     _translate(src, dest, src_size, wanted_num, translated_size, item_num,
         RmtBit0, RmtBit1, RmtDurationReset);
 }
-#else // ESP8266
-// special types and classes not officially supported by NPB
-class NeoBitsSpeedTm1815 : public NeoBitsSpeedBase
-{
-public:
-    const static uint16_t BitSendTimeNs = 2500;
-    const static uint16_t ResetTimeUs = 200;
-};
 
+#else // ESP8266
 // Tm1815 normal is inverted signal
 class NeoEspBitBangSpeedTm1815
 {
@@ -216,6 +210,14 @@ class NeoWrgbTm1815Feature :
 {
 };
 #endif
+
+// I2S / DMA custom timing
+class NeoBitsSpeedTm1815 : public NeoBitsSpeedBase
+{
+public:
+    const static uint16_t BitSendTimeNs = 2500;
+    const static uint16_t ResetTimeUs = 200;
+};
 
 // special non-native I2S NPB methods
 #ifdef ESP32

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -143,17 +143,6 @@
 #define I_HS_LPO_3 109
 #define I_SS_LPO_3 110
 
-#ifdef ESP32
-// RMT driver selection
-#if !defined(WLED_USE_SHARED_RMT)  && !defined(__riscv)
-#include <NeoEsp32RmtHIMethod.h>
-#define NeoEsp32RmtMethod(x) NeoEsp32RmtHIN ## x ## Method
-#else
-#include "internal/methods/NeoEsp32RmtMethod.h" // needed for custom RMT types
-#define NeoEsp32RmtMethod(x) NeoEsp32RmtN ## x ## Method
-#endif
-#endif
-
 // In the following NeoGammaNullMethod can be replaced with NeoGammaWLEDMethod to perform Gamma correction implicitly
 // unfortunately that may apply Gamma correction to pre-calculated palettes which is undesired
 
@@ -270,6 +259,14 @@
   typedef NeoEsp32I2s1Apa106Method X1Apa106Method;
   typedef NeoEsp32I2s1Ws2805Method X1Ws2805Method;
   typedef NeoEsp32I2s1Tm1914Method X1Tm1914Method;
+#endif
+
+// RMT driver selection
+#if !defined(WLED_USE_SHARED_RMT)  && !defined(__riscv)
+#include <NeoEsp32RmtHIMethod.h>
+#define NeoEsp32RmtMethod(x) NeoEsp32RmtHIN ## x ## Method
+#else
+#define NeoEsp32RmtMethod(x) NeoEsp32RmtN ## x ## Method
 #endif
 
 //RGB

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -301,10 +301,11 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define TYPE_FW1906              28            //RGB + CW + WW + unused channel (6 channels per IC)
 #define TYPE_UCS8904             29            //first RGBW digital type (hardcoded in busmanager.cpp, memUsage())
 #define TYPE_SK6812_RGBW         30
-#define TYPE_TM1814              31
+#define TYPE_TM1814              31            //RGBW
 #define TYPE_WS2805              32            //RGB + WW + CW
 #define TYPE_TM1914              33            //RGB
 #define TYPE_SM16825             34            //RGB + WW + CW
+#define TYPE_TM1815              35            //RGBW (half speed TM1814)
 #define TYPE_DIGITAL_MAX         39            // last usable digital type
 //"Analog" types (40-47)
 #define TYPE_ONOFF               40            //binary output (relays etc.; NOT PWM)

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -289,7 +289,7 @@
 				setPinConfig(n,t);
 				gId("abl"+n).style.display = (!abl || !isDig(t)) ? "none" : "inline"; // show/hide individual ABL settings
 				if (change) { // did we change LED type?
-					gId("rf"+n).checked = (gId("rf"+n).checked || t == 31); // LEDs require data in off state (mandatory for TM1814)
+					gId("rf"+n).checked = (gId("rf"+n).checked || t == 31 || t == 35); // LEDs require data in off state (mandatory for TM1814/TM1815)
 					if (isAna(t)) d.Sf["LC"+n].value = 1;                   // for sanity change analog count just to 1 LED
 					d.Sf["LA"+n].min = (!isDig(t) || !abl) ? 0 : 1;         // set minimum value for LED mA
 					d.Sf["MA"+n].min = (!isDig(t)) ? 0 : 250;               // set minimum value for PSU mA


### PR DESCRIPTION
This adds custom NPB timings and methods to support TM1815.

@willmmiles this also paves the way to add more custom timings. What do you think of this approach and the file structure I chose?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for TM1815 RGBW LED chipset across supported output methods.

* **User Interface**
  * TM1815 now appears alongside other LED types in selection lists.

* **Settings**
  * Per-LED “Refresh off” requirement now applies to TM1815 as well as TM1814.

* **Chores**
  * LED interface identifiers and public configuration entries updated to include TM1815 and clarified TM1814/TM1829 naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->