### PR TITLE
Add support for Australian Western Time

### DIFF
--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -165,6 +165,7 @@
 			<option value="21">MX-CST</option>
 			<option value="22">PKT (Pakistan)</option>
 			<option value="23">BRT (Brasília)</option>
+			<option value="24">AWST (Perth)</option>
 		</select><br>
 		UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 		Current local time is <span class="times">unknown</span>.<br>

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -37,8 +37,9 @@ Timezone* tz;
 #define TZ_MX_CENTRAL          21
 #define TZ_PAKISTAN            22
 #define TZ_BRASILIA            23
+#define TZ_AUSTRALIA_WESTERN   24
 
-#define TZ_COUNT               24
+#define TZ_COUNT               25
 #define TZ_INIT               255
 
 byte tzCurrent = TZ_INIT; //uninitialized
@@ -140,6 +141,10 @@ static const std::pair<TimeChangeRule, TimeChangeRule> TZ_TABLE[] PROGMEM = {
     /* TZ_BRASILIA */ {
       {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
       {Last, Sun, Mar, 1, -180}
+    },
+    /* TZ_AUSTRALIA_WESTERN */ {
+      {Last, Sun, Mar, 1, 480},     //AWST = UTC + 8 hours
+      {Last, Sun, Mar, 1, 480}      //AWST = UTC + 8 hours (no DST)
     }
 };
 


### PR DESCRIPTION
Western Australia doesn't currently have DST - it was trialed in the past and abandoned 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AWST (Perth) timezone option to the Time setup selector.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->