### PR TITLE
Simpler TZ

### DIFF
--- a/tools/timezone.json
+++ b/tools/timezone.json
@@ -1,0 +1,17 @@
+{
+  "name":"CHAST/CHADT",
+  "dst": {
+    "w": "Last",
+    "dow": "Sun",
+    "m": "Sep",
+    "h": 2,
+    "off": 825
+  },
+  "std": {
+    "w": "First",
+    "dow": "Sun",
+    "m": "Apr",
+    "h": 3,
+    "off": 765
+  }
+}

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -8,6 +8,7 @@
 	<script>
 	var el=false;
 	var ms=["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+	var zones = ["UTC"];
 	// load common.js with retry on error
 	(function loadFiles() {
 		const l = document.createElement('script');
@@ -23,6 +24,7 @@
 			updLatLon();
 			Cs();
 			FC();
+			TZ();
 		});	// If we set async false, file is loaded and executed, then next statement is processed
 		if (loc) d.Sf.action = getURL('/settings/time');
 	}
@@ -83,6 +85,15 @@
 			}
 		}
 	}
+	function TZ()
+	{
+		zones.forEach((n,i)=>{
+			let o = cE("option");
+			o.value = i++;
+			o.text = n;
+			d.Sf["TZ"].appendChild(o);
+		});
+	}
 	function Wd()
 	{
 		a = [0,0,0,0,0,0,0,0,0,0];
@@ -139,34 +150,7 @@
 		Get time from NTP server: <input type="checkbox" name="NT"><br>
 		<input type="text" name="NS" maxlength="32"><br>
 		Use 24h format: <input type="checkbox" name="CF"><br>
-		Time zone: 
-		<select name="TZ">
-			<option value="0" selected>GMT(UTC)</option>
-			<option value="1">GMT/BST</option>
-			<option value="2">CET/CEST</option>
-			<option value="3">EET/EEST</option>
-			<option value="4">US-EST/EDT</option>
-			<option value="5">US-CST/CDT</option>
-			<option value="6">US-MST/MDT</option>
-			<option value="7">US-AZ</option>
-			<option value="8">US-PST/PDT</option>
-			<option value="9">CST (AWST, PHST)</option>
-			<option value="10">JST (KST)</option>
-			<option value="11">AEST/AEDT</option>
-			<option value="12">NZST/NZDT</option>
-			<option value="13">North Korea</option>
-			<option value="14">IST (India)</option>
-			<option value="15">CA-Saskatchewan</option>
-			<option value="16">ACST</option>
-			<option value="17">ACST/ACDT</option>
-			<option value="18">HST (Hawaii)</option>
-			<option value="19">NOVT (Novosibirsk)</option>
-			<option value="20">AKST/AKDT (Anchorage)</option>
-			<option value="21">MX-CST</option>
-			<option value="22">PKT (Pakistan)</option>
-			<option value="23">BRT (Brasília)</option>
-			<option value="24">AWST (Perth)</option>
-		</select><br>
+		Time zone: <select name="TZ"></select><br>
 		UTC offset: <input name="UO" type="number" min="-65500" max="65500" required> seconds (max. 18 hours)<br>
 		Current local time is <span class="times">unknown</span>.<br>
 		Latitude: <select name="LTR"><option value="N">N</option><option value="S">S</option></select><input name="LT" type="number" class="xl" min="0" max="66.6" step="0.01"><br>

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -88,7 +88,7 @@
 	{
 		zones.forEach((n,i)=>{
 			let o = cE("option");
-			o.value = i++;
+			o.value = i;
 			o.text = n;
 			d.Sf["TZ"].appendChild(o);
 		});

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -24,7 +24,6 @@
 			updLatLon();
 			Cs();
 			FC();
-			TZ();
 		});	// If we set async false, file is loaded and executed, then next statement is processed
 		if (loc) d.Sf.action = getURL('/settings/time');
 	}

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -191,6 +191,7 @@ bool initMqtt();
 void publishMqtt();
 
 //ntp.cpp
+String getTZNamesJSONString();
 void handleTime();
 void handleNetworkTime();
 void sendNTPPacket();

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -13,153 +13,163 @@
 
 Timezone* tz;
 
-#define TZ_UTC                  0
-#define TZ_UK                   1
-#define TZ_EUROPE_CENTRAL       2
-#define TZ_EUROPE_EASTERN       3
-#define TZ_US_EASTERN           4
-#define TZ_US_CENTRAL           5
-#define TZ_US_MOUNTAIN          6
-#define TZ_US_ARIZONA           7
-#define TZ_US_PACIFIC           8
-#define TZ_CHINA                9
-#define TZ_JAPAN               10
-#define TZ_AUSTRALIA_EASTERN   11
-#define TZ_NEW_ZEALAND         12
-#define TZ_NORTH_KOREA         13
-#define TZ_INDIA               14
-#define TZ_SASKACHEWAN         15
-#define TZ_AUSTRALIA_NORTHERN  16
-#define TZ_AUSTRALIA_SOUTHERN  17
-#define TZ_HAWAII              18
-#define TZ_NOVOSIBIRSK         19
-#define TZ_ANCHORAGE           20
-#define TZ_MX_CENTRAL          21
-#define TZ_PAKISTAN            22
-#define TZ_BRASILIA            23
-#define TZ_AUSTRALIA_WESTERN   24
-
-#define TZ_COUNT               25
-#define TZ_INIT               255
-
+#define TZ_INIT 255
 byte tzCurrent = TZ_INIT; //uninitialized
 
 /* C++11 form -- static std::array<std::pair<TimeChangeRule, TimeChangeRule>, TZ_COUNT> TZ_TABLE PROGMEM = {{ */
-static const std::pair<TimeChangeRule, TimeChangeRule> TZ_TABLE[] PROGMEM = {
-    /* TZ_UTC */ {
-      {Last, Sun, Mar, 1, 0}, // UTC
-      {Last, Sun, Mar, 1, 0}  // Same
-    },
-    /* TZ_UK */ {
-      {Last, Sun, Mar, 1, 60},      //British Summer Time
-      {Last, Sun, Oct, 2, 0}       //Standard Time
-    },
-    /* TZ_EUROPE_CENTRAL */ {
-      {Last, Sun, Mar, 2, 120},     //Central European Summer Time
-      {Last, Sun, Oct, 3, 60}      //Central European Standard Time
-    },
-    /* TZ_EUROPE_EASTERN */ {
-      {Last, Sun, Mar, 3, 180},     //East European Summer Time
-      {Last, Sun, Oct, 4, 120}     //East European Standard Time
-    },
-    /* TZ_US_EASTERN */ {
-      {Second, Sun, Mar, 2, -240},  //EDT = UTC - 4 hours
-      {First,  Sun, Nov, 2, -300}  //EST = UTC - 5 hours
-    },
-    /* TZ_US_CENTRAL */ {
-      {Second, Sun, Mar, 2, -300},  //CDT = UTC - 5 hours
-      {First,  Sun, Nov, 2, -360}  //CST = UTC - 6 hours
-    },
-    /* TZ_US_MOUNTAIN */ {
-      {Second, Sun, Mar, 2, -360},  //MDT = UTC - 6 hours
-      {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
-    },
-    /* TZ_US_ARIZONA */ {
-      {First,  Sun, Nov, 2, -420},  //MST = UTC - 7 hours
-      {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
-    },
-    /* TZ_US_PACIFIC */ {
-      {Second, Sun, Mar, 2, -420},  //PDT = UTC - 7 hours
-      {First,  Sun, Nov, 2, -480}  //PST = UTC - 8 hours
-    },
-    /* TZ_CHINA */ {
-      {Last, Sun, Mar, 1, 480},     //CST = UTC + 8 hours
-      {Last, Sun, Mar, 1, 480}
-    },
-    /* TZ_JAPAN */ {
-      {Last, Sun, Mar, 1, 540},     //JST = UTC + 9 hours
-      {Last, Sun, Mar, 1, 540}
-    },
-    /* TZ_AUSTRALIA_EASTERN */ {
-      {First,  Sun, Oct, 2, 660},   //AEDT = UTC + 11 hours
-      {First,  Sun, Apr, 3, 600}   //AEST = UTC + 10 hours
-    },
-    /* TZ_NEW_ZEALAND */ {
-      {Last,   Sun, Sep, 2, 780},   //NZDT = UTC + 13 hours
-      {First,  Sun, Apr, 3, 720}   //NZST = UTC + 12 hours
-    },
-    /* TZ_NORTH_KOREA */ {
-      {Last, Sun, Mar, 1, 510},     //Pyongyang Time = UTC + 8.5 hours
-      {Last, Sun, Mar, 1, 510}
-    },
-    /* TZ_INDIA */ {
-      {Last, Sun, Mar, 1, 330},     //India Standard Time = UTC + 5.5 hours
-      {Last, Sun, Mar, 1, 330}
-    },
-    /* TZ_SASKACHEWAN */ {
-      {First,  Sun, Nov, 2, -360},  //CST = UTC - 6 hours
-      {First,  Sun, Nov, 2, -360}
-    },
-    /* TZ_AUSTRALIA_NORTHERN */ {
-      {First, Sun, Apr, 3, 570},   //ACST = UTC + 9.5 hours
-      {First, Sun, Apr, 3, 570}
-    },
-    /* TZ_AUSTRALIA_SOUTHERN */ {
-      {First, Sun, Oct, 2, 630},   //ACDT = UTC + 10.5 hours
-      {First, Sun, Apr, 3, 570}   //ACST = UTC + 9.5 hours
-    },
-    /* TZ_HAWAII */ {
-      {Last, Sun, Mar, 1, -600},   //HST =  UTC - 10 hours
-      {Last, Sun, Mar, 1, -600}
-    },
-    /* TZ_NOVOSIBIRSK */ {
-      {Last, Sun, Mar, 1, 420},     //CST = UTC + 7 hours
-      {Last, Sun, Mar, 1, 420}
-    },
-    /* TZ_ANCHORAGE */ {
-      {Second, Sun, Mar, 2, -480},  //AKDT = UTC - 8 hours
-      {First, Sun, Nov, 2, -540}   //AKST = UTC - 9 hours
-    },
-     /* TZ_MX_CENTRAL */ {
-      {First, Sun, Apr, 2, -360},  //CST = UTC - 6 hours
-      {First, Sun, Apr, 2, -360}
-    },
-    /* TZ_PAKISTAN */ {
-      {Last, Sun, Mar, 1, 300},     //Pakistan Standard Time = UTC + 5 hours
-      {Last, Sun, Mar, 1, 300}
-    },
-    /* TZ_BRASILIA */ {
-      {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
-      {Last, Sun, Mar, 1, -180}
-    },
-    /* TZ_AUSTRALIA_WESTERN */ {
-      {Last, Sun, Mar, 1, 480},     //AWST = UTC + 8 hours
-      {Last, Sun, Mar, 1, 480}      //AWST = UTC + 8 hours (no DST)
-    }
+static const std::tuple<const char*, TimeChangeRule, TimeChangeRule> TZ_TABLE[] PROGMEM = {
+  /* TZ_UTC */ {
+    "UTC",
+    {Last, Sun, Mar, 1, 0}, // UTC
+    {Last, Sun, Mar, 1, 0}  // Same
+  },
+  /* TZ_UK */ {
+    "GMT/BST",
+    {Last, Sun, Mar, 1, 60},      //British Summer Time
+    {Last, Sun, Oct, 2, 0}       //Standard Time
+  },
+  /* TZ_EUROPE_CENTRAL */ {
+    "CET/CEST",
+    {Last, Sun, Mar, 2, 120},     //Central European Summer Time
+    {Last, Sun, Oct, 3, 60}      //Central European Standard Time
+  },
+  /* TZ_EUROPE_EASTERN */ {
+    "EET/EEST",
+    {Last, Sun, Mar, 3, 180},     //East European Summer Time
+    {Last, Sun, Oct, 4, 120}     //East European Standard Time
+  },
+  /* TZ_US_EASTERN */ {
+    "US-EST/EDT",
+    {Second, Sun, Mar, 2, -240},  //EDT = UTC - 4 hours
+    {First,  Sun, Nov, 2, -300}  //EST = UTC - 5 hours
+  },
+  /* TZ_US_CENTRAL */ {
+    "US-CST/CDT",
+    {Second, Sun, Mar, 2, -300},  //CDT = UTC - 5 hours
+    {First,  Sun, Nov, 2, -360}  //CST = UTC - 6 hours
+  },
+  /* TZ_US_MOUNTAIN */ {
+    "US-MST/MDT",
+    {Second, Sun, Mar, 2, -360},  //MDT = UTC - 6 hours
+    {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
+  },
+  /* TZ_US_ARIZONA */ {
+    "US-AZ",
+    {First,  Sun, Nov, 2, -420},  //MST = UTC - 7 hours
+    {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
+  },
+  /* TZ_US_PACIFIC */ {
+    "US-PST/PDT",
+    {Second, Sun, Mar, 2, -420},  //PDT = UTC - 7 hours
+    {First,  Sun, Nov, 2, -480}  //PST = UTC - 8 hours
+  },
+  /* TZ_CHINA */ {
+    "CST (AWST, PHST)",
+    {Last, Sun, Mar, 1, 480},     //CST = UTC + 8 hours
+    {Last, Sun, Mar, 1, 480}
+  },
+  /* TZ_JAPAN */ {
+    "JST (KST)",
+    {Last, Sun, Mar, 1, 540},     //JST = UTC + 9 hours
+    {Last, Sun, Mar, 1, 540}
+  },
+  /* TZ_AUSTRALIA_EASTERN */ {
+    "AEST/AEDT",
+    {First,  Sun, Oct, 2, 660},   //AEDT = UTC + 11 hours
+    {First,  Sun, Apr, 3, 600}   //AEST = UTC + 10 hours
+  },
+  /* TZ_NEW_ZEALAND */ {
+    "NZST/NZDT",
+    {Last,   Sun, Sep, 2, 780},   //NZDT = UTC + 13 hours
+    {First,  Sun, Apr, 3, 720}   //NZST = UTC + 12 hours
+  },
+  /* TZ_NORTH_KOREA */ {
+    "North Korea",
+    {Last, Sun, Mar, 1, 510},     //Pyongyang Time = UTC + 8.5 hours
+    {Last, Sun, Mar, 1, 510}
+  },
+  /* TZ_INDIA */ {
+    "IST (India)",
+    {Last, Sun, Mar, 1, 330},     //India Standard Time = UTC + 5.5 hours
+    {Last, Sun, Mar, 1, 330}
+  },
+  /* TZ_SASKACHEWAN */ {
+    "CA-Saskatchewan",
+    {First,  Sun, Nov, 2, -360},  //CST = UTC - 6 hours
+    {First,  Sun, Nov, 2, -360}
+  },
+  /* TZ_AUSTRALIA_NORTHERN */ {
+    "ACST",
+    {First, Sun, Apr, 3, 570},   //ACST = UTC + 9.5 hours
+    {First, Sun, Apr, 3, 570}
+  },
+  /* TZ_AUSTRALIA_SOUTHERN */ {
+    "ACST/ACDT",
+    {First, Sun, Oct, 2, 630},   //ACDT = UTC + 10.5 hours
+    {First, Sun, Apr, 3, 570}   //ACST = UTC + 9.5 hours
+  },
+  /* TZ_HAWAII */ {
+    "HST (Hawaii)",
+    {Last, Sun, Mar, 1, -600},   //HST =  UTC - 10 hours
+    {Last, Sun, Mar, 1, -600}
+  },
+  /* TZ_NOVOSIBIRSK */ {
+    "NOVT (Novosibirsk)",
+    {Last, Sun, Mar, 1, 420},     //CST = UTC + 7 hours
+    {Last, Sun, Mar, 1, 420}
+  },
+  /* TZ_ANCHORAGE */ {
+    "AKST/AKDT (Anchorage)",
+    {Second, Sun, Mar, 2, -480},  //AKDT = UTC - 8 hours
+    {First, Sun, Nov, 2, -540}   //AKST = UTC - 9 hours
+  },
+    /* TZ_MX_CENTRAL */ {
+    "MX-CST",
+    {First, Sun, Apr, 2, -360},  //CST = UTC - 6 hours
+    {First, Sun, Apr, 2, -360}
+  },
+  /* TZ_PAKISTAN */ {
+    "PKT (Pakistan)",
+    {Last, Sun, Mar, 1, 300},     //Pakistan Standard Time = UTC + 5 hours
+    {Last, Sun, Mar, 1, 300}
+  },
+  /* TZ_BRASILIA */ {
+    "BRT (Brasília)",
+    {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
+    {Last, Sun, Mar, 1, -180}
+  },
+  /* TZ_AUSTRALIA_WESTERN */ {
+    "AWST (Perth)",
+    {Last, Sun, Mar, 1, 480},     //AWST = UTC + 8 hours
+    {Last, Sun, Mar, 1, 480}      //AWST = UTC + 8 hours (no DST)
+  }
 };
+
 
 void updateTimezone() {
   delete tz;
   TimeChangeRule tcrDaylight, tcrStandard;
   auto tz_table_entry = currentTimezone;
-  if (tz_table_entry >= TZ_COUNT) {
+  if (tz_table_entry >= countof(TZ_TABLE)) {
     tz_table_entry = 0;
   }
   tzCurrent = currentTimezone;
-  memcpy_P(&tcrDaylight, &TZ_TABLE[tz_table_entry].first, sizeof(tcrDaylight));
-  memcpy_P(&tcrStandard, &TZ_TABLE[tz_table_entry].second, sizeof(tcrStandard));
+  memcpy_P(&tcrDaylight, &std::get<1>(TZ_TABLE[tz_table_entry]), sizeof(tcrDaylight));
+  memcpy_P(&tcrStandard, &std::get<2>(TZ_TABLE[tz_table_entry]), sizeof(tcrStandard));
 
   tz = new Timezone(tcrDaylight, tcrStandard);
+}
+
+String getTZNamesJSONString() {
+  String names = "[";
+  for (size_t i = 0; i < countof(TZ_TABLE); i++) {
+    names += '"';
+    names += FPSTR(std::get<0>(TZ_TABLE[i]));
+    names += '"';
+    names += ',';
+  }
+  names.setCharAt(names.length()-1, ']'); // replace last comma with bracket
+  return names;
 }
 
 void handleTime() {

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -16,130 +16,156 @@ Timezone* tz;
 #define TZ_INIT 255
 byte tzCurrent = TZ_INIT; //uninitialized
 
-/* C++11 form -- static std::array<std::pair<TimeChangeRule, TimeChangeRule>, TZ_COUNT> TZ_TABLE PROGMEM = {{ */
-static const std::tuple<const char*, TimeChangeRule, TimeChangeRule> TZ_TABLE[] PROGMEM = {
-  /* TZ_UTC */ {
-    "UTC",
+// workaround to put all strings into PROGMEM
+static const char _utc[]    PROGMEM = "UTC";
+static const char _gmt[]    PROGMEM = "GMT/BST";
+static const char _cet[]    PROGMEM = "CET/CEST";
+static const char _eet[]    PROGMEM = "EET/EEST";
+static const char _us_est[] PROGMEM = "US-EST/EDT";
+static const char _us_cst[] PROGMEM = "US-CST/CDT";
+static const char _us_mst[] PROGMEM = "US-MST/MDT";
+static const char _us_az[]  PROGMEM = "US-AZ";
+static const char _us_pst[] PROGMEM = "US-PST/PDT";
+static const char _cst[]    PROGMEM = "CST (AWST, PHST)";
+static const char _jst[]    PROGMEM = "JST (KST)";
+static const char _aest[]   PROGMEM = "AEST/AEDT";
+static const char _nzst[]   PROGMEM = "NZST/NZDT";
+static const char _nkst[]   PROGMEM = "North Korea";
+static const char _ist[]    PROGMEM = "IST (India)";
+static const char _ca_sk[]  PROGMEM = "CA-Saskatchewan";
+static const char _acst[]   PROGMEM = "ACST";
+static const char _acst2[]  PROGMEM = "ACST/ACDT";
+static const char _hst[]    PROGMEM = "HST (Hawaii)";
+static const char _novt[]   PROGMEM = "NOVT (Novosibirsk)";
+static const char _akst[]   PROGMEM = "AKST/AKDT (Anchorage)";
+static const char _mxcst[]  PROGMEM = "MX-CST";
+static const char _pkt[]    PROGMEM = "PKT (Pakistan)";
+static const char _brt[]    PROGMEM = "BRT (Brasília)";
+static const char _awst[]   PROGMEM = "AWST (Perth)";
+
+static const std::tuple<const char*, const TimeChangeRule, const TimeChangeRule> TZ_TABLE[] PROGMEM = {
+  {
+    _utc,
     {Last, Sun, Mar, 1, 0}, // UTC
     {Last, Sun, Mar, 1, 0}  // Same
   },
-  /* TZ_UK */ {
-    "GMT/BST",
+  {
+    _gmt,
     {Last, Sun, Mar, 1, 60},      //British Summer Time
     {Last, Sun, Oct, 2, 0}       //Standard Time
   },
-  /* TZ_EUROPE_CENTRAL */ {
-    "CET/CEST",
+  {
+    _cet,
     {Last, Sun, Mar, 2, 120},     //Central European Summer Time
     {Last, Sun, Oct, 3, 60}      //Central European Standard Time
   },
-  /* TZ_EUROPE_EASTERN */ {
-    "EET/EEST",
+  {
+    _eet,
     {Last, Sun, Mar, 3, 180},     //East European Summer Time
     {Last, Sun, Oct, 4, 120}     //East European Standard Time
   },
-  /* TZ_US_EASTERN */ {
-    "US-EST/EDT",
+  {
+    _us_est,
     {Second, Sun, Mar, 2, -240},  //EDT = UTC - 4 hours
     {First,  Sun, Nov, 2, -300}  //EST = UTC - 5 hours
   },
-  /* TZ_US_CENTRAL */ {
-    "US-CST/CDT",
+  {
+    _us_cst,
     {Second, Sun, Mar, 2, -300},  //CDT = UTC - 5 hours
     {First,  Sun, Nov, 2, -360}  //CST = UTC - 6 hours
   },
-  /* TZ_US_MOUNTAIN */ {
-    "US-MST/MDT",
+  {
+    _us_mst,
     {Second, Sun, Mar, 2, -360},  //MDT = UTC - 6 hours
     {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
   },
-  /* TZ_US_ARIZONA */ {
-    "US-AZ",
+  {
+    _us_az,
     {First,  Sun, Nov, 2, -420},  //MST = UTC - 7 hours
     {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
   },
-  /* TZ_US_PACIFIC */ {
-    "US-PST/PDT",
+  {
+    _us_pst,
     {Second, Sun, Mar, 2, -420},  //PDT = UTC - 7 hours
     {First,  Sun, Nov, 2, -480}  //PST = UTC - 8 hours
   },
-  /* TZ_CHINA */ {
-    "CST (AWST, PHST)",
+  {
+    _cst,
     {Last, Sun, Mar, 1, 480},     //CST = UTC + 8 hours
     {Last, Sun, Mar, 1, 480}
   },
-  /* TZ_JAPAN */ {
-    "JST (KST)",
+  {
+    _jst,
     {Last, Sun, Mar, 1, 540},     //JST = UTC + 9 hours
     {Last, Sun, Mar, 1, 540}
   },
-  /* TZ_AUSTRALIA_EASTERN */ {
-    "AEST/AEDT",
+  {
+    _aest,
     {First,  Sun, Oct, 2, 660},   //AEDT = UTC + 11 hours
     {First,  Sun, Apr, 3, 600}   //AEST = UTC + 10 hours
   },
-  /* TZ_NEW_ZEALAND */ {
-    "NZST/NZDT",
+  {
+    _nzst,
     {Last,   Sun, Sep, 2, 780},   //NZDT = UTC + 13 hours
     {First,  Sun, Apr, 3, 720}   //NZST = UTC + 12 hours
   },
-  /* TZ_NORTH_KOREA */ {
-    "North Korea",
+  {
+    _nkst,
     {Last, Sun, Mar, 1, 510},     //Pyongyang Time = UTC + 8.5 hours
     {Last, Sun, Mar, 1, 510}
   },
-  /* TZ_INDIA */ {
-    "IST (India)",
+  {
+    _ist,
     {Last, Sun, Mar, 1, 330},     //India Standard Time = UTC + 5.5 hours
     {Last, Sun, Mar, 1, 330}
   },
-  /* TZ_SASKACHEWAN */ {
-    "CA-Saskatchewan",
+  {
+    _ca_sk,
     {First,  Sun, Nov, 2, -360},  //CST = UTC - 6 hours
     {First,  Sun, Nov, 2, -360}
   },
-  /* TZ_AUSTRALIA_NORTHERN */ {
-    "ACST",
+  {
+    _acst,
     {First, Sun, Apr, 3, 570},   //ACST = UTC + 9.5 hours
     {First, Sun, Apr, 3, 570}
   },
-  /* TZ_AUSTRALIA_SOUTHERN */ {
-    "ACST/ACDT",
+  {
+    _acst2,
     {First, Sun, Oct, 2, 630},   //ACDT = UTC + 10.5 hours
     {First, Sun, Apr, 3, 570}   //ACST = UTC + 9.5 hours
   },
-  /* TZ_HAWAII */ {
-    "HST (Hawaii)",
+  {
+    _hst,
     {Last, Sun, Mar, 1, -600},   //HST =  UTC - 10 hours
     {Last, Sun, Mar, 1, -600}
   },
-  /* TZ_NOVOSIBIRSK */ {
-    "NOVT (Novosibirsk)",
+  {
+    _novt,
     {Last, Sun, Mar, 1, 420},     //CST = UTC + 7 hours
     {Last, Sun, Mar, 1, 420}
   },
-  /* TZ_ANCHORAGE */ {
-    "AKST/AKDT (Anchorage)",
+  {
+    _akst,
     {Second, Sun, Mar, 2, -480},  //AKDT = UTC - 8 hours
     {First, Sun, Nov, 2, -540}   //AKST = UTC - 9 hours
   },
-    /* TZ_MX_CENTRAL */ {
-    "MX-CST",
+  {
+    _mxcst,
     {First, Sun, Apr, 2, -360},  //CST = UTC - 6 hours
     {First, Sun, Apr, 2, -360}
   },
-  /* TZ_PAKISTAN */ {
-    "PKT (Pakistan)",
+  {
+    _pkt,
     {Last, Sun, Mar, 1, 300},     //Pakistan Standard Time = UTC + 5 hours
     {Last, Sun, Mar, 1, 300}
   },
-  /* TZ_BRASILIA */ {
-    "BRT (Brasília)",
+  {
+    _brt,
     {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
     {Last, Sun, Mar, 1, -180}
   },
-  /* TZ_AUSTRALIA_WESTERN */ {
-    "AWST (Perth)",
+  {
+    _awst,
     {Last, Sun, Mar, 1, 480},     //AWST = UTC + 8 hours
     {Last, Sun, Mar, 1, 480}      //AWST = UTC + 8 hours (no DST)
   }
@@ -163,6 +189,7 @@ void updateTimezone() {
 String getTZNamesJSONString() {
   String names = "[";
   for (size_t i = 0; i < countof(TZ_TABLE); i++) {
+    // the following is shorter code than sprintf()
     names += '"';
     names += FPSTR(std::get<0>(TZ_TABLE[i]));
     names += '"';

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -232,7 +232,7 @@ bool jsonTimezone(TimeChangeRule &dst, TimeChangeRule &std) {
         dst.offset = o["dst"]["off"] | 0;
 
         if (o["std"]["w"].is<const char*>())
-          for (int i=0; i<4; i++) {
+          for (int i=0; i<5; i++) {
             if (strncmp(weekShortStr(i), o["std"]["w"].as<const char*>(), 3) == 0) {
               std.week = i;
               break;

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -45,128 +45,129 @@ static const char _awst[]   PROGMEM = "AWST (Perth)";
 
 // WARNING: Changing the order of entries in this table will change the meaning of stored timezone indices in settings!
 // Add new timezones only at the end of the list to preserve compatibility!
-static const std::tuple<const char*, const TimeChangeRule, const TimeChangeRule> TZ_TABLE[] PROGMEM = {
-  {
+using tz_data = std::tuple<const char*, const TimeChangeRule, const TimeChangeRule>;
+static const tz_data TZ_TABLE[] PROGMEM = {
+  tz_data{
     _utc,
     {Last, Sun, Mar, 1, 0}, // UTC
     {Last, Sun, Mar, 1, 0}  // Same
   },
-  {
+  tz_data{
     _gmt,
     {Last, Sun, Mar, 1, 60},      //British Summer Time
     {Last, Sun, Oct, 2, 0}       //Standard Time
   },
-  {
+  tz_data{
     _cet,
     {Last, Sun, Mar, 2, 120},     //Central European Summer Time
     {Last, Sun, Oct, 3, 60}      //Central European Standard Time
   },
-  {
+  tz_data{
     _eet,
     {Last, Sun, Mar, 3, 180},     //East European Summer Time
     {Last, Sun, Oct, 4, 120}     //East European Standard Time
   },
-  {
+  tz_data{
     _us_est,
     {Second, Sun, Mar, 2, -240},  //EDT = UTC - 4 hours
     {First,  Sun, Nov, 2, -300}  //EST = UTC - 5 hours
   },
-  {
+  tz_data{
     _us_cst,
     {Second, Sun, Mar, 2, -300},  //CDT = UTC - 5 hours
     {First,  Sun, Nov, 2, -360}  //CST = UTC - 6 hours
   },
-  {
+  tz_data{
     _us_mst,
     {Second, Sun, Mar, 2, -360},  //MDT = UTC - 6 hours
     {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
   },
-  {
+  tz_data{
     _us_az,
     {First,  Sun, Nov, 2, -420},  //MST = UTC - 7 hours
     {First,  Sun, Nov, 2, -420}  //MST = UTC - 7 hours
   },
-  {
+  tz_data{
     _us_pst,
     {Second, Sun, Mar, 2, -420},  //PDT = UTC - 7 hours
     {First,  Sun, Nov, 2, -480}  //PST = UTC - 8 hours
   },
-  {
+  tz_data{
     _cst,
     {Last, Sun, Mar, 1, 480},     //CST = UTC + 8 hours
     {Last, Sun, Mar, 1, 480}
   },
-  {
+  tz_data{
     _jst,
     {Last, Sun, Mar, 1, 540},     //JST = UTC + 9 hours
     {Last, Sun, Mar, 1, 540}
   },
-  {
+  tz_data{
     _aest,
     {First,  Sun, Oct, 2, 660},   //AEDT = UTC + 11 hours
     {First,  Sun, Apr, 3, 600}   //AEST = UTC + 10 hours
   },
-  {
+  tz_data{
     _nzst,
     {Last,   Sun, Sep, 2, 780},   //NZDT = UTC + 13 hours
     {First,  Sun, Apr, 3, 720}   //NZST = UTC + 12 hours
   },
-  {
+  tz_data{
     _nkst,
     {Last, Sun, Mar, 1, 510},     //Pyongyang Time = UTC + 8.5 hours
     {Last, Sun, Mar, 1, 510}
   },
-  {
+  tz_data{
     _ist,
     {Last, Sun, Mar, 1, 330},     //India Standard Time = UTC + 5.5 hours
     {Last, Sun, Mar, 1, 330}
   },
-  {
+  tz_data{
     _ca_sk,
     {First,  Sun, Nov, 2, -360},  //CST = UTC - 6 hours
     {First,  Sun, Nov, 2, -360}
   },
-  {
+  tz_data{
     _acst,
     {First, Sun, Apr, 3, 570},   //ACST = UTC + 9.5 hours
     {First, Sun, Apr, 3, 570}
   },
-  {
+  tz_data{
     _acst2,
     {First, Sun, Oct, 2, 630},   //ACDT = UTC + 10.5 hours
     {First, Sun, Apr, 3, 570}   //ACST = UTC + 9.5 hours
   },
-  {
+  tz_data{
     _hst,
     {Last, Sun, Mar, 1, -600},   //HST =  UTC - 10 hours
     {Last, Sun, Mar, 1, -600}
   },
-  {
+  tz_data{
     _novt,
     {Last, Sun, Mar, 1, 420},     //CST = UTC + 7 hours
     {Last, Sun, Mar, 1, 420}
   },
-  {
+  tz_data{
     _akst,
     {Second, Sun, Mar, 2, -480},  //AKDT = UTC - 8 hours
     {First, Sun, Nov, 2, -540}   //AKST = UTC - 9 hours
   },
-  {
+  tz_data{
     _mxcst,
     {First, Sun, Apr, 2, -360},  //CST = UTC - 6 hours
     {First, Sun, Apr, 2, -360}
   },
-  {
+  tz_data{
     _pkt,
     {Last, Sun, Mar, 1, 300},     //Pakistan Standard Time = UTC + 5 hours
     {Last, Sun, Mar, 1, 300}
   },
-  {
+  tz_data{
     _brt,
     {Last, Sun, Mar, 1, -180},    //Brasília Standard Time = UTC - 3 hours
     {Last, Sun, Mar, 1, -180}
   },
-  {
+  tz_data{
     _awst,
     {Last, Sun, Mar, 1, 480},     //AWST = UTC + 8 hours
     {Last, Sun, Mar, 1, 480}      //AWST = UTC + 8 hours (no DST)

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -239,7 +239,7 @@ bool jsonTimezone(TimeChangeRule &dst, TimeChangeRule &std) {
             }
           }
         else std.week = o["std"]["w"] | 0;
-        if (o["dst"]["dow"].is<const char*>())
+        if (o["std"]["dow"].is<const char*>())
           for (int i=0; i<7; i++) {
             if (strncmp(dayShortStr(i+1), o["std"]["dow"].as<const char*>(), 3) == 0) {
               std.dow = i+1;

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -188,6 +188,7 @@ void updateTimezone() {
 
 String getTZNamesJSONString() {
   String names = "[";
+  name.reserve(512);
   for (size_t i = 0; i < countof(TZ_TABLE); i++) {
     // the following is shorter code than sprintf()
     names += '"';
@@ -273,7 +274,7 @@ static bool isValidNtpResponse(const byte* ntpPacket) {
   // if((ntpPacket[0] & 0b00111000) >> 3 < 0b100) return false; //reject Version < 4
   if((ntpPacket[0] & 0b00000111) != 0b100)      return false; //reject Mode != Server
   if((ntpPacket[1] < 1) || (ntpPacket[1] > 15)) return false; //reject invalid Stratum
-  if( ntpPacket[16] == 0 && ntpPacket[17] == 0 && 
+  if( ntpPacket[16] == 0 && ntpPacket[17] == 0 &&
       ntpPacket[18] == 0 && ntpPacket[19] == 0 &&
       ntpPacket[20] == 0 && ntpPacket[21] == 0 &&
       ntpPacket[22] == 0 && ntpPacket[23] == 0)               //reject ReferenceTimestamp == 0
@@ -520,7 +521,7 @@ static int getSunriseUTC(int year, int month, int day, float lat, float lon, boo
 	return UT*60;
 }
 
-#define SUNSET_MAX (24*60) // 1day = max expected absolute value for sun offset in minutes 
+#define SUNSET_MAX (24*60) // 1day = max expected absolute value for sun offset in minutes
 // calculate sunrise and sunset (if longitude and latitude are set)
 void calculateSunriseAndSunset() {
   if ((int)(longitude*10.) || (int)(latitude*10.)) {

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -188,7 +188,7 @@ void updateTimezone() {
 
 String getTZNamesJSONString() {
   String names = "[";
-  name.reserve(512);
+  names.reserve(512);
   for (size_t i = 0; i < countof(TZ_TABLE); i++) {
     // the following is shorter code than sprintf()
     names += '"';

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -43,6 +43,8 @@ static const char _pkt[]    PROGMEM = "PKT (Pakistan)";
 static const char _brt[]    PROGMEM = "BRT (Brasília)";
 static const char _awst[]   PROGMEM = "AWST (Perth)";
 
+// WARNING: Changing the order of entries in this table will change the meaning of stored timezone indices in settings!
+// Add new timezones only at the end of the list to preserve compatibility!
 static const std::tuple<const char*, const TimeChangeRule, const TimeChangeRule> TZ_TABLE[] PROGMEM = {
   {
     _utc,
@@ -179,7 +181,7 @@ void updateTimezone() {
   if (tz_table_entry >= countof(TZ_TABLE)) {
     tz_table_entry = 0;
   }
-  tzCurrent = currentTimezone;
+  tzCurrent = currentTimezone = tz_table_entry;
   memcpy_P(&tcrDaylight, &std::get<1>(TZ_TABLE[tz_table_entry]), sizeof(tcrDaylight));
   memcpy_P(&tcrStandard, &std::get<2>(TZ_TABLE[tz_table_entry]), sizeof(tcrStandard));
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -270,6 +270,10 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
 
 #define STRINGIFY(X) #X
 #define TOSTRING(X) STRINGIFY(X)
+#ifdef countof
+  #undef countof
+#endif
+#define countof(x) (sizeof(x)/sizeof(x[0]))
 
 #define WLED_CODENAME "Niji"
 

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -544,7 +544,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 
   if (subPage == SUBPAGE_TIME)
   {
-    settingsScript.printf_P(PSTR("zones=%s;"), getTZNamesJSONString().c_str());
+    settingsScript.printf_P(PSTR("zones=%s;TZ();"), getTZNamesJSONString().c_str()); // we must fill select box immediately after populating array
     printSetFormCheckbox(settingsScript,PSTR("NT"),ntpEnabled);
     printSetFormValue(settingsScript,PSTR("NS"),ntpServerName);
     printSetFormCheckbox(settingsScript,PSTR("CF"),!useAMPM);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -544,6 +544,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 
   if (subPage == SUBPAGE_TIME)
   {
+    settingsScript.printf_P(PSTR("zones=%s;"), getTZNamesJSONString().c_str());
     printSetFormCheckbox(settingsScript,PSTR("NT"),ntpEnabled);
     printSetFormValue(settingsScript,PSTR("NS"),ntpServerName);
     printSetFormCheckbox(settingsScript,PSTR("CF"),!useAMPM);


### PR DESCRIPTION
Makes adding new timezones simpler by only needing to add new timezone to one array.
I've tried to put strings into PROGMEM but am not sure if that works. Would appreciate @willmmiles to take a look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Time zone definitions centralized on the device and no longer hard-coded in the page.

* **New Features**
  * Time zone names are delivered to the web UI as a structured payload and the Time page now auto-populates the Time Zone selector.
  * Optional support for custom time zones via a JSON file, selectable from the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->