### PR TITLE
fix button byte comment

### DIFF
--- a/wled00/remote.cpp
+++ b/wled00/remote.cpp
@@ -27,7 +27,7 @@
 typedef struct WizMoteMessageStructure {
   uint8_t program;  // 0x91 for ON button, 0x81 for all others
   uint8_t seq[4];   // Incremetal sequence number 32 bit unsigned integer LSB first
-  uint8_t dt1;      // Button Data Type (0x32)
+  uint8_t dt1;      // Button Data Type (0x20)
   uint8_t button;   // Identifies which button is being pressed
   uint8_t dt2;      // Battery Level Data Type (0x01)
   uint8_t batLevel; // Battery Level 0-100


### PR DESCRIPTION
I made a mistake in #4114 
Button byte is actually 0x20 and not 0x32

As brought up here: https://github.com/DedeHai/WLED-ESPNow-Remote/issues/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated remote message structure documentation for accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->