### PR TITLE
Use drop-downs for pins

### DIFF
--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -251,7 +251,10 @@ function makePinSelect(name, flags) {
 		if (j > -1 && (flags & 4) && (!d.adc || !d.adc.includes(j))) continue;
 		let txt = (j === -1) ? "unused" : `${j}`;
 		let used = j > -1 && d.um_p && d.um_p.includes(j) && j !== v;
-		if (used) txt += " used";
+		if (used) {
+			//txt += " used";
+			if (d.pin_names && d.pin_names[j]) txt += ` (${d.pin_names[j]})`;
+		}
 		if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)";
 		let opt = cE("option");
 		opt.value = j;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -222,3 +222,78 @@ function sendDDP(ws, start, len, colors) {
 	}
 	return true;
 }
+// Pin dropdown utilities
+// Create or rebuild a pin <select> from an <input> or existing <select>
+// name: form field name, flags: bitmask 1=output, 2=touch, 4=ADC
+function makePinSelect(name, flags) {
+	let el = gN(name);
+	if (!el) return null;
+	let v = parseInt(el.value);
+	if (isNaN(v)) v = -1;
+	let sel;
+	if (el.tagName === "SELECT") {
+		sel = el;
+		while (sel.lastChild) sel.lastChild.remove();
+	} else {
+		sel = cE('select');
+		sel.classList.add("pin");
+		sel.name = el.name;
+		if (el.required) sel.required = true;
+		let oc = el.getAttribute("onchange");
+		if (oc) sel.setAttribute("onchange", oc);
+		el.parentElement.replaceChild(sel, el);
+	}
+	let hasV = false;
+	for (let j = -1; j < (d.max_gpio||0); j++) {
+		if (j > -1 && d.rsvd && d.rsvd.includes(j)) continue;
+		if (j > -1 && (flags & 1) && d.ro_gpio && d.ro_gpio.includes(j)) continue;
+		if (j > -1 && (flags & 2) && (!d.touch || !d.touch.includes(j))) continue;
+		if (j > -1 && (flags & 4) && (!d.adc || !d.adc.includes(j))) continue;
+		let txt = (j === -1) ? "unused" : `${j}`;
+		let used = j > -1 && d.um_p && d.um_p.includes(j) && j !== v;
+		if (used) txt += " used";
+		if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)";
+		let opt = cE("option");
+		opt.value = j;
+		opt.text = txt;
+		sel.appendChild(opt);
+		if (j === v) { opt.selected = true; hasV = true; }
+		else if (used) opt.disabled = true;
+	}
+	if (!hasV && v >= 0) {
+		let opt = cE("option");
+		opt.value = v; opt.text = v + " ⚠"; opt.selected = true;
+		sel.insertBefore(opt, sel.options[1]);
+	}
+	sel.dataset.val = v;
+	return sel;
+}
+// Convert pin <select> back to <input type="number">
+function unmakePinSelect(name) {
+	let sel = gN(name);
+	if (!sel || sel.tagName !== "SELECT") return null;
+	let inp = cE('input');
+	inp.type = "number";
+	inp.name = sel.name;
+	inp.value = sel.value;
+	inp.className = "s";
+	if (sel.required) inp.required = true;
+	let oc = sel.getAttribute("onchange");
+	if (oc) inp.setAttribute("onchange", oc);
+	sel.parentElement.replaceChild(inp, sel);
+	return inp;
+}
+// Add option to select, auto-select matching data-val
+function addOption(sel, txt, val) {
+	if (!sel) return null;
+	let opt = cE("option");
+	opt.value = val;
+	opt.text = txt;
+	sel.appendChild(opt);
+	if (sel.dataset.val !== undefined) {
+		for (let i = 0; i < sel.options.length; i++) {
+			if (sel.options[i].value == sel.dataset.val) { sel.selectedIndex = i; break; }
+		}
+	}
+	return opt;
+}

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -307,7 +307,7 @@ function makePinSelect(name, flags) {
 		let used = j > -1 && pInfo && pInfo.a && j !== v;
 		let txt = j === -1 ? "unused" : `${j}`;
 		if (used) txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
-		if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)";
+		// if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)"; // read only pins  note: removed as pin is not shown for outputs
 
 		let opt = cE("option");
 		opt.value = j;

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -222,14 +222,42 @@ function sendDDP(ws, start, len, colors) {
 	}
 	return true;
 }
+
+// Pin utilities
+function getOwnerName(o,t,n) {
+	// Use firmware-provided name if available
+	if(n) return n;
+	if(!o) return "System"; // no owner provided
+	if(o===0x85){ return getBtnTypeName(t); } // button pin
+	return "UM #"+o;
+}
+function getBtnTypeName(t) {
+	var n=["None","Reserved","Push","Push Inv","Switch","PIR","Touch","Analog","Analog Inv","Touch Switch"];
+	var label = n[t] || "?";
+	return 'Button <span style="font-size:10px;color:#888">'+label+'</span>';
+}
+function getCaps(p,c) {
+	var r=[];
+	// Use touch info from settings endpoint
+	if(d.touch && d.touch.includes(p)) r.push("Touch");
+	if(d.ro_gpio && d.ro_gpio.includes(p)) r.push("Input Only");
+	// Use other caps from JSON (Analog, Boot, Input Only)
+	if(c&0x02) r.push("Analog");
+	if(c&0x08) r.push("Flash Boot");
+	if(c&0x10) r.push("Bootstrap");
+	return r.length?r.join(", "):"-";
+}
+
 // Pin dropdown utilities
 // Create or rebuild a pin <select> from an <input> or existing <select>
-// name: form field name, flags: bitmask 1=output, 2=touch, 4=ADC
-function makePinSelect(name, flags) {
+// name: form field name, requirement flags bitmask: 1=output, 2=touch, 4=ADC
+// name: form field name, flags: bitmask 1=output, 2=touch, 4=ADC, pinsData: array from /json/pins
+function makePinSelect(name, flags, pinsData = null) {
 	let el = gN(name);
 	if (!el) return null;
 	let v = parseInt(el.value);
 	if (isNaN(v)) v = -1;
+
 	let sel;
 	if (el.tagName === "SELECT") {
 		sel = el;
@@ -243,26 +271,45 @@ function makePinSelect(name, flags) {
 		if (oc) sel.setAttribute("onchange", oc);
 		el.parentElement.replaceChild(sel, el);
 	}
+
 	let hasV = false;
 	for (let j = -1; j < (d.max_gpio||0); j++) {
 		if (j > -1 && d.rsvd && d.rsvd.includes(j)) continue;
 		if (j > -1 && (flags & 1) && d.ro_gpio && d.ro_gpio.includes(j)) continue;
 		if (j > -1 && (flags & 2) && (!d.touch || !d.touch.includes(j))) continue;
 		if (j > -1 && (flags & 4) && (!d.adc || !d.adc.includes(j))) continue;
+
 		let txt = (j === -1) ? "unused" : `${j}`;
-		let used = j > -1 && d.um_p && d.um_p.includes(j) && j !== v;
+		// Find pin info from the JSON data if provided
+		let pInfo = pinsData ? pinsData.find(p => p.p === j) : null;
+
+		// Logic: A pin is "used" if the API says it's active (p.a) 
+		// AND it's not the pin currently assigned to this field (j !== v)
+		let used = (pInfo && pInfo.a && j !== v) || (j > -1 && d.um_p && d.um_p.includes(j) && j !== v);
+
 		if (used) {
-			//txt += " used";
-			if (d.pin_names && d.pin_names[j]) txt += ` (${d.pin_names[j]})`;
+			if (pInfo) {
+				// Use the same owner naming logic as your info list
+				txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
+			} else if (d.pin_names && d.pin_names[j]) {
+				txt += ` (${d.pin_names[j]})`;
+			} else {
+				txt += " (used)";
+			}
 		}
+
 		if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)";
+
 		let opt = cE("option");
 		opt.value = j;
 		opt.text = txt;
 		sel.appendChild(opt);
+
 		if (j === v) { opt.selected = true; hasV = true; }
 		else if (used) opt.disabled = true;
 	}
+
+	// Safety for invalid pins currently saved
 	if (!hasV && v >= 0) {
 		let opt = cE("option");
 		opt.value = v; opt.text = v + " ⚠"; opt.selected = true;
@@ -271,6 +318,7 @@ function makePinSelect(name, flags) {
 	sel.dataset.val = v;
 	return sel;
 }
+
 // Convert pin <select> back to <input type="number">
 function unmakePinSelect(name) {
 	let sel = gN(name);

--- a/wled00/data/common.js
+++ b/wled00/data/common.js
@@ -248,11 +248,35 @@ function getCaps(p,c) {
 	return r.length?r.join(", "):"-";
 }
 
+// Fetch GPIO caps (/settings/s.js?p=11) then pin occupancy (/json/pins) with retry.
+// Caches result in d.pinsData. Calls cb() when ready (or on failure).
+// If page already loaded its own s.js (d.max_gpio set), skips caps load and goes straight to pins fetch.
+function fetchPinInfo(cb, retries=5) {
+	if (d.pinsData) { cb&&cb(); return; }
+	var done=false, fr=retries;
+	function doFetch() {
+		fetch(getURL('/json/pins'))
+			.then(r=>r.json())
+			.then(j=>{ if(!done){done=true; d.pinsData=j.pins||[]; cb&&cb();} })
+			.catch(()=>{ fr-->0 ? setTimeout(doFetch,100) : (!done&&(done=true,d.pinsData=[],cb&&cb())); });
+	}
+	if (d.max_gpio) { doFetch(); return; }
+	// Load GPIO caps from s.js?p=11 first (sets d.rsvd/ro_gpio/max_gpio/touch/adc/um_p)
+	d.max_gpio=50; d.rsvd=[]; d.ro_gpio=[]; d.touch=[]; d.adc=[]; d.um_p=[];
+	var cr=retries;
+	function tryCaps() {
+		var s=cE("script"); s.src=getURL('/settings/s.js?p=11');
+		d.body.appendChild(s);
+		s.onload=function(){ GetV(); doFetch(); };
+		s.onerror=function(){ cr-->0 ? setTimeout(tryCaps,100) : doFetch(); };
+	}
+	tryCaps();
+}
+
 // Pin dropdown utilities
 // Create or rebuild a pin <select> from an <input> or existing <select>
 // name: form field name, requirement flags bitmask: 1=output, 2=touch, 4=ADC
-// name: form field name, flags: bitmask 1=output, 2=touch, 4=ADC, pinsData: array from /json/pins
-function makePinSelect(name, flags, pinsData = null) {
+function makePinSelect(name, flags) {
 	let el = gN(name);
 	if (!el) return null;
 	let v = parseInt(el.value);
@@ -279,25 +303,10 @@ function makePinSelect(name, flags, pinsData = null) {
 		if (j > -1 && (flags & 2) && (!d.touch || !d.touch.includes(j))) continue;
 		if (j > -1 && (flags & 4) && (!d.adc || !d.adc.includes(j))) continue;
 
-		let txt = (j === -1) ? "unused" : `${j}`;
-		// Find pin info from the JSON data if provided
-		let pInfo = pinsData ? pinsData.find(p => p.p === j) : null;
-
-		// Logic: A pin is "used" if the API says it's active (p.a) 
-		// AND it's not the pin currently assigned to this field (j !== v)
-		let used = (pInfo && pInfo.a && j !== v) || (j > -1 && d.um_p && d.um_p.includes(j) && j !== v);
-
-		if (used) {
-			if (pInfo) {
-				// Use the same owner naming logic as your info list
-				txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
-			} else if (d.pin_names && d.pin_names[j]) {
-				txt += ` (${d.pin_names[j]})`;
-			} else {
-				txt += " (used)";
-			}
-		}
-
+		let pInfo = d.pinsData && d.pinsData.find(p => p.p === j);
+		let used = j > -1 && pInfo && pInfo.a && j !== v;
+		let txt = j === -1 ? "unused" : `${j}`;
+		if (used) txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
 		if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)";
 
 		let opt = cE("option");

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -313,19 +313,19 @@
 				gId("p1d"+n).innerText = p1d;
 				gId("off"+n).innerText = off;
 				// convert pin fields so show/hide applies to the correct element type
- 				for (let p=0; p<5; p++) {
- 					let nm2 = "L"+p+n;
- 					let el = d.Sf[nm2];
- 					if (!el) continue;
- 					if (isVir(t) || isHub75(t)) {
- 						if (el.tagName === "SELECT") unmakePinSelect(nm2); // see common.js
- 					} else {
- 						if (el.tagName === "INPUT" && el.type === "number") {
- 							makePinSelect(nm2, 1); // see common.js
- 							d.pinUpdPending = true;
- 						}
- 					}
- 				}
+				for (let p=0; p<5; p++) {
+					let nm2 = "L"+p+n;
+					let el = d.Sf[nm2];
+					if (!el) continue;
+					if (isVir(t) || isHub75(t)) {
+						if (el.tagName === "SELECT") unmakePinSelect(nm2); // see common.js
+					} else {
+						if (el.tagName === "INPUT" && el.type === "number") {
+							makePinSelect(nm2, 1); // see common.js
+							d.pinUpdPending = true;
+						}
+					}
+				}
 				// show/hide secondary pins on whatever element type now exists
 				let pins = Math.max(gT(t).t.length,1) + 3*isNet(t) + 4*isHub75(t);
 				for (let p=1; p<5; p++) {
@@ -438,27 +438,6 @@
 					LC.style.color="#fff";
 					return; // do not check conflicts
 				}
-				/*
-				// check for pin conflicts & color fields
-				if (nm.search(/^L[0-4]/) == 0) // pin fields
-					if (LC.value!="" && LC.value!="-1") {
-						let p = d.rsvd.concat(d.um_p); // used pin array
-						d.Sf.querySelectorAll("select.pin").forEach((e)=>{if(e.value>-1)p.push(parseInt(e.value));}) // buttons, IR & relay
-						for (j=0; j<nList.length; j++) {
-							if (i==j) continue;
-							let n2 = nList[j].name.substring(0,2); // field name : /L./
-							if (n2.search(/^L[0-4]/) == 0) { // pin fields
-								let m  = nList[j].name.substring(2,3); // bus number (0-Z)
-								let t2 = parseInt(gN("LT"+m).value, 10);
-								if (isVir(t2)) continue;
-								if (nList[j].value!="" && nList[j].value!="-1") p.push(parseInt(nList[j].value,10));  // add current pin
-							}
-						}
-						// now check for conflicts
-						if (p.some((e)=>e==parseInt(LC.value))) LC.style.color = "red";
-						else LC.style.color = d.ro_gpio.some((e)=>e==parseInt(LC.value)) ? "orange" : "#fff";
-					} else LC.style.color = "#fff";
-				*/
 			});
 
 			// Use helper function to calculate channel usage
@@ -865,7 +844,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 			d.Sf.querySelectorAll("select.pin").forEach((e) => { pinUpd(e); });
 			// add dataset values for remaining LED GPIO inputs (virtual/HUB75)
 			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i) => {
-				if (i.value !== "" && i.value >= 0)
+				if (i.value !== "" && parseInt(i.value, 10) >= 0)
 					i.dataset.val = i.value;
 			});
 		}

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -49,7 +49,22 @@
 				setABL();
 				d.Sf.addEventListener("submit", trySubmit);
 				if (d.um_p[0]==-1) d.um_p.shift();
-				pinDropdowns();
+				fetch(getURL('/json/pins')).then(r=>r.json()).then(j=>{
+					if (j && j.pins) {
+						let um = [];
+						d.pin_names = {};
+						j.pins.forEach(p => {
+							// 0x82=BusDigital, 0x83=BusOnOff, 0x84=BusPwm, 0x85=Button, 0x86=IR, 0x87=Relay, 0x8E=HUB75
+							let ledOwners = [0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x8E];
+							if (p.a && !ledOwners.includes(p.o)) um.push(p.p);
+							if (p.n) d.pin_names[p.p] = p.n;
+						});
+						d.um_p = um;
+					}
+					pinDropdowns();
+				}).catch(e=>{
+					pinDropdowns();
+				});
 			});	// If we set async false, file is loaded and executed, then next statement is processed
 			if (loc) d.Sf.action = getURL('/settings/leds');
 		}
@@ -70,9 +85,10 @@
 		function isS2()   { return chipID == 2; }
 		function isS3()   { return chipID == 3; }
 		function is32()   { return chipID == 4; }
+
 		function pinsOK() {
 			var ok = true;
-			var nList = d.Sf.querySelectorAll("#mLC input[name^=L]");
+			var nList = Array.from(d.Sf.querySelectorAll("#mLC input[name^=L], #mLC select.pin[name^=L]")); // include both input types (numeric & dropdown)
 			nList.forEach((LC,i)=>{
 				if (!ok) return; // prevent iteration after conflict
 				let nm = LC.name.substring(0,2);  // field name : /L./
@@ -87,17 +103,17 @@
 				//check for pin conflicts
 				if (LC.value!="" && LC.value!="-1") {
 					let p = d.rsvd.concat(d.um_p); // used pin array
-					d.Sf.querySelectorAll("select.pin").forEach((e)=>{if(e.value>-1)p.push(parseInt(e.value));}) // buttons, IR & relay
+					//d.Sf.querySelectorAll("select.pin").forEach((e)=>{if(e.value>-1)p.push(parseInt(e.value));}) // buttons, IR & relay
+					// only non-LED selects (buttons, IR, relay) — LED pins check against each other below
+					d.Sf.querySelectorAll("select.pin").forEach((e)=>{if(!/^L[0-4]/.test(e.name) && e.value>-1)p.push(parseInt(e.value));})
 					if (p.some((e)=>e==parseInt(LC.value))) {
 						alert(`Sorry, pins ${JSON.stringify(p)} can't be used.`);
-						LC.value="";
-						LC.focus();
+						if (LC.tagName==="SELECT") LC.value="-1"; else { LC.value=""; LC.focus(); } // TODO: need to "focus" dropdowns too? if so how?
 						ok = false;
 						return;
 					} else if (d.ro_gpio.some((e)=>e==parseInt(LC.value))) {
 						alert(`Sorry, pins ${JSON.stringify(d.ro_gpio)} are input only.`);
-						LC.value="";
-						LC.focus();
+						if (LC.tagName==="SELECT") LC.value="-1"; else { LC.value=""; LC.focus(); }
 						ok = false;
 						return;
 					}
@@ -107,10 +123,9 @@
 							let m  = nList[j].name.substring(2,3); // bus number (0-Z)
 							let t2 = parseInt(gN("LT"+m).value, 10);
 							if (isVir(t2)) continue;
-							if (nList[j].value!="" && nList[i].value==nList[j].value) {
+							if (nList[j].value!="" && nList[j].value!="-1" && LC.value==nList[j].value) {
 								alert(`Pin conflict between ${LC.name}/${nList[j].name}!`);
-								nList[j].value="";
-								nList[j].focus();
+								if (nList[j].tagName==="SELECT") nList[j].value="-1"; else { nList[j].value=""; nList[j].focus(); }
 								ok = false;
 								return;
 								}
@@ -303,28 +318,28 @@
 				gId("p0d"+n).innerText = p0d;
 				gId("p1d"+n).innerText = p1d;
 				gId("off"+n).innerText = off;
-				// secondary pins show/hide (type string length is equivalent to number of pins used; except for network and on/off)
-				let pins = Math.max(gT(t).t.length,1) + 3*isNet(t) + 4*isHub75(t); // fixes network pins to 4
+				// convert pin fields so show/hide applies to the correct element type
+ 				for (let p=0; p<5; p++) {
+ 					let nm2 = "L"+p+n;
+ 					let el = d.Sf[nm2];
+ 					if (!el) continue;
+ 					if (isVir(t) || isHub75(t)) {
+ 						if (el.tagName === "SELECT") unmakePinSelect(nm2); // see common.js
+ 					} else {
+ 						if (el.tagName === "INPUT" && el.type === "number") {
+ 							makePinSelect(nm2, 1); // see common.js
+ 							d.pinUpdPending = true;
+ 						}
+ 					}
+ 				}
+				// show/hide secondary pins on whatever element type now exists
+				let pins = Math.max(gT(t).t.length,1) + 3*isNet(t) + 4*isHub75(t);
 				for (let p=1; p<5; p++) {
 					var LK = d.Sf["L"+p+n];
 					if (!LK) continue;
 					LK.style.display = (p < pins) ? "inline" : "none";
 					LK.required = (p < pins);
-					if (p >= pins) LK.value="";
-				}
-				// convert LED pin fields between dropdown and input based on bus type
-				for (let p=0; p<5; p++) {
-					let nm2 = "L"+p+n;
-					let el = d.Sf[nm2];
-					if (!el) continue;
-					if (isVir(t) || isHub75(t)) {
-						if (el.tagName === "SELECT") unmakePinSelect(nm2);
-					} else {
-						if (el.tagName === "INPUT" && el.type === "number") {
-							let s = makePinSelect(nm2, 1);
-							if (s) pinUpd(s);
-						}
-					}
+					if (p >= pins) LK.value = (LK.tagName === "SELECT") ? "-1" : "";
 				}
 			}
 
@@ -429,6 +444,7 @@
 					LC.style.color="#fff";
 					return; // do not check conflicts
 				}
+				/*
 				// check for pin conflicts & color fields
 				if (nm.search(/^L[0-4]/) == 0) // pin fields
 					if (LC.value!="" && LC.value!="-1") {
@@ -448,6 +464,7 @@
 						if (p.some((e)=>e==parseInt(LC.value))) LC.style.color = "red";
 						else LC.style.color = d.ro_gpio.some((e)=>e==parseInt(LC.value)) ? "orange" : "#fff";
 					} else LC.style.color = "#fff";
+				*/
 			});
 
 			// Use helper function to calculate channel usage
@@ -524,6 +541,11 @@
 			gId('fpsNone').style.display = (d.Sf.FR.value == 0) ? 'block':'none';
 			gId('fpsWarn').style.display = (d.Sf.FR.value == 0) || (d.Sf.FR.value >= 80) ? 'block':'none';
 			gId('fpsHigh').style.display = (d.Sf.FR.value >= 80) ? 'block':'none';
+
+			if (d.pinUpdPending) {
+				d.pinUpdPending = false;
+				d.Sf.querySelectorAll("select.pin").forEach((e) => { pinUpd(e); });
+			}
 		}
 
 		function lastEnd(i) {

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -85,6 +85,13 @@
 				}
 				// ignore IP address
 			  if (isNet(t)) return;
+				// LED pin(s) must be assigned for non-virtual types
+				let pIdx = parseInt(LC.name.charAt(1)); // determine pin index (0 for L0, 1 for L1, etc.)
+				if (pIdx < numPins(t) && !isVir(t) && (LC.value === "" || LC.value === "-1")) {
+						LC.focus();
+						ok = false;
+						return;
+				}
 				//check for pin conflicts
 				if (LC.value!="" && LC.value!="-1") {
 					let p = d.rsvd.concat(d.um_p); // used pin array
@@ -93,12 +100,14 @@
 					d.Sf.querySelectorAll("select.pin").forEach((e)=>{if(!/^L[0-4]/.test(e.name) && e.value>-1)p.push(parseInt(e.value));})
 					if (p.some((e)=>e==parseInt(LC.value))) {
 						alert(`Sorry, pins ${JSON.stringify(p)} can't be used.`);
-						if (LC.tagName==="SELECT") LC.value="-1"; else { LC.value=""; LC.focus(); } // TODO: need to "focus" dropdowns too? if so how?
+						if (LC.tagName==="SELECT") LC.value="-1"; else LC.value="";
+						LC.focus();
 						ok = false;
 						return;
 					} else if (d.ro_gpio.some((e)=>e==parseInt(LC.value))) {
 						alert(`Sorry, pins ${JSON.stringify(d.ro_gpio)} are input only.`);
-						if (LC.tagName==="SELECT") LC.value="-1"; else { LC.value=""; LC.focus(); }
+						if (LC.tagName==="SELECT") LC.value="-1"; else LC.value="";
+						LC.focus();
 						ok = false;
 						return;
 					}

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -312,6 +312,20 @@
 					LK.required = (p < pins);
 					if (p >= pins) LK.value="";
 				}
+				// convert LED pin fields between dropdown and input based on bus type
+				for (let p=0; p<5; p++) {
+					let nm2 = "L"+p+n;
+					let el = d.Sf[nm2];
+					if (!el) continue;
+					if (isVir(t) || isHub75(t)) {
+						if (el.tagName === "SELECT") unmakePinSelect(nm2);
+					} else {
+						if (el.tagName === "INPUT" && el.type === "number") {
+							let s = makePinSelect(nm2, 1);
+							if (s) pinUpd(s);
+						}
+					}
+				}
 			}
 
 			// enable/disable LED fields
@@ -671,11 +685,18 @@ Swap: <select id="xw${s}" name="XW${s}">
 			gId("com_rem").style.display = (i>0) ? "inline":"none";
 		}
 
+		// get pin dropdown flags for button type: touch=2, ADC=4, any=0
+		function btnPinFlags(t) { return (t==6||t==9) ? 2 : (t==7||t==8) ? 4 : 0; }
+		function btnPinDd(s) {
+			let t = parseInt(d.Sf["BE"+s].value);
+			makePinSelect("BT"+s, btnPinFlags(t));
+			d.Sf.querySelectorAll("select.pin").forEach(e => pinUpd(e));
+		}
 		function addBtn(i,p,t) {
 			var b = gId("btns");
 			var s = chrID(i);
 			var c = `<div id="btn${i}">#${i} GPIO: <input type="number" name="BT${s}" onchange="UI()" min="-1" max="${d.max_gpio}" class="xs" value="${p}">`;
-			c += `&nbsp;<select name="BE${s}">`
+			c += `&nbsp;<select name="BE${s}" onchange="btnPinDd('${s}')">`
 			c += `<option value="0" ${t==0?"selected":""}>Disabled</option>`;
 			c += `<option value="2" ${t==2?"selected":""}>Pushbutton</option>`;
 			c += `<option value="3" ${t==3?"selected":""}>Push inverted</option>`;
@@ -805,100 +826,56 @@ Swap: <select id="xw${s}" name="XW${s}">
 			}
 		}
 		function pinDropdowns() {
-			let fields = ["IR","RL"]; // IR & relay
-			gId("btns").querySelectorAll('input[type="number"]').forEach((e)=>{fields.push(e.name);}) // buttons
-			for (let i of d.Sf.elements) {
-				if (i.type === "number" && fields.includes(i.name)) { //select all pin select elements
-					let v = parseInt(i.value);
-					let sel = addDropdown(i.name,0);
-					for (var j = -1; j < d.max_gpio; j++) {
-						if (d.rsvd.includes(j)) continue;
-						let foundPin = d.um_p.indexOf(j);
-						let txt = (j === -1) ? "unused" : `${j}`;
-						if (foundPin >= 0 && j !== v) txt += ` used`; // already reserved pin
-						if (d.ro_gpio.includes(j)) txt += " (R/O)";
-						let opt = addOption(sel, txt, j);
-						if (j === v) opt.selected = true; // this is "our" pin
-						else if (d.um_p.includes(j) && j > -1) opt.disabled = true; // someone else's pin
-					}
-				}
-			}
-			// update select options
-			d.Sf.querySelectorAll("select.pin").forEach((e)=>{pinUpd(e);});
-			// add dataset values for LED GPIO pins
-			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i)=>{
-				if (i.value!=="" && i.value>=0)
+			// IR (any pin including input-only)
+			makePinSelect("IR", 0);
+			// Relay (output required)
+			makePinSelect("RL", 1);
+			// Buttons (flags depend on button type: touch=2, ADC=4)
+			gId("btns").querySelectorAll('input[type="number"]').forEach((e) => {
+				let s = e.name.substring(2);
+				let t = parseInt(d.Sf["BE"+s]?.value) || 0;
+				makePinSelect(e.name, btnPinFlags(t));
+			});
+			// cross-update all pin selects
+			d.Sf.querySelectorAll("select.pin").forEach((e) => { pinUpd(e); });
+			// add dataset values for remaining LED GPIO inputs (virtual/HUB75)
+			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i) => {
+				if (i.value !== "" && i.value >= 0)
 					i.dataset.val = i.value;
 			});
 		}
 		function pinUpd(e) {
-			// update changed select options across all usermods
+			// update changed select options across all pin selects
 			let oldV = parseInt(e.dataset.val);
 			e.dataset.val = e.value;
-			let txt = e.name;
+			let label = /^L[0-4].$/.test(e.name) ? 'LED' : e.name;
 			let pins = [];
-			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i)=>{
-				if (i.value!=="" && i.value>=0 && i.max<255)
+			// collect LED bus pin values from remaining inputs (virtual/HUB75)
+			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i) => {
+				if (i.value !== "" && parseInt(i.value) >= 0 && i.max < 255)
 					pins.push(i.value);
+			});
+			// collect LED bus pin values from selects
+			d.Sf.querySelectorAll(".iST select.pin[name^=L]").forEach((s) => {
+				if (s !== e && parseInt(s.value) >= 0)
+					pins.push(s.value);
 			});
 			let selects = d.Sf.querySelectorAll("select.pin");
 			for (let sel of selects) {
-				if (sel == e) continue
-				Array.from(sel.options).forEach((i)=>{
+				if (sel == e) continue;
+				Array.from(sel.options).forEach((i) => {
 					let led = pins.includes(i.value);
-					if (!(i.value==oldV || i.value==e.value || led)) return;
-					if (i.value == -1) {
-						i.text = "unused";
-						return
-					}
+					if (!(i.value == oldV || i.value == e.value || led)) return;
+					if (i.value == -1) { i.text = "unused"; return; }
 					i.text = i.value;
-					if (i.value==oldV) {
-						i.disabled = false;
-					}
-					if (i.value==e.value || led) {
+					if (i.value == oldV) { i.disabled = false; }
+					if (i.value == e.value || led) {
 						i.disabled = true;
-						i.text += ` ${led?'LED':txt}`;
+						i.text += ` ${led ? 'LED' : label}`;
 					}
 					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)";
 				});
 			}
-		}
-		// https://stackoverflow.com/questions/39729741/javascript-change-input-text-to-select-option
-		function addDropdown(field) {
-			let sel = cE('select');
-			sel.classList.add("pin");
-			let inp = d.getElementsByName(field)[0];
-			if (inp && inp.tagName === "INPUT" && (inp.type === "text" || inp.type === "number")) {  // may also use nodeName
-				let v = inp.value;
-				let n = inp.name;
-				// copy the existing input element's attributes to the new select element
-				for (var i = 0; i < inp.attributes.length; ++ i) {
-					var att = inp.attributes[i];
-					// type and value don't apply, so skip them
-					// ** you might also want to skip style, or others -- modify as needed **
-					if (att.name != 'type' && att.name != 'value' && att.name != 'class' && att.name != 'style') {
-						sel.setAttribute(att.name, att.value);
-					}
-				}
-				sel.setAttribute("data-val", v);
-				sel.setAttribute("onchange", "pinUpd(this)");
-				// finally, replace the old input element with the new select element
-				inp.parentElement.replaceChild(sel, inp);
-				return sel;
-			}
-			return null;
-		}
-		function addOption(sel,txt,val) {
-			if (sel===null) return; // select object missing
-			let opt = cE("option");
-			opt.value = val;
-			opt.text = txt;
-			sel.appendChild(opt);
-			for (let i=0; i<sel.childNodes.length; i++) {
-				let c = sel.childNodes[i];
-				if (c.value == sel.dataset.val) sel.selectedIndex = i;
-			}
-			return opt;
 		}
 		// calculate channel usage across all buses
 		function getDuse() {

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -842,6 +842,12 @@ Swap: <select id="xw${s}" name="XW${s}">
 			}
 		}
 		function pinDropdowns() {
+			// Rebuild LED GPIO selects now that d.pinsData is available.
+			d.Sf.querySelectorAll(".iST input.s[name^=L], .iST select.pin[name^=L]").forEach((e) => {
+				let n = e.name.substring(2, 3);
+				let t = parseInt(d.Sf["LT"+n].value, 10);
+				if (!isVir(t) && !isHub75(t)) makePinSelect(e.name, 1);
+			});
 			// IR (any pin including input-only)
 			let irSel = makePinSelect("IR", 0);
 			if (irSel) irSel.onchange = function() { UI(); pinUpd(this); };
@@ -849,7 +855,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 			let rlSel = makePinSelect("RL", 1);
 			if (rlSel) rlSel.onchange = function() { UI(); pinUpd(this); };
 			// Buttons (flags depend on button type: touch=2, ADC=4)
-			gId("btns").querySelectorAll('input[type="number"]').forEach((e) => {
+			gId("btns").querySelectorAll('input[type="number"], select.pin[name^=BT]').forEach((e) => {
 				let s = e.name.substring(2);
 				let t = parseInt(d.Sf["BE"+s]?.value) || 0;
 				let bSel = makePinSelect(e.name, btnPinFlags(t));
@@ -871,8 +877,11 @@ Swap: <select id="xw${s}" name="XW${s}">
 			let pins = [];
 			// collect LED bus pin values from remaining inputs (virtual/HUB75)
 			d.Sf.querySelectorAll(".iST input.s[name^=L]").forEach((i) => {
-				if (i.value !== "" && parseInt(i.value) >= 0 && i.max < 255)
-					pins.push(i.value);
+				let busN = i.name.substring(2, 3);
+				let t = parseInt(d.Sf["LT"+busN].value, 10);
+				let p = parseInt(i.name.charAt(1), 10);
+				if (isVir(t) || isHub75(t) || p >= numPins(t)) return;
+				if (i.value !== "" && parseInt(i.value, 10) >= 0) pins.push(i.value);
 			});
 			// collect LED bus pin values from selects
 			d.Sf.querySelectorAll(".iST select.pin[name^=L]").forEach((s) => {

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -893,7 +893,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 						i.disabled = true;
 						i.text += ` ${led ? 'LED' : label}`;
 					}
-					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)";
+					//if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)"; // read only pin note: removed as pin is not shown for outputs
 				});
 			}
 		}

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -49,22 +49,7 @@
 				setABL();
 				d.Sf.addEventListener("submit", trySubmit);
 				if (d.um_p[0]==-1) d.um_p.shift();
-				fetch(getURL('/json/pins')).then(r=>r.json()).then(j=>{
-					if (j && j.pins) {
-						let um = [];
-						d.pin_names = {};
-						j.pins.forEach(p => {
-							// 0x82=BusDigital, 0x83=BusOnOff, 0x84=BusPwm, 0x85=Button, 0x86=IR, 0x87=Relay, 0x8E=HUB75
-							let ledOwners = [0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x8E];
-							if (p.a && !ledOwners.includes(p.o)) um.push(p.p);
-							if (p.n) d.pin_names[p.p] = p.n;
-						});
-						d.um_p = um;
-					}
-					pinDropdowns();
-				}).catch(e=>{
-					pinDropdowns();
-				});
+				fetchPinInfo(pinDropdowns);
 			});	// If we set async false, file is loaded and executed, then next statement is processed
 			if (loc) d.Sf.action = getURL('/settings/leds');
 		}
@@ -849,14 +834,17 @@ Swap: <select id="xw${s}" name="XW${s}">
 		}
 		function pinDropdowns() {
 			// IR (any pin including input-only)
-			makePinSelect("IR", 0);
+			let irSel = makePinSelect("IR", 0);
+			if (irSel) irSel.onchange = function() { UI(); pinUpd(this); };
 			// Relay (output required)
-			makePinSelect("RL", 1);
+			let rlSel = makePinSelect("RL", 1);
+			if (rlSel) rlSel.onchange = function() { UI(); pinUpd(this); };
 			// Buttons (flags depend on button type: touch=2, ADC=4)
 			gId("btns").querySelectorAll('input[type="number"]').forEach((e) => {
 				let s = e.name.substring(2);
 				let t = parseInt(d.Sf["BE"+s]?.value) || 0;
-				makePinSelect(e.name, btnPinFlags(t));
+				let bSel = makePinSelect(e.name, btnPinFlags(t));
+				if (bSel) bSel.onchange = function() { UI(); pinUpd(this); };
 			});
 			// cross-update all pin selects
 			d.Sf.querySelectorAll("select.pin").forEach((e) => { pinUpd(e); });
@@ -886,6 +874,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 			for (let sel of selects) {
 				if (sel == e) continue;
 				Array.from(sel.options).forEach((i) => {
+					if (i.value == sel.dataset.val) return; // skip sel's own selected pin
 					let led = pins.includes(i.value);
 					if (!(i.value == oldV || i.value == e.value || led)) return;
 					if (i.value == -1) { i.text = "unused"; return; }

--- a/wled00/data/settings_pininfo.htm
+++ b/wled00/data/settings_pininfo.htm
@@ -16,17 +16,7 @@
 		var pinsTimer=null, gpioInfo={};
 		function S() {
 			getLoc();
-			loadJS(getURL('/settings/s.js?p=11'), false, ()=>{
-				d.um_p = [];
-				d.rsvd = [];
-				d.ro_gpio = [];
-				d.max_gpio = 50;
-				d.touch = [];
-			}, ()=>{
-				// Load extended GPIO info and start pin polling
-				loadPins();
-				pinsTimer = setInterval(loadPins, 250);
-			});
+			fetchPinInfo(()=>{ loadPins(); pinsTimer=setInterval(loadPins,250); });
 		}
 
 		function B(){window.open(getURL('/settings'),'_self');} // back button

--- a/wled00/data/settings_pininfo.htm
+++ b/wled00/data/settings_pininfo.htm
@@ -31,29 +31,6 @@
 
 		function B(){window.open(getURL('/settings'),'_self');} // back button
 
-		function getOwnerName(o,t,n) {
-			// Use firmware-provided name if available
-			if(n) return n;
-			if(!o) return "System"; // no owner provided
-			if(o===0x85){ return getBtnTypeName(t); } // button pin
-			return "UM #"+o;
-		}
-		function getBtnTypeName(t) {
-			var n=["None","Reserved","Push","Push Inv","Switch","PIR","Touch","Analog","Analog Inv","Touch Switch"];
-			var label = n[t] || "?";
-			return 'Button <span style="font-size:10px;color:#888">'+label+'</span>';
-		}
-		function getCaps(p,c) {
-			var r=[];
-			// Use touch info from settings endpoint
-			if(d.touch && d.touch.includes(p)) r.push("Touch");
-			if(d.ro_gpio && d.ro_gpio.includes(p)) r.push("Input Only");
-			// Use other caps from JSON (Analog, Boot, Input Only)
-			if(c&0x02) r.push("Analog");
-			if(c&0x08) r.push("Flash Boot");
-			if(c&0x10) r.push("Bootstrap");
-			return r.length?r.join(", "):"-";
-		}
 		function loadPins() {
 			fetch(getURL('/json/pins'),{method:'get'})
 			.then(r=>r.json())

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -49,9 +49,9 @@
 		return (loc ? locproto + "//" + locip : "") + path;
 	}
 	const dmxNs = ["IDMR","IDMT","IDME"];
-	let dmxOwnPins; // track dmx pins to update dropdowns
+	let dmxOwnPins; // track dmx pins to update dropdown restrictions on pin change
 	function pinDropdowns() {
-		dmxNs.forEach((n,i) => { const s = makePinSelect(n, i?1:0); if (s) s.onchange = dmxPinUpd; });
+		dmxNs.forEach((n,i) => { const s = makePinSelect(n, i?1:0); if (s) s.onchange = dmxPinUpd; }); // note on the i?1:0 -> RX pin is allowed input only but TX/EN pins must be GPIO
 		dmxOwnPins = dmxNs.map(n => parseInt(gN(n)?.value??-1));
 		dmxPinUpd();
 	}

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -42,11 +42,29 @@
 	function SetVal(){switch(parseInt(d.Sf.EP.value)){case 5568: d.Sf.DI.value = 5568; break; case 6454: d.Sf.DI.value = 6454; break; case 4048: d.Sf.DI.value = 4048; break; }; SP();FC();}
 	function S(){
 		getLoc();
-		loadJS(getURL('/settings/s.js?p=4'), false, undefined, ()=>{SetVal();});	// If we set async false, file is loaded and executed, then next statement is processed
+		loadJS(getURL('/settings/s.js?p=4'), false, undefined, ()=>{SetVal(); fetchPinInfo(pinDropdowns);});	// If we set async false, file is loaded and executed, then next statement is processed
 		if (loc) d.Sf.action = getURL('/settings/sync');
 	}
 	function getURL(path) {
 		return (loc ? locproto + "//" + locip : "") + path;
+	}
+	const dmxNs = ["IDMR","IDMT","IDME"];
+	let dmxOwnPins; // track dmx pins to update dropdowns
+	function pinDropdowns() {
+		dmxNs.forEach((n,i) => { const s = makePinSelect(n, i?1:0); if (s) s.onchange = dmxPinUpd; });
+		dmxOwnPins = dmxNs.map(n => parseInt(gN(n)?.value??-1));
+		dmxPinUpd();
+	}
+	function dmxPinUpd() {
+		const vs = dmxNs.map(n => parseInt(gN(n)?.value??-1));
+		dmxNs.forEach((n,i) => {
+			for (const o of gN(n)?.options??[]) {
+				const p = parseInt(o.value); if (p<0) continue;
+				// unlock old selected pin, lock newly selected one
+				o.disabled = (p!==vs[i] && !dmxOwnPins.includes(p) && !!d.pinsData?.find(pi=>pi.p===p)?.a) || vs.some((v,j)=>j!==i&&v===p);
+				if (!o.disabled) o.text = String(p); // clear owner name i.e. (DMX input)
+			}
+		});
 	}
 	function hideDMXInput(){gId("dmxInput").style.display="none";}
 	function hideNoDMXInput(){gId("dmxInputOff").style.display="none";}
@@ -126,8 +144,8 @@ Send notifications on direct change: <input type="checkbox" name="SD"><br>
 Send notifications on button press or IR: <input type="checkbox" name="SB"><br>
 Send Alexa notifications: <input type="checkbox" name="SA"><br>
 Send Philips Hue change notifications: <input type="checkbox" name="SH"><br>
-UDP packet retransmissions: <input name="UR" type="number" min="0" max="30" class="d5" required><br><br>
-<i>Reboot required to apply changes. </i>
+UDP packet retransmissions: <input name="UR" type="number" min="0" max="30" class="d5" required><br>
+<i class="warn">Reboot required to apply changes. </i>
 </div>
 <div class="sec">
 <h3>Instance List</h3>
@@ -139,7 +157,7 @@ Make this instance discoverable: <input type="checkbox" name="NB">
 Receive UDP realtime: <input type="checkbox" name="RD"><br>
 Use main segment only: <input type="checkbox" name="MO"><br>
 Respect LED Maps: <input type="checkbox" name="RLM"><br><br>
-<i>Network DMX input</i><br>
+<h4>Network DMX input</h4><br>
 Type:
 <select name=DI onchange="SP(); adj();">
 <option value=5568>E1.31 (sACN)</option>
@@ -174,12 +192,14 @@ Force max brightness: <input type="checkbox" name="FB"><br>
 Disable realtime gamma correction: <input type="checkbox" name="RG"><br>
 Realtime LED offset: <input name="WO" type="number" min="-255" max="255" required>
 <div id="dmxInput">
-	<h4>Wired DMX Input Pins</h4>
-	DMX RX: <input name="IDMR" type="number" min="-1" max="99">RO<br/>
-	DMX TX: <input name="IDMT" type="number" min="-1" max="99">DI<br/>
-	DMX Enable: <input name="IDME" type="number" min="-1" max="99">RE+DE<br/>
+	<br>
+	<h4>Wired DMX Input</h4>
+	DMX RX Pin: <input name="IDMR" type="number" min="-1" max="99">RO<br/>
+	DMX TX Pin: <input name="IDMT" type="number" min="-1" max="99">DI<br/>
+	DMX Enable Pin: <input name="IDME" type="number" min="-1" max="99">RE+DE<br/>
 	DMX Port: <input name="IDMP" type="number" min="1" max="2"><br/>
-</div> 
+	<i class="warn">Reboot required to apply changes.</i>
+</div>
 <div id="dmxInputOff">
 	<br><i class="warn">This firmware build does not include DMX Input support. <br></i>
 </div> 
@@ -223,7 +243,7 @@ Device Topic: <input type="text" name="MD" maxlength="32"><br>
 Group Topic: <input type="text" name="MG" maxlength="32"><br>
 Publish on button press: <input type="checkbox" name="BM"><br>
 Retain brightness & color messages: <input type="checkbox" name="RT"><br>
-<i>Reboot required to apply changes. </i><a href="https://kno.wled.ge/interfaces/mqtt/" target="_blank">MQTT info</a>
+<i class="warn">Reboot required to apply changes. </i><a href="https://kno.wled.ge/interfaces/mqtt/" target="_blank">MQTT info</a>
 </div>
 </div>
 <div class="sec">

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -7,7 +7,6 @@
 	<style> html { visibility: hidden; } </style> <!-- prevent white & ugly display while loading, unhidden in loadResources() -->
 	<script>
 	var umCfg = {};
-	var pins = [], pinO = [], owner;
 	var urows;
 	var numM = 0;
 	// load common.js with retry on error
@@ -32,7 +31,6 @@
 		})
 		.then(json => {
 			umCfg = json.um;
-			getPins(json);
 			urows="";
 			if (isO(umCfg)) {
 				for (const [k,o] of Object.entries(umCfg)) {
@@ -50,11 +48,9 @@
 				d.ro_gpio = [];
 				d.extra = [];
 			}, ()=>{
-				for (let r of d.rsvd) { pins.push(r); pinO.push("rsvd"); } // reserved pins
 				if (d.um_p[0]==-1) d.um_p.shift();	// remove filler
 				d.Sf.SDA.max = d.Sf.SCL.max = d.Sf.MOSI.max = d.Sf.SCLK.max = d.Sf.MISO.max = d.max_gpio;
-				//for (let i of d.getElementsByTagName("input")) if (i.type === "number" && i.name.replace("[]","").substr(-3) === "pin") i.max = d.max_gpio;
-				pinDD(); // convert INPUT to SELECT for pins
+				fetchPinInfo(pinDD); // load pin occupancy, then convert INPUT to SELECT for pins
 			});	// If we set async false, file is loaded and executed, then next statement is processed
 		})
 		.catch((error)=>{
@@ -90,28 +86,7 @@
 		}
 		*/
 	}
-	function getPins(o) {
-		if (isO(o)) {
-			for (const [k,v] of Object.entries(o)) {
-				if (isO(v)) {
-					let oldO = owner; // keep parent name
-					owner = k;
-					getPins(v);
-					owner = oldO;
-					continue;
-				}
-				if (k.replace("[]","").substr(-3)=="pin") {
-					if (Array.isArray(v)) {
-						for (var i=0; i<v.length; i++) if (v[i]>=0) { pins.push(v[i]); pinO.push(owner); }
-					} else {
-						if (v>=0) { pins.push(v); pinO.push(owner); }
-					}
-				} else if (Array.isArray(v)) {
-					for (var i=0; i<v.length; i++) getPins(v[i]);
-				}
-			}
-		}
-	}
+
 	function initCap(s) {
   		if (typeof s !== 'string') return '';
 		// https://www.freecodecamp.org/news/how-to-capitalize-words-in-javascript/
@@ -161,15 +136,17 @@
 			if (i.type === "number" && (i.name.includes("pin") || ["SDA","SCL","MOSI","MISO","SCLK"].includes(i.name))) { //select all pin select elements
 				let v = parseInt(i.value);
 				let sel = addDD(i.name,0);
+				if (!sel) continue;
 				for (var j = -1; j < d.max_gpio; j++) {
-					if (d.rsvd.includes(j)) continue;
-					let foundPin = pins.indexOf(j);
+					if (j > -1 && d.rsvd && d.rsvd.includes(j)) continue;
+					let pInfo = d.pinsData && d.pinsData.find(p => p.p === j);
+					let used = j > -1 && pInfo && pInfo.a && j !== v; // add owner info if used and not "our" pin
 					let txt = (j === -1) ? "unused" : `${j}`;
-					if (foundPin >= 0 && j !== v) txt += ` ${pinO[foundPin]=="if"?"global":pinO[foundPin]}`; // already reserved pin
-					if (d.ro_gpio.includes(j)) txt += " (R/O)";
+					if (used) txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
+					if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)"; // read-only pin
 					let opt = addO(sel, txt, j);
 					if (j === v) opt.selected = true; // this is "our" pin
-					else if (pins.includes(j)) opt.disabled = true; // someone else's pin
+					else if (used) opt.disabled = true; // someone else's pin
 				}
 				let um = i.name.split(":")[0];
 				d.extra.forEach((o)=>{

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -143,7 +143,7 @@
 					let used = j > -1 && pInfo && pInfo.a && j !== v; // add owner info if used and not "our" pin
 					let txt = (j === -1) ? "unused" : `${j}`;
 					if (used) txt += ` (${getOwnerName(pInfo.o, pInfo.t, pInfo.n)})`;
-					if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (R/O)"; // read-only pin
+					if (j > -1 && d.ro_gpio && d.ro_gpio.includes(j)) txt += " (input only)"; // read-only pin
 					let opt = addO(sel, txt, j);
 					if (j === v) opt.selected = true; // this is "our" pin
 					else if (used) opt.disabled = true; // someone else's pin
@@ -181,7 +181,7 @@
 						i.disabled = true;
 						i.text += ` ${txt}`;
 					}
-					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)";
+					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (input only)"; // read-only pin
 				}
 			});
 		}

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -7,7 +7,7 @@
 	<style> html { visibility: hidden; } </style> <!-- prevent white & ugly display while loading, unhidden in loadResources() -->
 	<script>
 	var umCfg = {};
-	var owner;
+	var pins = [], pinO = [], owner;
 	var urows;
 	var numM = 0;
 	// load common.js with retry on error
@@ -32,6 +32,7 @@
 		})
 		.then(json => {
 			umCfg = json.um;
+			getPins(json);
 			urows="";
 			if (isO(umCfg)) {
 				for (const [k,o] of Object.entries(umCfg)) {
@@ -47,26 +48,13 @@
 				d.um_p = [];
 				d.rsvd = [];
 				d.ro_gpio = [];
-				d.touch = [];
-				d.adc = [];
 				d.extra = [];
 			}, ()=>{
+				for (let r of d.rsvd) { pins.push(r); pinO.push("rsvd"); } // reserved pins
 				if (d.um_p[0]==-1) d.um_p.shift();	// remove filler
-				fetch(getURL('/json/pins')).then(r=>r.json()).then(j=>{
-					if (j && j.pins) {
-						let um = [];
-						d.pin_names = {};
-						j.pins.forEach(p => {
-							// Usermods (< 0x80), HW I2C (0x8B), HW SPI (0x8C)
-							if (p.a && !(p.o < 0x80 || p.o === 0x8B || p.o === 0x8C)) um.push(p.p);
-							if (p.n) d.pin_names[p.p] = p.n;
-						});
-						d.um_p = um;
-					}
-					pinDD();
-				}).catch(e=>{
-					pinDD();
-				});
+				d.Sf.SDA.max = d.Sf.SCL.max = d.Sf.MOSI.max = d.Sf.SCLK.max = d.Sf.MISO.max = d.max_gpio;
+				//for (let i of d.getElementsByTagName("input")) if (i.type === "number" && i.name.replace("[]","").substr(-3) === "pin") i.max = d.max_gpio;
+				pinDD(); // convert INPUT to SELECT for pins
 			});	// If we set async false, file is loaded and executed, then next statement is processed
 		})
 		.catch((error)=>{
@@ -101,6 +89,28 @@
 			}
 		}
 		*/
+	}
+	function getPins(o) {
+		if (isO(o)) {
+			for (const [k,v] of Object.entries(o)) {
+				if (isO(v)) {
+					let oldO = owner; // keep parent name
+					owner = k;
+					getPins(v);
+					owner = oldO;
+					continue;
+				}
+				if (k.replace("[]","").substr(-3)=="pin") {
+					if (Array.isArray(v)) {
+						for (var i=0; i<v.length; i++) if (v[i]>=0) { pins.push(v[i]); pinO.push(owner); }
+					} else {
+						if (v>=0) { pins.push(v); pinO.push(owner); }
+					}
+				} else if (Array.isArray(v)) {
+					for (var i=0; i<v.length; i++) getPins(v[i]);
+				}
+			}
+		}
 	}
 	function initCap(s) {
   		if (typeof s !== 'string') return '';
@@ -147,50 +157,110 @@
 		}
 	}
 	function pinDD() {
-		let hwPins = ["SDA","SCL","MOSI","MISO","SCLK"];
 		for (let i of d.Sf.elements) {
-			if (i.type !== "number") continue;
-			let isPin = i.name.replace("[]","").endsWith("pin") || hwPins.includes(i.name);
-			if (!isPin) continue;
-			// HW I2C/SPI pins need output capability; usermod pins allow any
-			let flags = hwPins.includes(i.name) ? 1 : 0;
-			let sel = makePinSelect(i.name, flags);
-			if (!sel) continue;
-			sel.setAttribute("onchange", "UI(this)");
-			// append d.extra special options (non-GPIO named pins)
-			let um = i.name.split(":")[0];
-			let v = parseInt(sel.dataset.val);
-			d.extra.forEach((o) => {
-				if (o[um] && o[um].pin) o[um].pin.forEach((e) => {
-					let opt = addOption(sel, e[0], e[1]);
-					if (e[1] == v) opt.selected = true;
+			if (i.type === "number" && (i.name.includes("pin") || ["SDA","SCL","MOSI","MISO","SCLK"].includes(i.name))) { //select all pin select elements
+				let v = parseInt(i.value);
+				let sel = addDD(i.name,0);
+				for (var j = -1; j < d.max_gpio; j++) {
+					if (d.rsvd.includes(j)) continue;
+					let foundPin = pins.indexOf(j);
+					let txt = (j === -1) ? "unused" : `${j}`;
+					if (foundPin >= 0 && j !== v) txt += ` ${pinO[foundPin]=="if"?"global":pinO[foundPin]}`; // already reserved pin
+					if (d.ro_gpio.includes(j)) txt += " (R/O)";
+					let opt = addO(sel, txt, j);
+					if (j === v) opt.selected = true; // this is "our" pin
+					else if (pins.includes(j)) opt.disabled = true; // someone else's pin
+				}
+				let um = i.name.split(":")[0];
+				d.extra.forEach((o)=>{
+					if (o[um] && o[um].pin) o[um].pin.forEach((e)=>{
+						let opt = addO(sel,e[0],e[1]);
+						if (e[1]==v) opt.selected = true;
+					});
 				});
-			});
+			}
 		}
 	}
 	function UI(e) {
 		// update changed select options across all usermods
 		let oldV = parseInt(e.dataset.val);
 		e.dataset.val = e.value;
-		let label = e.name.split(":").slice(-2,-1)[0] || e.name;
-		let selects = d.Sf.querySelectorAll("select.pin");
+		let txt = e.name.split(":")[e.name.split(":").length-2];
+		let selects = d.Sf.querySelectorAll("select[class='pin']");
 		for (let sel of selects) {
-			if (sel == e) continue;
-			Array.from(sel.options).forEach((i) => {
-				if (!(i.value == oldV || i.value == e.value)) return;
-				if (i.value == -1) { i.text = "unused"; return; }
-				if (parseInt(i.value) < d.max_gpio) { // skip d.extra named pins
+			if (sel == e) continue
+			Array.from(sel.options).forEach((i)=>{
+				if (!(i.value==oldV || i.value==e.value)) return;
+				if (i.value == -1) {
+					i.text = "unused";
+					return
+				}
+				if (i.value<100) { // TODO remove this hack and use d.extra
 					i.text = i.value;
-					if (i.value == oldV) i.disabled = false;
-					if (i.value == e.value) { i.disabled = true; i.text += ` ${label}`; }
+					if (i.value==oldV) {
+						i.disabled = false;
+					}
+					if (i.value==e.value) {
+						i.disabled = true;
+						i.text += ` ${txt}`;
+					}
 					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)";
 				}
 			});
 		}
 	}
-	function addDropdown(name, flags) { return makePinSelect(name, flags); } // backwards compatibility
-	function addDD(name, flags) { return makePinSelect(name, flags); }       // backwards compatibility
-	function addO(sel, txt, val) { return addOption(sel, txt, val); }        // backwards compatibility
+	// https://stackoverflow.com/questions/39729741/javascript-change-input-text-to-select-option
+	function addDD(um,fld) {
+		let sel = cE('select');
+		if (typeof(fld) === "string") {	// parameter from usermod (field name)
+			if (fld.includes("pin")) sel.classList.add("pin");
+			um += ":"+fld;
+		} else if (typeof(fld) === "number") sel.classList.add("pin"); // a hack to add a class
+		let arr = d.getElementsByName(um);
+		let idx = arr[0].type==="hidden"?1:0; // ignore hidden field
+		if (arr.length > 1+idx) {
+			// we have array of values (usually pins)
+			for (let i of arr) {
+				if (i.nodeName === "INPUT" && i.type === "number") break;
+				idx++;
+			}
+		}
+		let inp = arr[idx];
+		if (inp && inp.tagName === "INPUT" && (inp.type === "text" || inp.type === "number")) {  // may also use nodeName
+			let v = inp.value;
+			let n = inp.name;
+			// copy the existing input element's attributes to the new select element
+			for (var i = 0; i < inp.attributes.length; ++ i) {
+				var att = inp.attributes[i];
+				// type and value don't apply, so skip them
+				// ** you might also want to skip style, or others -- modify as needed **
+				if (att.name != 'type' && att.name != 'value' && att.name != 'class' && att.name != 'style' && att.name != 'oninput' && att.name != 'max' && att.name != 'min') {
+					sel.setAttribute(att.name, att.value);
+				}
+			}
+			sel.setAttribute("data-val", v);
+			sel.setAttribute("onchange", "UI(this)");
+			// finally, replace the old input element with the new select element
+			inp.parentElement.replaceChild(sel, inp);
+			return sel;
+		}
+		return null;
+	}
+	var addDropdown = addDD; // backwards compatibility
+	function addO(sel,txt,val) {
+		if (sel===null) return; // select object missing
+		let opt = cE("option");
+		opt.value = val;
+		opt.text = txt;
+		sel.appendChild(opt);
+		for (let i=0; i<sel.childNodes.length; i++) {
+			let c = sel.childNodes[i];
+			if (c.value == sel.dataset.val) sel.selectedIndex = i;
+		}
+		return opt;
+	}
+	var addOption = addO; // backwards compatibility
+	// https://stackoverflow.com/questions/26440494/insert-text-after-this-input-element-with-javascript
 	function addI(name,el,txt, txt2="") {
 		let obj = d.getElementsByName(name);
 		if (!obj.length) return;

--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -7,7 +7,7 @@
 	<style> html { visibility: hidden; } </style> <!-- prevent white & ugly display while loading, unhidden in loadResources() -->
 	<script>
 	var umCfg = {};
-	var pins = [], pinO = [], owner;
+	var owner;
 	var urows;
 	var numM = 0;
 	// load common.js with retry on error
@@ -32,7 +32,6 @@
 		})
 		.then(json => {
 			umCfg = json.um;
-			getPins(json);
 			urows="";
 			if (isO(umCfg)) {
 				for (const [k,o] of Object.entries(umCfg)) {
@@ -48,13 +47,26 @@
 				d.um_p = [];
 				d.rsvd = [];
 				d.ro_gpio = [];
+				d.touch = [];
+				d.adc = [];
 				d.extra = [];
 			}, ()=>{
-				for (let r of d.rsvd) { pins.push(r); pinO.push("rsvd"); } // reserved pins
 				if (d.um_p[0]==-1) d.um_p.shift();	// remove filler
-				d.Sf.SDA.max = d.Sf.SCL.max = d.Sf.MOSI.max = d.Sf.SCLK.max = d.Sf.MISO.max = d.max_gpio;
-				//for (let i of d.getElementsByTagName("input")) if (i.type === "number" && i.name.replace("[]","").substr(-3) === "pin") i.max = d.max_gpio;
-				pinDD(); // convert INPUT to SELECT for pins
+				fetch(getURL('/json/pins')).then(r=>r.json()).then(j=>{
+					if (j && j.pins) {
+						let um = [];
+						d.pin_names = {};
+						j.pins.forEach(p => {
+							// Usermods (< 0x80), HW I2C (0x8B), HW SPI (0x8C)
+							if (p.a && !(p.o < 0x80 || p.o === 0x8B || p.o === 0x8C)) um.push(p.p);
+							if (p.n) d.pin_names[p.p] = p.n;
+						});
+						d.um_p = um;
+					}
+					pinDD();
+				}).catch(e=>{
+					pinDD();
+				});
 			});	// If we set async false, file is loaded and executed, then next statement is processed
 		})
 		.catch((error)=>{
@@ -89,28 +101,6 @@
 			}
 		}
 		*/
-	}
-	function getPins(o) {
-		if (isO(o)) {
-			for (const [k,v] of Object.entries(o)) {
-				if (isO(v)) {
-					let oldO = owner; // keep parent name
-					owner = k;
-					getPins(v);
-					owner = oldO;
-					continue;
-				}
-				if (k.replace("[]","").substr(-3)=="pin") {
-					if (Array.isArray(v)) {
-						for (var i=0; i<v.length; i++) if (v[i]>=0) { pins.push(v[i]); pinO.push(owner); }
-					} else {
-						if (v>=0) { pins.push(v); pinO.push(owner); }
-					}
-				} else if (Array.isArray(v)) {
-					for (var i=0; i<v.length; i++) getPins(v[i]);
-				}
-			}
-		}
 	}
 	function initCap(s) {
   		if (typeof s !== 'string') return '';
@@ -157,110 +147,50 @@
 		}
 	}
 	function pinDD() {
+		let hwPins = ["SDA","SCL","MOSI","MISO","SCLK"];
 		for (let i of d.Sf.elements) {
-			if (i.type === "number" && (i.name.includes("pin") || ["SDA","SCL","MOSI","MISO","SCLK"].includes(i.name))) { //select all pin select elements
-				let v = parseInt(i.value);
-				let sel = addDD(i.name,0);
-				for (var j = -1; j < d.max_gpio; j++) {
-					if (d.rsvd.includes(j)) continue;
-					let foundPin = pins.indexOf(j);
-					let txt = (j === -1) ? "unused" : `${j}`;
-					if (foundPin >= 0 && j !== v) txt += ` ${pinO[foundPin]=="if"?"global":pinO[foundPin]}`; // already reserved pin
-					if (d.ro_gpio.includes(j)) txt += " (R/O)";
-					let opt = addO(sel, txt, j);
-					if (j === v) opt.selected = true; // this is "our" pin
-					else if (pins.includes(j)) opt.disabled = true; // someone else's pin
-				}
-				let um = i.name.split(":")[0];
-				d.extra.forEach((o)=>{
-					if (o[um] && o[um].pin) o[um].pin.forEach((e)=>{
-						let opt = addO(sel,e[0],e[1]);
-						if (e[1]==v) opt.selected = true;
-					});
+			if (i.type !== "number") continue;
+			let isPin = i.name.replace("[]","").endsWith("pin") || hwPins.includes(i.name);
+			if (!isPin) continue;
+			// HW I2C/SPI pins need output capability; usermod pins allow any
+			let flags = hwPins.includes(i.name) ? 1 : 0;
+			let sel = makePinSelect(i.name, flags);
+			if (!sel) continue;
+			sel.setAttribute("onchange", "UI(this)");
+			// append d.extra special options (non-GPIO named pins)
+			let um = i.name.split(":")[0];
+			let v = parseInt(sel.dataset.val);
+			d.extra.forEach((o) => {
+				if (o[um] && o[um].pin) o[um].pin.forEach((e) => {
+					let opt = addOption(sel, e[0], e[1]);
+					if (e[1] == v) opt.selected = true;
 				});
-			}
+			});
 		}
 	}
 	function UI(e) {
 		// update changed select options across all usermods
 		let oldV = parseInt(e.dataset.val);
 		e.dataset.val = e.value;
-		let txt = e.name.split(":")[e.name.split(":").length-2];
-		let selects = d.Sf.querySelectorAll("select[class='pin']");
+		let label = e.name.split(":").slice(-2,-1)[0] || e.name;
+		let selects = d.Sf.querySelectorAll("select.pin");
 		for (let sel of selects) {
-			if (sel == e) continue
-			Array.from(sel.options).forEach((i)=>{
-				if (!(i.value==oldV || i.value==e.value)) return;
-				if (i.value == -1) {
-					i.text = "unused";
-					return
-				}
-				if (i.value<100) { // TODO remove this hack and use d.extra
+			if (sel == e) continue;
+			Array.from(sel.options).forEach((i) => {
+				if (!(i.value == oldV || i.value == e.value)) return;
+				if (i.value == -1) { i.text = "unused"; return; }
+				if (parseInt(i.value) < d.max_gpio) { // skip d.extra named pins
 					i.text = i.value;
-					if (i.value==oldV) {
-						i.disabled = false;
-					}
-					if (i.value==e.value) {
-						i.disabled = true;
-						i.text += ` ${txt}`;
-					}
+					if (i.value == oldV) i.disabled = false;
+					if (i.value == e.value) { i.disabled = true; i.text += ` ${label}`; }
 					if (d.ro_gpio.includes(parseInt(i.value))) i.text += " (R/O)";
 				}
 			});
 		}
 	}
-	// https://stackoverflow.com/questions/39729741/javascript-change-input-text-to-select-option
-	function addDD(um,fld) {
-		let sel = cE('select');
-		if (typeof(fld) === "string") {	// parameter from usermod (field name)
-			if (fld.includes("pin")) sel.classList.add("pin");
-			um += ":"+fld;
-		} else if (typeof(fld) === "number") sel.classList.add("pin"); // a hack to add a class
-		let arr = d.getElementsByName(um);
-		let idx = arr[0].type==="hidden"?1:0; // ignore hidden field
-		if (arr.length > 1+idx) {
-			// we have array of values (usually pins)
-			for (let i of arr) {
-				if (i.nodeName === "INPUT" && i.type === "number") break;
-				idx++;
-			}
-		}
-		let inp = arr[idx];
-		if (inp && inp.tagName === "INPUT" && (inp.type === "text" || inp.type === "number")) {  // may also use nodeName
-			let v = inp.value;
-			let n = inp.name;
-			// copy the existing input element's attributes to the new select element
-			for (var i = 0; i < inp.attributes.length; ++ i) {
-				var att = inp.attributes[i];
-				// type and value don't apply, so skip them
-				// ** you might also want to skip style, or others -- modify as needed **
-				if (att.name != 'type' && att.name != 'value' && att.name != 'class' && att.name != 'style' && att.name != 'oninput' && att.name != 'max' && att.name != 'min') {
-					sel.setAttribute(att.name, att.value);
-				}
-			}
-			sel.setAttribute("data-val", v);
-			sel.setAttribute("onchange", "UI(this)");
-			// finally, replace the old input element with the new select element
-			inp.parentElement.replaceChild(sel, inp);
-			return sel;
-		}
-		return null;
-	}
-	var addDropdown = addDD; // backwards compatibility
-	function addO(sel,txt,val) {
-		if (sel===null) return; // select object missing
-		let opt = cE("option");
-		opt.value = val;
-		opt.text = txt;
-		sel.appendChild(opt);
-		for (let i=0; i<sel.childNodes.length; i++) {
-			let c = sel.childNodes[i];
-			if (c.value == sel.dataset.val) sel.selectedIndex = i;
-		}
-		return opt;
-	}
-	var addOption = addO; // backwards compatibility
-	// https://stackoverflow.com/questions/26440494/insert-text-after-this-input-element-with-javascript
+	function addDropdown(name, flags) { return makePinSelect(name, flags); } // backwards compatibility
+	function addDD(name, flags) { return makePinSelect(name, flags); }       // backwards compatibility
+	function addO(sel, txt, val) { return addOption(sel, txt, val); }        // backwards compatibility
 	function addI(name,el,txt, txt2="") {
 		let obj = d.getElementsByName(name);
 		if (!obj.length) return;

--- a/wled00/dmx_input.cpp
+++ b/wled00/dmx_input.cpp
@@ -122,7 +122,7 @@ bool DMXInput::installDriver()
   return true;
 }
 
-void DMXInput::init(uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint8_t inputPortNum)
+void DMXInput::init(int8_t rxPin, int8_t txPin, int8_t enPin, uint8_t inputPortNum)
 {
 
 #ifdef WLED_ENABLE_DMX_OUTPUT
@@ -142,7 +142,7 @@ void DMXInput::init(uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint8_t inputPo
     return;
   }
 
-  if (rxPin > 0 && enPin > 0 && txPin > 0) {
+  if (rxPin >= 0 && enPin >= 0 && txPin >= 0) {
 
     const managed_pin_type pins[] = {
         {(int8_t)txPin, false}, // these are not used as gpio pins, thus isOutput is always false.

--- a/wled00/dmx_input.h
+++ b/wled00/dmx_input.h
@@ -12,7 +12,7 @@
 class DMXInput
 {
 public:
-  void init(uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint8_t inputPortNum);
+  void init(int8_t rxPin, int8_t txPin, int8_t enPin, uint8_t inputPortNum);
   void update();
 
   /**disable dmx receiver (do this before disabling the cache)*/
@@ -54,9 +54,9 @@ private:
   friend void dmxReceiverTask(void * context);
 
   uint8_t inputPortNum = 255; 
-  uint8_t rxPin = 255;
-  uint8_t txPin = 255;
-  uint8_t enPin = 255;
+  int8_t rxPin = -1;
+  int8_t txPin = -1;
+  int8_t enPin = -1;
 
   /// is written to by the dmx receive task.
   byte dmxdata[DMX_PACKET_SIZE]; 
@@ -72,5 +72,5 @@ private:
   TaskHandle_t task;
   /// Guards access to dmxData
   std::mutex dmxDataLock;
-  
+
 };

--- a/wled00/pin_manager.h
+++ b/wled00/pin_manager.h
@@ -43,7 +43,7 @@ enum struct PinOwner : uint8_t {
   Relay         = 0x87,   // 'Rly'       == Relay pin from configuration
   SPI_RAM       = 0x88,   // 'SpiR'      == SPI RAM
   DebugOut      = 0x89,   // 'Dbg'       == debug output always IO1
-  DMX           = 0x8A,   // 'DMX'       == hard-coded to IO2
+  DMX           = 0x8A,   // 'DMX'       == DMX output, hard-coded to IO2
   HW_I2C        = 0x8B,   // 'I2C'       == hardware I2C pins (4&5 on ESP8266, 21&22 on ESP32)
   HW_SPI        = 0x8C,   // 'SPI'       == hardware (V)SPI pins (13,14&15 on ESP8266, 5,18&23 on ESP32)
   DMX_INPUT     = 0x8D,   // 'DMX_INPUT' == DMX input via serial

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -212,7 +212,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
       char ld[4] = "LD"; ld[2] = offset+s; ld[3] = 0; //driver type (RMT=0, I2S=1)
       char hs[4] = "HS"; hs[2] = offset+s; hs[3] = 0; //hostname (for network types, custom text for others)
       if (!request->hasArg(lp)) {
-        DEBUG_PRINTF_P(PSTR("# of buses: %d\n"), s+1);
+        DEBUG_PRINTF_P(PSTR("# of buses: %d\n"), s);
         break;
       }
       for (int i = 0; i < 5; i++) {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -469,9 +469,9 @@ WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to f
   WLED_GLOBAL uint16_t DMXStartLED _INIT(0);      // LED from which DMX fixtures start
 #endif
 #ifdef WLED_ENABLE_DMX_INPUT
-  WLED_GLOBAL int dmxInputTransmitPin _INIT(0);
-  WLED_GLOBAL int dmxInputReceivePin _INIT(0);
-  WLED_GLOBAL int dmxInputEnablePin _INIT(0);
+  WLED_GLOBAL int dmxInputTransmitPin _INIT(-1);
+  WLED_GLOBAL int dmxInputReceivePin _INIT(-1);
+  WLED_GLOBAL int dmxInputEnablePin _INIT(-1);
   WLED_GLOBAL int dmxInputPort _INIT(2);
   WLED_GLOBAL DMXInput dmxInput;
 #endif

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -185,6 +185,18 @@ static void appendGPIOinfo(Print& settingsScript)
   #else
   settingsScript.print(F("d.touch=[];"));
   #endif
+
+  // add info about ADC-capable GPIO (for analog button pin filtering)
+  settingsScript.print(F("d.adc=["));
+  firstPin = true;
+  for (unsigned i = 0; i < WLED_NUM_PINS; i++) {
+    if (PinManager::isAnalogPin(i)) {
+      if (!firstPin) settingsScript.print(',');
+      settingsScript.print(i);
+      firstPin = false;
+    }
+  }
+  settingsScript.print(F("];"));
 }
 
 //get values for settings form in javascript


### PR DESCRIPTION
Adding functions to easily create (restricted) dropdowns for pins and use those in LED settings and UM settings.

In LED settings pins are restricted by pinmanager, info about pin owner is also pulled from firmware. When populating a dropdown, flags can be passed and the dropdown will omit unusable pins i.e. does not show input only pins in LED outputs or non-analog or touch capable pins for analog/touch buttons. 

This restriction is not implemented for usermods (yet) - usermods still show pins without restrictions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebuilt pin-selection UI with dynamic dropdowns for LEDs, buttons and peripherals; can switch between numeric inputs and selects.
  * Asynchronous pin-info retrieval (with retries) exposing ADC/touch capabilities and human-readable owner/type labels.
  * New DMX pin dropdowns with clearer labels and reboot warning placement.

* **Bug Fixes**
  * Stronger validation for non‑virtual LED pins and type-aware conflict detection/clearing.
  * Pin option disabling now reflects actual occupancy.

* **Chores**
  * DMX input pins now default to unassigned at startup; DMX input pin handling updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->