### PR TITLE
service cleanup after removing return FRAMETIME

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1288,7 +1288,7 @@ void WS2812FX::service() {
 
     if (seg.isActive()) {
       // current segment is active -> re-run effect, and remember that show() call is necessary
-      //if (timeToShow) // removed - if we arrive here, its always showtime
+      // if we arrive here, its always showtime (timeToShow == true)
       doShow = true;
       if (!seg.freeze) { //only run effect function if not frozen
         // Effect blending


### PR DESCRIPTION
Clean-up and simplification of strip.service() after individual effect FRAMETIME was removed.

* Activation "_frametime"  is now the same for all effects, so effects scheduling based on individual frametime is not needed any more
* Special handling for mode_static is obsolete, because the solid effect does not have a different timing any more

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified frame/timing so effects refresh on a single global schedule for more consistent visuals.
  * Only active segments now determine when a frame is shown, reducing irregular timing.
  * Triggered updates and unlimited‑FPS still force immediate refreshes for snappier responses.
  * Early timing gate skips work when no update is due, lowering CPU use.
  * Ensures a safe fallback segment after servicing to avoid stale state.
  * Brightness changes use a capped refresh threshold to avoid excessive redraws.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->