### PR TITLE
Apply most recent time-controlled preset on boot

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -712,6 +712,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     }
     it++;
   }
+  CJSON(applyTimerOnBoot, tm["aob"]);
 
   JsonObject ota = doc["ota"];
   const char* pwd = ota["psk"]; //normally not present due to security
@@ -1220,6 +1221,7 @@ void serializeConfig(JsonObject root) {
       end["day"] = timerDayEnd[i];
     }
   }
+  timers["aob"] = applyTimerOnBoot;
 
   JsonObject ota = root.createNestedObject("ota");
   ota[F("lock")] = otaLock;

--- a/wled00/data/settings_time.htm
+++ b/wled00/data/settings_time.htm
@@ -210,6 +210,8 @@
 		</table>
 		<a href="https://kno.wled.ge/features/macros/#analog-button" target="_blank">Analog Button setup</a>
 		<h3>Time-controlled presets</h3>
+		Apply scheduled preset on boot: <input type="checkbox" name="TB"><br>
+		<i style="color:#999">When enabled, if you power on after a scheduled time, that preset will be applied automatically.</i><br><br>
 		<div style="display: inline-block">
 		<table id="TMT" style="min-width:330px;"></table>
 		</div>

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -202,6 +202,7 @@ void setCountdown();
 byte weekdayMondayFirst();
 bool isTodayInDateRange(byte monthStart, byte dayStart, byte monthEnd, byte dayEnd);
 void checkTimers();
+void applyBootTimerPreset();
 void calculateSunriseAndSunset();
 void setTimeFromAPI(uint32_t timein);
 

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -289,10 +289,10 @@ bool checkNTPResponse()
   #endif
 
   if (countdownTime - toki.second() > 0) countdownOverTriggered = false;
-  // if time changed re-calculate sunrise/sunset
+
+  // NTP sync succeeded
   updateLocalTime();
   calculateSunriseAndSunset();
-  // Apply most recent timer preset on first NTP sync after boot
   applyBootTimerPreset();
   return true;
 }

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -461,8 +461,10 @@ void applyBootTimerPreset()
       if (timerMinute < 0) continue;  // would be yesterday, skip
     }
 
-    // Only consider timers that should have already triggered today
-    if (timerMinute <= currentMinuteOfDay && timerMinute > latestTimerMinute) {
+    // Only consider timers that should have already triggered today.
+    // Use >= so that if multiple timers share the same minute, the highest index wins,
+    // matching checkTimers() behavior where all are applied and the last one sticks.
+    if (timerMinute <= currentMinuteOfDay && timerMinute >= latestTimerMinute) {
       latestTimerMinute = timerMinute;
       latestPreset = timerMacro[i];
     }

--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -420,12 +420,12 @@ void checkTimers()
     // re-calculate sunrise and sunset just after midnight
     if (!hour(localTime) && minute(localTime)==1) calculateSunriseAndSunset();
 
-    int currentMinuteOfDay = hour(localTime) * 60 + minute(localTime);
+    int currentMinuteOfDay = elapsedSecsToday(localTime) / 60;
     DEBUG_PRINTF_P(PSTR("Local time: %02d:%02d\n"), hour(localTime), minute(localTime));
 
     for (unsigned i = 0; i < 10; i++)
     {
-      int timerMinute = getTimerMinuteOfDay(i);
+      int timerMinute = getTimerMinuteOfDay(i);  // returns -1 if timer not valid for today
       if (timerMinute == currentMinuteOfDay) {
         applyPreset(timerMacro[i]);
         if (i == 8) DEBUG_PRINTF_P(PSTR("Sunrise macro %d triggered."), timerMacro[8]);
@@ -444,7 +444,7 @@ void applyBootTimerPreset()
   if (bootTimerApplied || !applyTimerOnBoot) return;
   bootTimerApplied = true;
 
-  int currentMinuteOfDay = hour(localTime) * 60 + minute(localTime);
+  int currentMinuteOfDay = elapsedSecsToday(localTime) / 60;
   int latestTimerMinute = -1;
   byte latestPreset = 0;
 
@@ -452,7 +452,7 @@ void applyBootTimerPreset()
 
   for (unsigned i = 0; i < 10; i++)
   {
-    int timerMinute = getTimerMinuteOfDay(i);
+    int timerMinute = getTimerMinuteOfDay(i);  // returns -1 if timer not valid for today
     if (timerMinute < 0) continue;
 
     // For "every hour" timers, find the most recent past occurrence

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -568,6 +568,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
         timerDayEnd[i] = request->arg(k).toInt();
       }
     }
+    applyTimerOnBoot = request->hasArg(F("TB"));
   }
 
   //SECURITY

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -816,7 +816,7 @@ WLED_GLOBAL bool countdownOverTriggered _INIT(true);
 //timer
 WLED_GLOBAL byte lastTimerMinute  _INIT(0);
 WLED_GLOBAL bool bootTimerApplied _INIT(false);  // whether boot-time timer check has been performed
-WLED_GLOBAL bool applyTimerOnBoot _INIT(true);   // apply most recent scheduled timer preset on boot (after NTP sync)
+WLED_GLOBAL bool applyTimerOnBoot _INIT(false);  // apply most recent scheduled timer preset on boot (after NTP sync)
 WLED_GLOBAL byte timerHours[]     _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
 WLED_GLOBAL int8_t timerMinutes[] _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
 WLED_GLOBAL byte timerMacro[]     _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -815,6 +815,8 @@ WLED_GLOBAL bool countdownOverTriggered _INIT(true);
 
 //timer
 WLED_GLOBAL byte lastTimerMinute  _INIT(0);
+WLED_GLOBAL bool bootTimerApplied _INIT(false);  // whether boot-time timer check has been performed
+WLED_GLOBAL bool applyTimerOnBoot _INIT(true);   // apply most recent scheduled timer preset on boot (after NTP sync)
 WLED_GLOBAL byte timerHours[]     _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
 WLED_GLOBAL int8_t timerMinutes[] _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));
 WLED_GLOBAL byte timerMacro[]     _INIT_N(({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }));

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -601,6 +601,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
 				k[0] = 'E'; printSetFormValue(settingsScript,k,timerDayEnd[i]);
       }
     }
+    printSetFormCheckbox(settingsScript,PSTR("TB"),applyTimerOnBoot);
   }
 
   if (subPage == SUBPAGE_SEC)


### PR DESCRIPTION
Adds an option to apply the most recent scheduled preset when the device boots after NTP sync.

Currently, timed presets only trigger at the exact scheduled minute. If you power on at 9pm with an 8pm preset, nothing happens until 8pm the next day. This checks what preset should be active and applies it.

New checkbox in Time & Macros: "Apply scheduled preset on boot" (enabled by default).

Also refactored checkTimers() to share validation logic with the new code.

My use case: WLED bulbs on a wall switch that I wanted to go red after 8pm to reduce melatonin suppression before sleep.

Addresses #2546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Apply scheduled preset on boot" checkbox in Time settings to optionally apply the most recent scheduled preset after a restart (off by default).

* **Improvements**
  * Unified timer evaluation across all timer types; after time sync on boot, the device can detect and apply the most recent missed preset for today (includes hourly and sunrise/sunset presets).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->