### PR TITLE
Add WiFi band preference for dual-band ESP32 chips

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -157,6 +157,10 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   noWifiSleep = !(wifi[F("sleep")] | !noWifiSleep); // inverted
   //noWifiSleep = !noWifiSleep;
   CJSON(force802_3g, wifi[F("phy")]); //force phy mode g?
+#ifdef SOC_WIFI_SUPPORT_5G
+  CJSON(wifiBandMode, wifi[F("band")]);
+  if (wifiBandMode < WIFI_BAND_MODE_2G_ONLY || wifiBandMode > WIFI_BAND_MODE_AUTO) wifiBandMode = WIFI_BAND_MODE_AUTO;
+#endif
 #ifdef ARDUINO_ARCH_ESP32
   CJSON(txPower, wifi[F("txpwr")]);
   txPower = min(max((int)txPower, (int)WIFI_POWER_2dBm), (int)WIFI_POWER_19_5dBm);  // ToDO: V5 allows WIFI_POWER_21dBm = 84 ... WIFI_POWER_MINUS_1dBm = -4
@@ -907,6 +911,9 @@ void serializeConfig(JsonObject root) {
   JsonObject wifi = root.createNestedObject(F("wifi"));
   wifi[F("sleep")] = !noWifiSleep;
   wifi[F("phy")] = force802_3g;
+#ifdef SOC_WIFI_SUPPORT_5G
+  wifi[F("band")] = wifiBandMode;
+#endif
 #ifdef ARDUINO_ARCH_ESP32
   wifi[F("txpwr")] = txPower;
 #endif

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -250,6 +250,11 @@ Static subnet mask:<br>
 		Disable WiFi sleep: <input type="checkbox" name="WS"><br>
 		<i>Can help with connectivity issues and Audioreactive sync.<br>
 		Disabling WiFi sleep increases power consumption.</i><br>
+		<div id="bm">WiFi band: <select name="BM">
+			<option value="1">2.4 GHz only</option>
+			<option value="2">5 GHz only</option>
+			<option value="3">Auto (both)</option>
+		</select><br></div>
 		<div id="tx">TX power: <select name="TX">  <!-- ToDO: V5 framework allows  84 = 21dBm ... -4 = Minus_1dBm-->
 			<option value="78">19.5 dBm</option>
 			<option value="76">19 dBm</option>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -123,6 +123,15 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 
     force802_3g = request->hasArg(F("FG"));
     noWifiSleep = request->hasArg(F("WS"));
+    #ifdef SOC_WIFI_SUPPORT_5G
+    if (request->hasArg(F("BM"))) {
+      int bm = request->arg(F("BM")).toInt();
+      if (bm >= WIFI_BAND_MODE_2G_ONLY && bm <= WIFI_BAND_MODE_AUTO) {
+        if (bm != wifiBandMode) forceReconnect = true;
+        wifiBandMode = bm;
+      }
+    }
+    #endif
 
     #ifndef WLED_DISABLE_ESPNOW
     bool oldESPNow = enableESPNow;

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -745,10 +745,9 @@ if (multiWiFi.empty()) {                       // guard: handle empty WiFi list 
       DEBUG_PRINTLN(F("Access point disabled (init)."));
       WiFi.softAPdisconnect(true);
       WiFi.mode(WIFI_STA);
-      #if defined(ARDUINO_ARCH_ESP32) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2))
-      // we need to renew the "band mode" here, otherwise WiFi falls back to 2.4Ghz only
-      if (!WiFi.setBandMode(WIFI_BAND_MODE_AUTO)) {   // WIFI_BAND_MODE_AUTO = 5GHz+2.4GHz; WIFI_BAND_MODE_5G_ONLY, WIFI_BAND_MODE_2G_ONLY
-        DEBUG_PRINTLN(F("initConnection(): Wifi band configuration failed!\n"));
+      #if defined(SOC_WIFI_SUPPORT_5G) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2))
+      if (!WiFi.setBandMode((wifi_band_mode_t)wifiBandMode)) {
+        DEBUG_PRINTLN(F("initConnection(): WiFi band configuration failed!"));
       }
       #endif
     }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -393,6 +393,9 @@ WLED_GLOBAL bool noWifiSleep _INIT(false);
   #endif
 WLED_GLOBAL bool force802_3g _INIT(false);
 #endif // WLED_SAVE_RAM
+#ifdef SOC_WIFI_SUPPORT_5G
+WLED_GLOBAL byte wifiBandMode _INIT((byte)WIFI_BAND_MODE_AUTO);  // default for dual-band chips (1=2.4G, 2=5G, 3=Auto)
+#endif
 #if defined(ARDUINO_ARCH_ESP32)
   #if defined(LOLIN_WIFI_FIX) // extend this fix to all esp32 boards
 WLED_GLOBAL uint8_t txPower _INIT(WIFI_POWER_8_5dBm);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -244,6 +244,11 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     #endif
     printSetFormCheckbox(settingsScript,PSTR("FG"),force802_3g);
     printSetFormCheckbox(settingsScript,PSTR("WS"),noWifiSleep);
+    #ifdef SOC_WIFI_SUPPORT_5G
+    printSetFormValue(settingsScript,PSTR("BM"),wifiBandMode);
+    #else
+    settingsScript.print(F("gId('bm').style.display='none';"));
+    #endif
 
     #ifndef WLED_DISABLE_ESPNOW
     printSetFormCheckbox(settingsScript,PSTR("RE"),enableESPNow);


### PR DESCRIPTION
## Summary
- Adds a "WiFi band" dropdown to WiFi settings: **2.4 GHz only**, **5 GHz only**, or **Auto (both)**
- Defaults to **Auto** on dual-band chips
- Uses `WiFi.setBandMode()` from the Arduino ESP32 core (IDF 5.4.2+)
- Replaces the hardcoded `WIFI_BAND_MODE_AUTO` in V5-C6 with a user-selectable setting
- Guarded by `#ifdef SOC_WIFI_SUPPORT_5G` - zero impact on single-band builds
- Input validation ensures only valid band mode values (1-3) are accepted

## Changes (6 files, 32 lines added, 4 removed)
| File | Change |
|------|--------|
| `wled00/wled.h` | New `wifiBandMode` global (default: `WIFI_BAND_MODE_AUTO`) |
| `wled00/cfg.cpp` | Serialize/deserialize with range validation |
| `wled00/set.cpp` | Handle `BM` form param with validation, trigger reconnect |
| `wled00/xml.cpp` | Populate dropdown value; hide on non-5G chips |
| `wled00/wled.cpp` | Pass `wifiBandMode` to `WiFi.setBandMode()` in `initConnection()` |
| `wled00/data/settings_wifi.htm` | "WiFi band" dropdown in Experimental section |

## Test plan
Tested on ESP32-C5 hardware:
- [x] Auto mode - connects to strongest available AP
- [x] 5 GHz only mode - connects to 5 GHz AP (channel 44)
- [x] 2.4 GHz only mode - connects to 2.4 GHz AP (channel 6)
- [x] Settings persist across reboots (verified in /cfg.json)
- [x] Dropdown hidden on non-5G chips
- [x] Band mode change triggers WiFi reconnection
- [x] Invalid values rejected (validation in set.cpp and cfg.cpp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WiFi band selector (Experimental): 2.4 GHz / 5 GHz / Auto.
  * Info panel now displays the configured WiFi band and channel when available.

* **Improvements**
  * Changing band preference triggers a WiFi reconnect.
  * Expanded TX power choices with inline warning about potential connectivity impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->