### PR TITLE
Experimental: H-bridge safe mode for TYPE_ANALOG_2CH (cheap hardware?)

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -532,7 +532,7 @@ void BusPwm::show() {
     unsigned duty = (_data[i] * pwmBri) / 255;
     unsigned deadTime = 0;
 
-    if ((_type == TYPE_ANALOG_2CH) && Bus::_cctBlend == 0) {
+    if (_type == TYPE_ANALOG_2CH && Bus::_cctBlend == 0) {
       // add dead time between signals (when using dithering, two full 8bit pulses are required)
       deadTime = (1+dithering) << bitShift;
       // we only need to take care of shortening the signal at (almost) full brightness otherwise pulses may overlap


### PR DESCRIPTION
Add H-bridge compatible mode for TYPE_ANALOG_2CH_HBRIDGE 
(mutually exclusive PWM outputs)

### Summary

This PR modifies the behavior of TYPE_ANALOG_2CH in WLED to better support 2-wire CCT LED strips driven via an H-bridge (reverse polarity).

Instead of driving both channels simultaneously (as in standard WW/CW blending), this change ensures that only one channel is active at a time, based on the CCT value.

### Motivation

When using an H-bridge for polarity-based CCT control:

Driving both outputs simultaneously can lead to short circuits (shoot-through) inside the H-bridge
The current implementation (Bus::calculateCCT) assumes independent LED channels, which is unsafe for this use case

### This PR introduces a safer mapping:

CCT range 0–127 → Channel A active
CCT range 128–255 → Channel B active
Never both at the same time
Implementation

### Adds the new TYPE_ANALOG_2CH_HBRIDGE handling with:

case TYPE_ANALOG_2CH_HBRIDGE:
{
  uint8_t level = (Bus::_cct < 0 || Bus::_cct > 255) ? 127 : Bus::_cct;
  uint8_t brightness = w;

  if (level <= 127) {
    _data[0] = (map(level, 0, 127, 255, 0) * brightness) / 255;
    _data[1] = 0;
  } else {
    _data[0] = 0;
    _data[1] = (map(level, 128, 255, 0, 255) * brightness) / 255;
  }
}
break;

### Behavior
Ensures mutually exclusive outputs
Maps CCT slider directly to polarity direction
Preserves brightness via w scaling

### Current Status  (Needs Review)
This implementation works in principle, but is not perfect:

Output switching is not hardware-synchronized
GPIO/PWM updates happen sequentially
There may still be very short overlap periods (µs range) between channels
Behavior near the midpoint (127/128) may not be perfectly smooth

Because of this, I consider this:
Experimental / partial solution

### Request for Review 
I would really appreciate feedback from maintainers or contributors on:

Whether this approach fits WLED’s design philosophy
If there is a better way to integrate H-bridge support
Possibility of:
synchronized PWM updates
using ESP32 LEDC features for safer switching
or introducing a dedicated “H-bridge mode” instead of modifying default behavior

### Safety Notes 
This change reduces the risk of shoot-through by avoiding simultaneous activation of both outputs in software
However, perfect synchronization between GPIO updates is not guaranteed
On ESP32, PWM channels are updated sequentially, which may still introduce very short overlap periods (µs range)

### Users should still:

Prefer H-bridge drivers with built-in shoot-through protection / dead-time
Avoid high-power configurations without proper hardware safeguards

### Scope / Limitations
Applies only to TYPE_ANALOG_2CH_HBRIDGE
Intended for H-bridge-driven 2-wire CCT setups
Not suitable for motor control or general bidirectional loads

### Notes
Ignores Bus::calculateCCT() intentionally
Uses Bus::_cct directly for deterministic channel selection

This aligns with the existing warning in LED settings regarding H-bridge usage and enforces safer behavior at the firmware level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted warm/cold white channel mapping for 2-channel analog LED configurations. Brightness levels now independently control warm and cold channels for improved lighting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->