### PR TITLE
 Fix: ESP32-S3 DHCP Hostname timing issue (Option 12) for OpenWrt/dnsmasq

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -865,6 +865,17 @@ void WLED::handleConnection()
   #endif
   const bool wifiConfigured = WLED_WIFI_CONFIGURED;
 
+  // The DNS name of the ESP must be set before the first connection to the DHCP server. Otherwise, the esp default name, such as “esp32s3-267D0C,” will be used. GG
+  #ifdef ARDUINO_ARCH_ESP32
+    // Use cmDNS (this is the buffer that holds your name)
+  if (cmDNS && cmDNS[0] != '\0') {
+    WiFi.setHostname(cmDNS);
+  } else {
+    // Fallback to DEVICE_NAME if cmDNS is still empty
+    WiFi.setHostname(WLED_HOST_NAME);
+  }
+  #endif
+  
   // ignore connection handling if WiFi is configured and scan still running
   // or within first 2s if WiFi is not configured or AP is always active
   if ((wifiConfigured && multiWiFi.size() > 1 && WiFi.scanComplete() < 0) || (now < 2000 && (!wifiConfigured || apBehavior == AP_BEHAVIOR_ALWAYS)))


### PR DESCRIPTION
Description:
On ESP32-S3 (and other fast S3/C3 targets), the WiFi stack starts the DHCP handshake (DHCPDISCOVER) almost immediately after WiFi.begin(). In the current WLED implementation, WiFi.setHostname() is often called too late, after the first discovery packet has already been sent with the default esp32s3-xxxxxx identifier.
This causes issues in strict network environments like OpenWrt (dnsmasq), where the router caches the first hostname it sees during the lease process and ignores subsequent updates.

Changes:
I 'moved' or better set another WiFi.setHostname() call to the very beginning of WLED::initConnection(). By doing this, the hostname (Option 12) is injected into the LwIP stack before the radio starts transmitting.
The fix uses the dynamic cmDNS buffer but falls back to the hardcoded DEVICE_NAME if the config hasn't been loaded yet (first boot).

I successfully tested the fix with my OpenWrt server (logread -f | grep -i dhcp) and an ESP32-S3-DevKitC-N16R8 (ESP32-S3 (QFN56) (revision v0.2)) as well as an ESP32-DevKitC (ESP32-D0WDQ6 (revision v1.0)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WiFi hostname assignment on ESP32 devices, now prioritizing custom network identification when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->