### PR TITLE
Fixes issue in Dissolve when a palette has same color pixel as the current background color when Complete is enabled

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -687,7 +687,6 @@ static const char _data_FX_MODE_TWINKLE[] PROGMEM = "Twinkle@!,!;!,!;!;;m12=0"; 
  * Dissolve function
  */
 void dissolve(uint32_t color) {
-  if (SEGLEN < 1) FX_FALLBACK_STATIC;
   unsigned dataSize = sizeof(uint32_t) * SEGLEN;
   if (!SEGENV.allocateData(dataSize)) FX_FALLBACK_STATIC; //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -704,7 +704,7 @@ void dissolve(uint32_t color) {
         if (SEGENV.aux0) { //dissolve to primary/palette
           if (pixels[i] == SEGCOLOR(1)) {
             uint32_t c = color == SEGCOLOR(0) ? SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0) : color;
-            if (c == SEGCOLOR(1)) c ^= 0x00000001;  // change the color slightly so the effect doesn't get stuck in Complete mode if color is same as bkg color
+            if (SEGMENT.check2 && c == SEGCOLOR(1)) c ^= 0x00000001;  // change the color slightly so the effect doesn't get stuck in Complete mode if color is same as bkg color
             pixels[i] = c;
             break; //only spawn 1 new pixel per frame
           }

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -687,6 +687,7 @@ static const char _data_FX_MODE_TWINKLE[] PROGMEM = "Twinkle@!,!;!,!;!;;m12=0"; 
  * Dissolve function
  */
 void dissolve(uint32_t color) {
+  if (SEGLEN < 1) FX_FALLBACK_STATIC;
   unsigned dataSize = sizeof(uint32_t) * SEGLEN;
   if (!SEGENV.allocateData(dataSize)) FX_FALLBACK_STATIC; //allocation failed
   uint32_t* pixels = reinterpret_cast<uint32_t*>(SEGENV.data);
@@ -702,7 +703,9 @@ void dissolve(uint32_t color) {
         unsigned i = hw_random16(SEGLEN);
         if (SEGENV.aux0) { //dissolve to primary/palette
           if (pixels[i] == SEGCOLOR(1)) {
-            pixels[i] = color == SEGCOLOR(0) ? SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0) : color;
+            uint32_t c = color == SEGCOLOR(0) ? SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0) : color;
+            if (c == SEGCOLOR(1)) c ^= 0x00000001;  // change the color slightly so the effect doesn't get stuck in Complete mode if color is same as bkg color
+            pixels[i] = c;
             break; //only spawn 1 new pixel per frame
           }
         } else { //dissolve to secondary


### PR DESCRIPTION
When you select the Dissolve effect, select a palette, and enable the Complete checkbox, the effect should fill in the LEDs with the colors from the palette.  Then, after all of them have been filled in ("completed"), it will wait the normal delay time and then dissolve all of them.  But if the selected palette contains the same color as you have selected as the background color (SEGCOLOR(1)), then the Complete process will never be able to complete, so it looks like the effect is hung up or paused.  Example palettes that cause this issue are the Fire and Ice Fire palettes if you have black selected for your background color since those palettes contain black, CRGB(0,0,0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the dissolve effect where spawned colors could exactly match the background, causing invisible or incorrect pixels; spawned colors are now adjusted to ensure they remain visible and transitions display reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->