### PR TITLE
apply inverse gamma to segment brightness for better color preservation

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1384,7 +1384,7 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
   const unsigned progInv   = 0xFFFFU - progress;
   uint8_t       opacity    = topSegment.currentBri(); // returns transitioned opacity for style FADE
   uint8_t       cct        = topSegment.currentCCT();
-  if (gammaCorrectCol) opacity = gamma8inv(opacity); // use inverse gamma on brightness for correct color scaling after gamma correction
+  if (gammaCorrectCol) opacity = gamma8inv(opacity); // use inverse gamma on brightness for correct color scaling after gamma correction (see #5343 for details)
 
   Segment::setClippingRect(0, 0);             // disable clipping by default
 


### PR DESCRIPTION
to make global brightness slider and segment brightness slider behave the same, the segment brightness needs to be gamma-inverted when using gamma for color correction. 

the reason being (with g = gamma)
global brightness:  `(color)^g * brightness`
segment brightness: `(color * brightness)^g`

using `brightness^(1/g) `results in `(color *  brightness^(1/g) )^g = color^g * brightness` i.e. the same as with global brightness. 

The way WLED handles gamma is not mathematically correct but is an approximation and a good compromise (I ran A LOT of tests on that before setteling for the way it is currently done). The correct way would actually be to do `(color * brightness)^g` but the issue is that that results in color loss. To make it work would require to scale colors to 16bit, apply brightness, then apply gamma, then scale back to 8bit, which is much slower and does only gain "linearity" in brightness scaling which was never really a thing in WLED.


Fixes #5342 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced gamma correction handling to ensure brightness scaling maintains color accuracy and consistency during rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->