### PR TITLE
feat(eps-now): add 3 scenes for GLEDOPTO ESP-NOW WLED Remote Control

### DIFF
--- a/wled00/remote.cpp
+++ b/wled00/remote.cpp
@@ -220,8 +220,8 @@ void handleRemote() {
       case WIZMOTE_BUTTON_TWO            : presetWithFallback(2, FX_MODE_BREATH,        0); break;
       case WIZMOTE_BUTTON_THREE          : presetWithFallback(3, FX_MODE_FIRE_FLICKER,  0); break;
       case WIZMOTE_BUTTON_FOUR           : presetWithFallback(4, FX_MODE_RAINBOW,       0); break;
-      case WIZMOTE_BUTTON_FIVE           : presetWithFallback(5, FX_MODE_DISSOLVE,      0); break;
-      case WIZMOTE_BUTTON_SIX            : presetWithFallback(6, FX_MODE_BLINK,         0); break;
+      case WIZMOTE_BUTTON_FIVE           : presetWithFallback(5, FX_MODE_CANDLE,        0); break;
+      case WIZMOTE_BUTTON_SIX            : presetWithFallback(6, FX_MODE_RANDOM_COLOR,  0); break;
       case WIZMOTE_BUTTON_SEVEN          : presetWithFallback(7, FX_MODE_FADE,          0); break;
       case WIZMOTE_BUTTON_NIGHT          : activateNightMode();                             break;
       case WIZMOTE_BUTTON_BRIGHT_UP      : brightnessUp();                                  break;


### PR DESCRIPTION
This PR adds three new scenes to the EPS-NOW remote controller to support the GLEDOPTO ESP-NOW WLED Remote Control.

**Product link:**   https://gledopto.com/h-pd-146.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for three new WizMote remote buttons (5, 6, 7) for one-press access to lighting presets: Candle, Random Color, and Fade for quicker mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->