### PR TITLE
DMX Output support exclude message incorrectly displayed on builds *with* support

### DIFF
--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -50,6 +50,7 @@
 	}
 	function hideDMXInput(){gId("dmxInput").style.display="none";}
 	function hideNoDMXInput(){gId("dmxInputOff").style.display="none";}
+	function hideNoDMXOutput(){gId("dmxOnOffOutput").style.display="none";}
 	</script>
 </head>
 <body>
@@ -170,7 +171,7 @@ Realtime LED offset: <input name="WO" type="number" min="-255" max="255" require
 <div id="dmxInputOff">
 	<br><em style="color:darkorange">This firmware build does not include DMX Input support. <br></em>
 </div> 
-<div id="dmxOnOff2">
+<div id="dmxOnOffOutput">
   <br><em style="color:darkorange">This firmware build does not include DMX output support. <br></em>
 </div> 
 <hr class="sml">

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -459,7 +459,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormCheckbox(settingsScript,PSTR("EM"),e131Multicast);
     printSetFormValue(settingsScript,PSTR("EU"),e131Universe);
 #ifdef WLED_ENABLE_DMX
-    settingsScript.print(SET_F("hideNoDMX();"));  // hide "not compiled in" message
+    settingsScript.print(SET_F("hideNoDMXOutput();"));  // hide "not compiled in" message
 #endif
 #ifndef WLED_ENABLE_DMX_INPUT
     settingsScript.print(SET_F("hideDMXInput();"));  // hide "dmx input" settings


### PR DESCRIPTION
Builds display message saying no DMX output support for builds which do contain this feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the display handling for DMX output settings in the Sync configuration page, ensuring proper visibility controls for the DMX output section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->