### PR TITLE
fix for missing lang="en" in some UI pages

### DIFF
--- a/wled00/data/404.htm
+++ b/wled00/data/404.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta content='width=device-width' name='viewport'>

--- a/wled00/data/cpal/cpal.htm
+++ b/wled00/data/cpal/cpal.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 	<title>WLED Palette Editor</title>

--- a/wled00/data/dmxmap.htm
+++ b/wled00/data/dmxmap.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><head><meta content='width=device-width' name='viewport'>
+<html lang="en"><head><meta content='width=device-width' name='viewport'>
 <title>DMX Map</title>
 <script>function B(){window.history.back()};function RS(){window.location = "/settings";}function RP(){top.location.href="/";}function FM() {
   var dmxlabels = ["SET 0","RED","GREEN","BLUE","WHITE","SHUTTER","SET 255", "DISABLED"];

--- a/wled00/data/icons-ui/demo.html
+++ b/wled00/data/icons-ui/demo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <title>IcoMoon Demo</title>

--- a/wled00/data/liveview.htm
+++ b/wled00/data/liveview.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
   <meta charset="utf-8">

--- a/wled00/data/liveviewws2D.htm
+++ b/wled00/data/liveviewws2D.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
 	<meta charset="utf-8">

--- a/wled00/data/msg.htm
+++ b/wled00/data/msg.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
 	<meta content='width=device-width' name='viewport'>

--- a/wled00/data/pixart/pixart.htm
+++ b/wled00/data/pixart/pixart.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<meta content='width=device-width' name='viewport'>
 	<title>WLED Update</title>

--- a/wled00/data/usermod.htm
+++ b/wled00/data/usermod.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <body>No usermod custom web page set.</body>
 

--- a/wled00/data/welcome.htm
+++ b/wled00/data/welcome.htm
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta content='width=device-width' name='viewport'>


### PR DESCRIPTION
This PR adds the ``lang="en"`` attribute to all html pages where a language identifier was still missing.

Previously when opening the welcome page or update page, some _smart_ browsers suggested to "translate from Danish".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved HTML standards compliance and accessibility by adding language attribute declarations to interface pages, enabling proper language detection for browsers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->