### PR TITLE
Spinning Wheel FX in the user_fx usermod

### DIFF
--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -58,14 +58,25 @@ def check_elf_modules(elf_path: Path, env, module_lib_builders) -> set[str]:
     # nm -l appends a tab-separated "file:lineno" location to each symbol line.
     remaining = {Path(str(b.src_dir)): Path(b.build_dir).name for b in module_lib_builders}
     found = set()
-    for builder in module_lib_builders:
-        # builder.src_dir is the library source directory (used by is_wled_module() too)
-        src_dir = str(builder.src_dir).rstrip("/\\")
-        # Guard against prefix collisions (e.g. /path/to/mod vs /path/to/mod-extra)
-        # by requiring a path separator immediately after the directory name.
-        src_dir_pattern = re.escape(src_dir).replace(r'\\', r'[/\\]')
-        if re.search(src_dir_pattern + r'[/\\]', placed_output):
-            found.add(Path(builder.build_dir).name)
+
+    for line in nm_output.splitlines():
+        if not remaining:
+            break  # all builders matched
+        addr, _, _ = line.partition(' ')
+        if not addr.lstrip('0'):
+            continue  # zero address — skip debug-section marker
+        if '\t' not in line:
+            continue
+        loc = line.rsplit('\t', 1)[1]
+        # Strip trailing :lineno  (e.g. "/path/to/foo.cpp:42" → "/path/to/foo.cpp")
+        src_path = Path(loc.rsplit(':', 1)[0])
+        # Path.is_relative_to() handles OS-specific separators correctly without
+        # any regex, avoiding Windows path escaping issues.
+        for src_dir in list(remaining):
+            if src_path.is_relative_to(src_dir):
+                found.add(remaining.pop(src_dir))
+                break
+
     return found
 
 

--- a/pio-scripts/validate_modules.py
+++ b/pio-scripts/validate_modules.py
@@ -66,7 +66,8 @@ def check_elf_modules(elf_path: Path, env, module_lib_builders) -> set[str]:
         src_dir = str(builder.src_dir).rstrip("/\\")
         # Guard against prefix collisions (e.g. /path/to/mod vs /path/to/mod-extra)
         # by requiring a path separator immediately after the directory name.
-        if re.search(re.escape(src_dir) + r'[/\\]', placed_output):
+        src_dir_pattern = re.escape(src_dir).replace(r'\\', r'[/\\]')
+        if re.search(src_dir_pattern + r'[/\\]', placed_output):
             found.add(Path(builder.build_dir).name)
     return found
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -108,7 +108,7 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
  *  aux1 stores the color scale for performance
  */
 
-uint16_t mode_spinning_wheel(void) {
+static uint16_t mode_spinning_wheel(void) {
   if (SEGLEN < 1) return mode_static();
   
   unsigned strips = SEGMENT.nrOfVStrips();
@@ -166,7 +166,7 @@ uint16_t mode_spinning_wheel(void) {
         needsReset = true;
       } else if (phase == 3 && state[STOP_TIME_IDX] != 0) {
           uint16_t spin_delay = map(SEGMENT.custom3, 0, 31, 2000, 15000);  // delay between spins
-          if (now >= state[STOP_TIME_IDX] + spin_delay)
+          if ((now - state[STOP_TIME_IDX]) >= spin_delay)
             needsReset = true;
       }
 
@@ -204,7 +204,7 @@ uint16_t mode_spinning_wheel(void) {
       // Phase management
       if (phase == 0) {
         // Fast spinning phase
-        if (now >= state[SLOWDOWN_TIME_IDX]) {
+        if ((int32_t)(now - state[SLOWDOWN_TIME_IDX]) >= 0) {
           phase = 1;
           state[PHASE_IDX] = 1;
         }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -303,7 +303,7 @@ static uint16_t mode_spinning_wheel(void) {
       uint8_t hue;
       if (SEGMENT.check2) {
         // Each spinner block gets its own color based on strip number
-        uint16_t numSpinners = max(1, (int)(SEGMENT.nrOfVStrips() / spinnerSize));
+        uint16_t numSpinners = max(1U, (SEGMENT.nrOfVStrips() + spinnerSize - 1) / spinnerSize);
         hue = (255 * (stripNr / spinnerSize)) / numSpinners;
       } else {
         // Color changes with position

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -3,7 +3,7 @@
 // for information how FX metadata strings work see https://kno.wled.ge/interfaces/json-api/#effect-metadata
 
 // paletteBlend: 0 - wrap when moving, 1 - always wrap, 2 - never wrap, 3 - none (undefined)
-#define PALETTE_SOLID_WRAP   (strip.paletteBlend == 1 || strip.paletteBlend == 3)
+#define PALETTE_SOLID_WRAP   (paletteBlend == 1 || paletteBlend == 3)
 
 #define indexToVStrip(index, stripNr) ((index) | (int((stripNr)+1)<<16))
 
@@ -115,6 +115,10 @@ static uint16_t mode_spinning_wheel(void) {
   if (SEGLEN < 1) return mode_static();
   
   unsigned strips = SEGMENT.nrOfVStrips();
+  if (strips == 0) return mode_static();
+
+  const uint16_t vstripLen = SEGLEN / strips;
+
   constexpr unsigned stateVarsPerStrip = 8;
   unsigned dataSize = sizeof(uint32_t) * stateVarsPerStrip;
   if (!SEGENV.allocateData(dataSize * strips)) return mode_static();
@@ -143,7 +147,7 @@ static uint16_t mode_spinning_wheel(void) {
   // Handle random seeding globally (outside the virtual strip)
   if (SEGENV.call == 0) {
     random16_set_seed(hw_random16());
-    SEGENV.aux1 = (255 << 8) / SEGLEN; // Cache the color scaling
+    SEGENV.aux1 = (255 << 8) / vstripLen; // Cache the color scaling
   }
 
   // Check if settings changed (do this once, not per virtual strip)
@@ -175,10 +179,9 @@ static uint16_t mode_spinning_wheel(void) {
       }
     }
   }
-
+ 
   struct virtualStrip {
-    
-    static void runStrip(uint16_t stripNr, uint32_t* state, bool settingsChanged, bool allReadyToRestart) {
+    static void runStrip(uint16_t stripNr, uint32_t* state, bool settingsChanged, bool allReadyToRestart, uint16_t vstripLen) {
 
       uint8_t phase = state[PHASE_IDX];
       uint32_t now = strip.now;
@@ -257,7 +260,7 @@ static uint16_t mode_spinning_wheel(void) {
           phase = 2;
           state[PHASE_IDX] = 2;
           state[WOBBLE_STEP_IDX] = 0;
-          uint16_t stop_pos = (pos_fixed >> 16) % SEGLEN;
+          uint16_t stop_pos = (pos_fixed >> 16) % vstripLen;
           state[STOP_POS_IDX] = stop_pos;
           state[WOBBLE_TIME_IDX] = now;
         }
@@ -269,7 +272,7 @@ static uint16_t mode_spinning_wheel(void) {
         
         if (wobble_step == 0 && elapsed >= 200) {
           // Move back one LED from stop position
-          uint16_t back_pos = (stop_pos == 0) ? SEGLEN - 1 : stop_pos - 1;
+          uint16_t back_pos = (stop_pos == 0) ? vstripLen - 1 : stop_pos - 1;
           pos_fixed = ((uint32_t)back_pos) << 16;
           state[CUR_POS_IDX] = pos_fixed;
           state[WOBBLE_STEP_IDX] = 1;
@@ -295,7 +298,7 @@ static uint16_t mode_spinning_wheel(void) {
       }
       
       // Draw LED for all phases
-      uint16_t pos = (pos_fixed >> 16) % SEGLEN;
+      uint16_t pos = (pos_fixed >> 16) % vstripLen;
 
       uint8_t spinnerSize = map(SEGMENT.custom1, 0, 255, 1, 10);
 
@@ -315,7 +318,7 @@ static uint16_t mode_spinning_wheel(void) {
       // Draw the spinner with configurable size (1-10 LEDs)
       for (int8_t x = 0; x < spinnerSize; x++) {
         for (uint8_t y = 0; y < spinnerSize; y++) {
-          uint16_t drawPos = (pos + y) % SEGLEN;
+          uint16_t drawPos = (pos + y) % vstripLen;
           int16_t drawStrip = stripNr + x;
           
           // Wrap horizontally if needed, or skip if out of bounds
@@ -331,7 +334,7 @@ static uint16_t mode_spinning_wheel(void) {
     // Only run on strips that are multiples of spinnerSize to avoid overlap
     uint8_t spinnerSize = map(SEGMENT.custom1, 0, 255, 1, 10);
     if (stripNr % spinnerSize == 0) {
-      virtualStrip::runStrip(stripNr, &state[stripNr * stateVarsPerStrip], settingsChanged, allReadyToRestart);
+      virtualStrip::runStrip(stripNr, &state[stripNr * stateVarsPerStrip], settingsChanged, allReadyToRestart, vstripLen);
     }
   }
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -115,7 +115,7 @@ static uint16_t mode_spinning_wheel(void) {
   if (SEGLEN < 1) return mode_static();
   
   unsigned strips = SEGMENT.nrOfVStrips();
-  const unsigned stateVarsPerStrip = 8;
+  constexpr unsigned stateVarsPerStrip = 8;
   unsigned dataSize = sizeof(uint32_t) * stateVarsPerStrip;
   if (!SEGENV.allocateData(dataSize * strips)) return mode_static();
   uint32_t* state = reinterpret_cast<uint32_t*>(SEGENV.data);
@@ -142,7 +142,7 @@ static uint16_t mode_spinning_wheel(void) {
 
   // Handle random seeding globally (outside the virtual strip)
   if (SEGENV.call == 0) {
-    random16_set_seed(analogRead(0));
+    random16_set_seed(hw_random16());
     SEGENV.aux1 = (255 << 8) / SEGLEN; // Cache the color scaling
   }
 
@@ -150,7 +150,7 @@ static uint16_t mode_spinning_wheel(void) {
   uint32_t settingssum = SEGMENT.speed + SEGMENT.intensity + SEGMENT.custom1 + SEGMENT.custom3 + SEGMENT.check3;
   bool settingsChanged = (SEGENV.aux0 != settingssum);
   if (settingsChanged) {
-    random16_add_entropy(analogRead(0));
+    random16_add_entropy(hw_random16());
     SEGENV.aux0 = settingssum;
   }
 

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -140,7 +140,7 @@ static uint16_t mode_spinning_wheel(void) {
   // Handle random seeding globally (outside the virtual strip)
   if (SEGENV.call == 0) {
     random16_set_seed(analogRead(0));
-    SEGENV.aux1 = (255 << 16) / SEGLEN; // Cache the color scaling
+    SEGENV.aux1 = (255 << 8) / SEGLEN; // Cache the color scaling
   }
 
   // Check if settings changed (do this once, not per virtual strip)
@@ -176,7 +176,7 @@ static uint16_t mode_spinning_wheel(void) {
         
         // Set velocity
         if (SEGMENT.check2) {  // random speed
-          state[VELOCITY_IDX] = random16(200, 900) * 655;
+          state[VELOCITY_IDX] = random16(200, 900) * 655;   // fixed-point velocity scaling (approx. 65536/100) 
         } else {
           uint16_t speed = map(SEGMENT.speed, 0, 255, 300, 800);
           state[VELOCITY_IDX] = random16(speed - 100, speed + 100) * 655;
@@ -262,7 +262,7 @@ static uint16_t mode_spinning_wheel(void) {
       
       // Draw LED for all phases using indexToVStrip
       uint16_t pos = (pos_fixed >> 16) % SEGLEN;
-      uint8_t hue = (SEGENV.aux1 * pos) >> 16; // Use cached color scaling
+      uint8_t hue = (SEGENV.aux1 * pos) >> 8; // Use cached color scaling
       uint32_t color = SEGMENT.check1 ? SEGMENT.color_wheel(hue) : SEGMENT.color_from_palette(hue, true, PALETTE_SOLID_WRAP, 0);
       SEGMENT.setPixelColor(indexToVStrip(pos, stripNr), color);
     }

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -99,20 +99,19 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
 
 
 /*
-/ Spinning Wheel effect - LED animates around 1D strip (or each column in a 2D matrix), slows down and stops at random position
-*  Created by Bob Loeffler and claude.ai
-*  First slider (Spin speed) is for the speed of the moving/spinning LED (random number within a narrow speed range).
-*     If value is 0, a random speed will be selected from the full range of values.
-*  Second slider (Spin slowdown start time) is for how long before the slowdown phase starts (random number within a narrow time range).
-*     If value is 0, a random time will be selected from the full range of values.
-*  Third slider (Spinner size) is for the number of pixels that make up the spinner.
-*  Fourth slider (Spin delay) is for how long it takes for the LED to start spinning again after the previous spin.
-*  The first checkbox sets the color mode (color wheel or palette).
-*  The second checkbox sets "color per block" mode. Enabled means that each spinner block will be the same color no matter what its LED position is.
-*  The third checkbox enables synchronized restart (all spinners restart together instead of individually).
-*  aux0 stores the settings checksum to detect changes
-*  aux1 stores the color scale for performance
-*/
+ * Spinning Wheel effect - LED animates around 1D strip (or each column in a 2D matrix), slows down and stops at random position
+ *  Created by Bob Loeffler and claude.ai
+ *  First slider (Spin speed) is for the speed of the moving/spinning LED (random number within a narrow speed range).
+ *     If value is 0, a random speed will be selected from the full range of values.
+ *  Second slider (Spin slowdown start time) is for how long before the slowdown phase starts (random number within a narrow time range).
+ *     If value is 0, a random time will be selected from the full range of values.
+ *  Third slider (Spinner size) is for the number of pixels that make up the spinner.
+ *  Fourth slider (Spin delay) is for how long it takes for the LED to start spinning again after the previous spin.
+ *  The first checkbox sets "color per block" mode. Enabled means that each spinner block will be the same color no matter what its LED position is.
+ *  The second checkbox enables synchronized restart (all spinners restart together instead of individually).
+ *  aux0 stores the settings checksum to detect changes
+ *  aux1 stores the color scale for performance
+ */
 
 static void mode_spinning_wheel(void) {
   if (SEGLEN < 1) FX_FALLBACK_STATIC;
@@ -182,8 +181,7 @@ static void mode_spinning_wheel(void) {
   }
  
   struct virtualStrip {
-    static void runStrip(uint16_t stripNr, uint32_t* state, bool settingsChanged, bool allReadyToRestart) {
-
+    static void runStrip(uint16_t stripNr, uint32_t* state, bool settingsChanged, bool allReadyToRestart, unsigned strips) {
       uint8_t phase = state[PHASE_IDX];
       uint32_t now = strip.now;
 
@@ -307,14 +305,14 @@ static void mode_spinning_wheel(void) {
       uint8_t hue;
       if (SEGMENT.check2) {
         // Each spinner block gets its own color based on strip number
-        uint16_t numSpinners = max(1U, (SEGMENT.nrOfVStrips() + spinnerSize - 1) / spinnerSize);
-        hue = (255 * (stripNr / spinnerSize)) / numSpinners;
+        uint16_t numSpinners = max(1U, (strips + spinnerSize - 1) / spinnerSize);
+        hue = (uint32_t)(255) * (stripNr / spinnerSize) / numSpinners;
       } else {
         // Color changes with position
         hue = (SEGENV.aux1 * pos) >> 8;
       }
 
-      uint32_t color = SEGMENT.check1 ? SEGMENT.color_wheel(hue) : SEGMENT.color_from_palette(hue, true, PALETTE_SOLID_WRAP, 0);
+      uint32_t color = ColorFromPaletteWLED(SEGPALETTE, hue, 255, LINEARBLEND);
 
       // Draw the spinner with configurable size (1-10 LEDs)
       for (int8_t x = 0; x < spinnerSize; x++) {
@@ -323,7 +321,7 @@ static void mode_spinning_wheel(void) {
           int16_t drawStrip = stripNr + x;
           
           // Wrap horizontally if needed, or skip if out of bounds
-          if (drawStrip >= 0 && drawStrip < (int16_t)SEGMENT.nrOfVStrips()) {
+          if (drawStrip >= 0 && drawStrip < strips) {
             SEGMENT.setPixelColor(indexToVStrip(drawPos, drawStrip), color);
           }
         }
@@ -331,15 +329,15 @@ static void mode_spinning_wheel(void) {
     }
   };
 
-  for (unsigned stripNr=0; stripNr<strips; stripNr++) {
+  for (unsigned stripNr = 0; stripNr < strips; stripNr++) {
     // Only run on strips that are multiples of spinnerSize to avoid overlap
     uint8_t spinnerSize = map(SEGMENT.custom1, 0, 255, 1, 10);
     if (stripNr % spinnerSize == 0) {
-      virtualStrip::runStrip(stripNr, &state[stripNr * stateVarsPerStrip], settingsChanged, allReadyToRestart);
+      virtualStrip::runStrip(stripNr, &state[stripNr * stateVarsPerStrip], settingsChanged, allReadyToRestart, strips);
     }
   }
 }
-static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,Color mode,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8";
+static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8";
 
 
 /*

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -107,8 +107,10 @@ static const char _data_FX_MODE_DIFFUSIONFIRE[] PROGMEM = "Diffusion Fire@!,Spar
  *     If value is 0, a random time will be selected from the full range of values.
  *  Third slider (Spinner size) is for the number of pixels that make up the spinner.
  *  Fourth slider (Spin delay) is for how long it takes for the LED to start spinning again after the previous spin.
- *  The first checkbox sets "color per block" mode. Enabled means that each spinner block will be the same color no matter what its LED position is.
- *  The second checkbox enables synchronized restart (all spinners restart together instead of individually).
+ *  The first checkbox allows the spinner to spin. If it's enabled, the spinner will do its thing. If it's not enabled, it will wait for the user to enable
+ *     it either by clicking the checkbox or by pressing a physical button (e.g. using a playlist to run a couple presets that have JSON API codes).
+ *  The second checkbox sets "color per block" mode. Enabled means that each spinner block will be the same color no matter what its LED position is.
+ *  The third checkbox enables synchronized restart (all spinners restart together instead of individually).
  *  aux0 stores the settings checksum to detect changes
  *  aux1 stores the color scale for performance
  */
@@ -151,7 +153,7 @@ static void mode_spinning_wheel(void) {
   }
 
   // Check if settings changed (do this once, not per virtual strip)
-  uint32_t settingssum = SEGMENT.speed + SEGMENT.intensity + SEGMENT.custom1 + SEGMENT.custom3 + SEGMENT.check3;
+  uint32_t settingssum = SEGMENT.speed + SEGMENT.intensity + SEGMENT.custom1 + SEGMENT.custom3 + SEGMENT.check1 + SEGMENT.check3;
   bool settingsChanged = (SEGENV.aux0 != settingssum);
   if (settingsChanged) {
     random16_add_entropy(hw_random16());
@@ -189,7 +191,7 @@ static void mode_spinning_wheel(void) {
       bool needsReset = false;
       if (SEGENV.call == 0) {
         needsReset = true;
-      } else if (settingsChanged) {
+      } else if (settingsChanged && SEGMENT.check1) {
         needsReset = true;
       } else if (phase == 3 && state[STOP_TIME_IDX] != 0) {
           // If synchronized restart is enabled, only restart when all strips are ready
@@ -207,7 +209,7 @@ static void mode_spinning_wheel(void) {
       }
 
       // Initialize or restart
-      if (needsReset) {
+      if (needsReset && SEGMENT.check1) {   // spin the spinner(s) only if the "Spin me!" checkbox is enabled
         state[CUR_POS_IDX] = 0;
         
         // Set velocity
@@ -233,7 +235,7 @@ static void mode_spinning_wheel(void) {
         state[STOP_POS_IDX] = 0; // Initialize stop position
         phase = 0;
       }
-      
+
       uint32_t pos_fixed = state[CUR_POS_IDX];
       uint32_t velocity = state[VELOCITY_IDX];
       
@@ -337,7 +339,7 @@ static void mode_spinning_wheel(void) {
     }
   }
 }
-static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8";
+static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,Spin me!,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8,o3=1";
 
 
 /*

--- a/usermods/user_fx/user_fx.cpp
+++ b/usermods/user_fx/user_fx.cpp
@@ -339,7 +339,7 @@ static void mode_spinning_wheel(void) {
     }
   }
 }
-static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,Spin me!,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8,o3=1";
+static const char _data_FX_MODE_SPINNINGWHEEL[] PROGMEM = "Spinning Wheel@Speed (0=random),Slowdown (0=random),Spinner size,,Spin delay,Spin me!,Color per block,Sync restart;!,!;!;;m12=1,c1=1,c3=8,o1=1,o3=1";
 
 
 /*


### PR DESCRIPTION
This PR will add the Spinning Wheel effect into the new user_fx usermod instead of FX.cpp

 *  Spinning Wheel effect by Bob Loeffler 2026
 *    LED animates around a 1D strip, slows down and stops at a random position.  It can also use virtual strips on a 2D matrix.
 *    Created by Bob Loeffler and claude.ai
 *    First slider (Spin speed) is for the speed of the moving/spinning LED (random number within a narrow speed range).  If value is 0, a random speed will be selected from the full range of values.
 *    Second slider (Spin slowdown start time) is for how long before the slowdown phase starts (random number within a narrow time range).  If value is 0, a random time will be selected from the full range of values.
 *    Third slider (Spinner size) is for the number of pixels that make up the spinner.
 *    Fourth slider (Spin delay) is for how long it takes for the LED to start spinning again after the previous spin.
 *    The first checkbox sets the color mode (color wheel or palette).
 *    The second checkbox sets "color per block" mode. Enabled means that each spinner block will be the same color no matter what its LED position is.
 *    The third checkbox enables synchronized restart (all spinners restart together instead of individually).
 *    aux0 stores the settings checksum to detect changes
 *    aux1 stores the color scale for performance

Fun ideas on a 32x32 2D matrix:

 * Kaleidoscope effect
   Effect settings:  Spinner size 1, enable Color Mode checkbox, select Rainbow (or any) palette
   Segment settings: enable X mirror, enable Y mirror, grouping 1, spacing 0, and Expand 1D FX = Bar

 * Slot machine effect
   Effect settings:  Spinner size 4, enable Color Mode checkbox, select Rainbow (or any) palette, enable Color per block checkbox (or not)
   Segment settings: default settings and Expand 1D FX = Bar

 * Wheel of Fortune effect
   Effect settings:  Spinner size 1, enable Color Mode checkbox, select Rainbow (or any) palette
   Segment settings: default settings and Expand 1D FX = Pinwheel

Example videos:

1D strip

https://github.com/user-attachments/assets/65d517e0-ce83-4de2-bb77-cb8f57342fb1

2D kaleidoscope

https://github.com/user-attachments/assets/9b616281-54fc-4177-ad46-739a1fdb8796

2D slot machine

https://github.com/user-attachments/assets/036aef22-1cfd-48d7-b205-204b6a77f034


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "Spinning Wheel" LED effect with multi-phase animation (fast spin, slowdown, wobble, stop).
  * Per-strip independent runs with stored state and optional synchronized restart when settings change.
  * Configurable color modes: continuous color wheel or palette-based colors.
  * Optional randomized spin speed and timing for varied animations.
  * Effect is now available in the FX list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
