### PR TITLE
Info page: Total LEDs, GitHub repo, minor re-styling

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -717,7 +717,7 @@ ${inforow("CPU clock",i.clock," MHz")}
 ${inforow("Flash size",i.flash," MB")}
 ${inforow("Filesystem",i.fs.u + "/" + i.fs.t + " kB (" +Math.round(i.fs.u*100/i.fs.t) + "%)")}
 ${inforow("Environment",i.arch + " " + i.core + ( i.lwip ? " (" + i.lwip + ")" : ""))}
-${i.repo?inforow("GitHub","<a href=\"https://github.com/"+i.repo+"\" target=\"_blank\">" + i.repo + "</a>"):""}
+${i.repo?inforow("GitHub","<a href=\"https://github.com/"+i.repo+"\" target=\"_blank\" rel=\"noopener noreferrer\">" + i.repo + "</a>"):""}
 </table>`;
 	gId('kv').innerHTML = cn;
 	//  update all sliders in Info


### PR DESCRIPTION
* added GitHub repo (link)
* added Total LEDs
* removed lwip major version on esp32 
* two horizontal lines for better readability


<img width="479" height="856" alt="image" src="https://github.com/user-attachments/assets/a372f1ef-9edd-4078-bc7c-c7c48c6230ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device information now displays total LED count.
  * Device information now includes a direct link to the device's GitHub repository.

* **UI Improvements**
  * Information sections are separated with additional visual dividers for better readability.
  * Environment details are streamlined to show only applicable fields (omitting empty values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->