### PR TITLE
Reduce flash size of TetrisAI_V2 by 97%

### DIFF
--- a/usermods/TetrisAI_v2/gridbw.h
+++ b/usermods/TetrisAI_v2/gridbw.h
@@ -13,7 +13,6 @@
 #ifndef __GRIDBW_H__
 #define __GRIDBW_H__
 
-#include <iterator>
 #include <vector>
 #include "pieces.h"
 

--- a/usermods/TetrisAI_v2/pieces.h
+++ b/usermods/TetrisAI_v2/pieces.h
@@ -19,7 +19,6 @@
 #include <bitset>
 #include <cstddef>
 #include <cassert>
-#include <iostream>
 
 #define numPieces 7
 

--- a/usermods/TetrisAI_v2/tetrisbag.h
+++ b/usermods/TetrisAI_v2/tetrisbag.h
@@ -15,7 +15,6 @@
 
 #include <stdint.h>
 #include <vector>
-#include <algorithm>
 
 #include "tetrisbag.h"
 
@@ -87,15 +86,10 @@ public:
     void queuePiece()
     {
         //move vector to left
-        std::rotate(piecesQueue.begin(), piecesQueue.begin() + 1, piecesQueue.end());
+        for (uint8_t i = 1; i < piecesQueue.size(); i++) {
+            piecesQueue[i - 1] = piecesQueue[i];
+        }
         piecesQueue[piecesQueue.size() - 1] = getNextPiece();
-    }
-
-    void queuePiece(uint8_t idx)
-    {
-        //move vector to left
-        std::rotate(piecesQueue.begin(), piecesQueue.begin() + 1, piecesQueue.end());
-        piecesQueue[piecesQueue.size() - 1] = Piece(idx % nPieces);
     }
 
     void reset()


### PR DESCRIPTION
Main branch without Tetris
Flash: [========  ]  79.8% (used 1255301 bytes from 1572864 bytes)

Main branch with Tetris (+196kb)
Flash: [========= ]  92.3% (used 1452049 bytes from 1572864 bytes)

This commit with Tetris (+6kb, 97% less flash)
Flash: [========  ]  80.2% (used 1261625 bytes from 1572864 bytes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visualizes recently cleared cells so they briefly render as white for clearer line-clear feedback.
* **Refactor**
  * Simplified piece-queue advancement logic.
  * Removed unused header includes.
  * Streamlined public API by removing an internal queue-enqueue method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->