### PR TITLE
Fix leak in blockRouterAdvertisements

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -377,6 +377,7 @@ bool isWiFiConfigured() {
 static u8_t blockRouterAdvertisements(void* arg, struct raw_pcb* pcb, struct pbuf* p, const ip_addr_t* addr) {
   // ICMPv6 type is the first byte of the payload, so we skip the header
   if (p->len > 0 && (pbuf_get_at(p, sizeof(struct ip6_hdr)) == ICMP6_TYPE_RA)) {
+    pbuf_free(p);
     return 1; // claim the packet — lwIP will not pass it further
   }
   return 0; // not consumed, pass it on


### PR DESCRIPTION
Fix memory leak introduced by #5438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak in network packet handling operations, improving system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->