### PR TITLE
Change default LED pin to 4 in esp32 ethernet builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -511,7 +511,7 @@ upload_speed = 921600
 custom_usermods = audioreactive
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32_Ethernet\" -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
-  -D SR_DMTYPE=-1 ;; force AR to not allocate any PINs at startup
+  -D SR_DMTYPE=-1 -D AUDIOPIN=-1 -D I2S_SDPIN=-1 -D I2S_WSPIN=-1 -D I2S_CKPIN=-1 -D MCLK_PIN=-1 ;; force AR to not allocate any PINs at startup
   -D DATA_PINS=4 ;; default led pin = 16 conflicts with pins used for ethernet
   ; -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only => uncomment if your board uses ETH_CLOCK_GPIO0_OUT, ETH_CLOCK_GPIO16_OUT, ETH_CLOCK_GPIO17_OUT
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -613,7 +613,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #else
   #if defined(WLED_USE_ETHERNET)
     #define DEFAULT_LED_PIN 4    // GPIO4 seems to be a "safe bet" for all known ethernet boards (issue #5155)
-    #warning "Compiling with Ethernet support. The default LED pin has been changed to pin 4."
+    //#warning "Compiling with Ethernet support. The default LED pin has been changed to pin 4."
   #else
     #define DEFAULT_LED_PIN 16   // aligns with GPIO2 (D4) on Wemos D1 mini32 compatible boards (if it is unusable it will be reassigned in WS2812FX::finalizeInit())
   #endif


### PR DESCRIPTION
change default LED pin to 4 in ethernet builds, and set AR default to "no mic" mode.
The "normal" default LED pin 16 is conflicting with pins needed by many ethernet boards, which can cause random crashes.

This should avoid some stability problems reported by ethernet users:

* https://github.com/wled/WLED/issues/5155#issuecomment-3614391561 
* https://github.com/wled/WLED/issues/4703#issuecomment-2963586108 
* https://github.com/wled/WLED/issues/5210 
* https://github.com/wled/WLED/issues/5322 

Ethernet-related ESP-NOW and WIFI AP problems are not addressed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents LED pin conflicts on Ethernet-enabled ESP32 boards by changing the default LED pin when Ethernet is active, improving startup reliability.

* **Chores**
  * Adds build-time options to control pin allocation and data-pin count.
  * Re-enables ESP-NOW by default while preserving a note about its interaction with Ethernet.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->