### PR TITLE
Additional features for the Dissolve FX

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -696,8 +696,8 @@ static const char _data_FX_MODE_TWINKLE[] PROGMEM = "Twinkle@!,!;!,!;!;;m12=0"; 
  *   checkbox 1 is to select random colors
  *   checkbox 2 is to force it to wait until all LEDs have been completely filled or dissolved
  *   checkbox 3 is to select whether one last LED will stay lit (like a "last one standing" or "sole survivor")
- *   aux0: 2 packed values: phase/stage of dissolve/refill process, and whether done dissolving/refilling
- *   aux1: 2 packed values: random survivor pixel index, and previous value of lastOneMode
+ *   aux0: 3 packed values: phase/stage of dissolve/refill process, whether done dissolving/refilling, and previous value of lastOneMode
+ *   aux1: random survivor pixel index
  */
 #define DISSOLVE_PHASE          (SEGENV.aux0 & 0xFF)
 #define DISSOLVE_DONE           ((SEGENV.aux0 >> 8) & 0x01)
@@ -742,7 +742,6 @@ void dissolve(uint32_t color) {
       SEGENV.step = 0;
       SET_PHASE(2);
       SET_DONE(0);
-      SEGENV.aux1 = hw_random16(SEGLEN);
     } else {
       SEGENV.step++;
     }
@@ -810,7 +809,7 @@ void dissolve(uint32_t color) {
       switch (DISSOLVE_PHASE) {
         case 0: SET_PHASE(1); break;
         case 1: SET_PHASE(2); break;
-        case 2: SET_PHASE(3); break;
+        case 2: SEGENV.aux1 = hw_random16(SEGLEN); SET_PHASE(3); break;
         case 3: SET_PHASE(4); break;
         case 4: SET_PHASE(2); break;
       }


### PR DESCRIPTION
This PR will add the following features to the Dissolve effect in FX.cpp

* Added a slider for filling speed (the previous slider was for both filling and dissolving); the existing slider is only for dissolving now.
* Added a checkbox to select whether one last LED will stay lit ("last one" mode).
* Added a slider for the delay when only one LED is lit and in "last one" mode.

In last one mode, if the delay slider is max (255), the effect will not redraw any LEDs, so this can be used with a playlist and physical button to, for example, restart the animation by unchecking checkbox 3 using a preset and then checking it again using another preset.  That will redraw the LEDs, stop with only one random LED lit, and then wait until the playlist is run again.

A couple of these features were requested in https://github.com/wled/WLED/issues/1044 back in 2020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended dissolve effect with multi-phase visuals and refined phase control
  * Added a configurable "Last one" mode with delay slider and optional freeze behavior
  * New timed pause phase to hold the final pixel before continuing
  * UI updated: added sliders for fill speed and last-one delay; adjusted defaults for random dissolve
<!-- end of auto-generated comment: release notes by coderabbit.ai -->