### PR TITLE
8MB partition: 2.3MB program, 3.4MB LittleFS (for discussion)

### DIFF
--- a/tools/WLED_ESP32_8MB.csv
+++ b/tools/WLED_ESP32_8MB.csv
@@ -1,7 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 nvs,      data, nvs,     0x9000,  0x5000,
 otadata,  data, ota,     0xe000,  0x2000,
-app0,     app,  ota_0,   0x10000, 0x200000,
-app1,     app,  ota_1,   0x210000,0x200000,
-spiffs,   data, spiffs,  0x410000,0x3E0000,
+app0,     app,  ota_0,   0x10000, 0x220000,
+app1,     app,  ota_1,   0x230000,0x220000,
+spiffs,   data, spiffs,  0x450000,0x3A0000,
 coredump, data, coredump,,64K

--- a/tools/WLED_zigbee_8MB.csv
+++ b/tools/WLED_zigbee_8MB.csv
@@ -1,9 +1,9 @@
 # Name,     Type, SubType, Offset,  Size, Flags
 nvs,        data, nvs,     0x9000,  0x5000,
 otadata,    data, ota,     0xe000,  0x2000,
-app0,       app,  ota_0,   0x10000, 0x220000,
-app1,       app,  ota_1,   0x230000,0x220000,
-spiffs,     data, spiffs,  0x450000,0x39B000,
+app0,       app,  ota_0,   0x10000, 0x270000,
+app1,       app,  ota_1,   0x280000,0x270000,
+spiffs,     data, spiffs,  0x4F0000,0x2FB000,
 zb_storage, data, fat,     0x7EB000,0x4000,
 zb_fct,     data, fat,     0x7EF000,0x1000,
 coredump,   data, coredump,0x7F0000,0x10000,

--- a/tools/WLED_zigbee_8MB.csv
+++ b/tools/WLED_zigbee_8MB.csv
@@ -1,0 +1,9 @@
+# Name,     Type, SubType, Offset,  Size, Flags
+nvs,        data, nvs,     0x9000,  0x5000,
+otadata,    data, ota,     0xe000,  0x2000,
+app0,       app,  ota_0,   0x10000, 0x220000,
+app1,       app,  ota_1,   0x230000,0x220000,
+spiffs,     data, spiffs,  0x450000,0x39B000,
+zb_storage, data, fat,     0x7EB000,0x4000,
+zb_fct,     data, fat,     0x7EF000,0x1000,
+coredump,   data, coredump,0x7F0000,0x10000,


### PR DESCRIPTION
* increase program partition by 132 KB (to be discussed)
* additional zigbee compatible 8MB partition file: 2.5MB program, 3MB LittleFS (to be discussed)

Actually the esp32-c5 "full debug" build is the best reason for increasing the 8MB program partition now (before massive rollout) - it barely fits into the current partitions' layout.

## comparison:

### V4

esp32-S3 8MB "opi" PSRAM (**tasmota** framework)
* old:  ``Flash: [======    ]  58.4% (used 1224085 bytes from 2097152 bytes)`` with 4MB LittleFS
* new: ``Flash: [=====     ]  54.9% (used 1224085 bytes from 2228224 bytes)`` with 3.75MB LittleFS

### V5

esp32-C5 8M "qspi" PSRAM (**pioarduino** framework)

* old  ``Flash: [========= ]  85.4% (used 1790459 bytes from 2097152 bytes)``
* new ``Flash: [========  ]  80.4% (used 1790459 bytes from 2228224 bytes)``

C5 full debug build (build_type = debug, -fno-lto, -D WLED_DEBUG -D CORE_DEBUG_LEVEL=5)
* old: 96% used (and > 100% before we replaced fastled ;-) )
* new: ``Flash: [========= ]  91.6% (used 2040809 bytes from 2228224 bytes)``

C5 build with -O2 (optimize for speed), no debug
* new ``Flash: [========= ]  87.4% (used 1946845 bytes from 2228224 bytes)``


### question
This is mainly a discussion input for finding a good balance between LittleFS and program size on 8MB boards.
The partition boundaries can be changed in 64KB steps. We need two OTA partitions, that's why each program increase counts 2x against LittleFS.

What do you think - Should we increase the 8MB program partition even more? Or better to stay with the previous 2MB/4MB layout, risking that some ``V5`` debug builds will not fit onto an 8MB board in the future?