### PR TITLE
Classic ESP32: GPIO17 is not needed to be reserved for chips with in-package PSRAM

### DIFF
--- a/wled00/pin_manager.cpp
+++ b/wled00/pin_manager.cpp
@@ -246,11 +246,14 @@ bool PinManager::isPinOk(byte gpio, bool output)
       // for classic ESP32 (non-mini) modules, these are the SPI flash pins
       if (gpio > 5 && gpio < 12) return false;      //SPI flash pins
     }
-    if ((strncmp_P(PSTR("ESP32-D0WDR2-V3"), ESP.getChipModel(), 15) == 0) || (strncmp_P(PSTR("ESP32-D0WDRH2-V3"), ESP.getChipModel(), 16) == 0)) {  // allow gpio17 on modules with in-package PSRAM
-        if (gpio == 16) return !psramFound();
-        if (gpio == 17) return true;
-    } else if (gpio == 16 || gpio == 17) return !psramFound(); // PSRAM pins on modules with off-package PSRAM
-    
+    if (gpio == 16) return !psramFound(); // PSRAM pins on modules with off-package or in-package PSRAM
+    if (gpio == 17) {
+      if (strncmp_P(PSTR("ESP32-D0WDR2-V3"), ESP.getChipModel(), 15) == 0) {
+        return true;
+      } else {
+        return !psramFound(); // PSRAM pins on modules with in-package PSRAM
+      }
+    }    
   #endif
     if (output) return digitalPinCanOutput(gpio);
     else        return true;


### PR DESCRIPTION
Fix for https://github.com/wled/WLED/issues/5334


Edit (softhack007): The change relies on the framework knowing about the "ESP32-D0WDR2-V3" chip model - available since arduino-esp32 v2.0.7. It means that only "V4" builds will allow using GPIO17. WLED 0.15.3 is still using the older framework, only WLED 0.16 will be able to detect the "ESP32-D0WDR2-V3" chip properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPIO compatibility checks for ESP32 devices with external memory, enhancing detection of available pins across different module variants and memory configurations. This update better handles device-model-specific cases to reduce false negatives and ensure more reliable pin availability reporting on affected hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->