### PR TITLE
prevent file data loss due to replacing an open file handle (partial fix for #5275)

### DIFF
--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -38,7 +38,7 @@ void closeFile() {
     DEBUGFS_PRINT(F("Close -> "));
     uint32_t s = millis();
   #endif
-  if (f) f.close(); // only close if we have an open file
+  f.close(); // "if (f)" check is aleady done inside f.close(), and f cannot be nullptr -> no need for double checking before closing the file handle.
   DEBUGFS_PRINTF("took %lu ms\n", millis() - s);
   doCloseFile = false;
 }


### PR DESCRIPTION
The function ``writeObjectToFile()`` was re-assigning ``f`` (global file handle, file.cpp) without first completing any pending write operations on f. 

Reassigning a file pointer thats still in use can lead to loss of data and file corruption.
This PR provides a fix by first checking for pending writes (doCloseFile == true) and calling f.close() when needed.

The same protection code is already preset in `readObjectFromFile()`, it looks like protecting ``writeObjectToFile()`` was forgotten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-handling reliability by ensuring files are properly closed when needed.
  * Ensured cached file data is flushed before files are reopened or written, reducing risk of data loss and improving consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->