### PR TITLE
prevent /upload from overwriting wsec.json

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -723,6 +723,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   if (pwdCorrect) { //only accept these values from cfg.json if ota is unlocked (else from wsec.json)
     CJSON(otaLock, ota[F("lock")]);
     CJSON(wifiLock, ota[F("lock-wifi")]);
+    CJSON(denyWsecUpload, ota[F("deny-wsec")]);
     #ifndef WLED_DISABLE_OTA
     CJSON(aOtaEnabled, ota[F("aota")]);
     #endif
@@ -1228,6 +1229,7 @@ void serializeConfig(JsonObject root) {
   JsonObject ota = root.createNestedObject("ota");
   ota[F("lock")] = otaLock;
   ota[F("lock-wifi")] = wifiLock;
+  ota[F("deny-wsec")] = denyWsecUpload;
   ota[F("pskl")] = strlen(otaPass);
   #ifndef WLED_DISABLE_OTA
   ota[F("aota")] = aOtaEnabled;
@@ -1303,6 +1305,7 @@ bool deserializeConfigSec() {
   getStringFromJson(otaPass, ota[F("pwd")], 33);
   CJSON(otaLock, ota[F("lock")]);
   CJSON(wifiLock, ota[F("lock-wifi")]);
+  CJSON(denyWsecUpload, ota[F("deny-wsec")]);
   #ifndef WLED_DISABLE_OTA
   CJSON(aOtaEnabled, ota[F("aota")]);
   #endif
@@ -1345,6 +1348,7 @@ void serializeConfigSec() {
   ota[F("pwd")] = otaPass;
   ota[F("lock")] = otaLock;
   ota[F("lock-wifi")] = wifiLock;
+  ota[F("deny-wsec")] = denyWsecUpload;
   #ifndef WLED_DISABLE_OTA
   ota[F("aota")] = aOtaEnabled;
   #endif

--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -55,7 +55,8 @@
 		The password should be changed when OTA is enabled.<br>
 		<b>Disable OTA when not in use, otherwise an attacker can reflash device software!</b><br>
 		<i>Settings on this page are only changeable if OTA lock is disabled!</i><br>
-		Deny access to WiFi settings if locked: <input type="checkbox" name="OW"><br><br>
+		Deny access to WiFi settings if locked: <input type="checkbox" name="OW"><br>
+        Deny uploading wsec.json file: <input type="checkbox" name="OU"><br><br>
 		Factory reset: <input type="checkbox" name="RS"><br>
 		All settings and presets will be erased.<br><br>
 		<div class="warn">&#9888; Unencrypted transmission. An attacker on the same network can intercept form data!</div>

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -663,6 +663,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     {
       otaLock = request->hasArg(F("NO"));
       wifiLock = request->hasArg(F("OW"));
+      denyWsecUpload = request->hasArg(F("OU"));
       #ifndef WLED_DISABLE_OTA
       aOtaEnabled = request->hasArg(F("AO"));
       #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -576,6 +576,7 @@ WLED_GLOBAL bool otaLock        _INIT(true);     // prevents OTA firmware update
 WLED_GLOBAL bool otaLock        _INIT(false);     // prevents OTA firmware updates without password. ALWAYS enable if system exposed to any public networks
 #endif
 WLED_GLOBAL bool wifiLock       _INIT(false);     // prevents access to WiFi settings when OTA lock is enabled
+WLED_GLOBAL bool denyWsecUpload _INIT(false);     // when true, POST /upload refuses to overwrite wsec.json
 #ifdef WLED_ENABLE_AOTA
 WLED_GLOBAL bool aOtaEnabled    _INIT(true);      // ArduinoOTA allows easy updates directly from the IDE. Careful, it does not auto-disable when OTA lock is on
 #else

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -199,7 +199,7 @@ static void handleUpload(AsyncWebServerRequest *request, const String& filename,
     return;
   }
 
-  if (filename.indexOf(FPSTR(s_wsec)) >= 0) {
+  if (denyWsecUpload && filename.indexOf(FPSTR(s_wsec)) >= 0) {
     if (isFinal) request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // block wsec.json
     return;
   }

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -200,7 +200,7 @@ static void handleUpload(AsyncWebServerRequest *request, const String& filename,
   }
 
   if (filename.indexOf(FPSTR(s_wsec)) >= 0) {
-    request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // skip wsec.json
+    if (isFinal) request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // block wsec.json
     return;
   }
 

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -204,6 +204,11 @@ static void handleUpload(AsyncWebServerRequest *request, const String& filename,
       finalname = '/' + finalname; // prepend slash if missing
     }
 
+    if (finalname.indexOf(FPSTR(s_wsec)) >= 0) {
+      request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // skip wsec.json
+      return;
+    }
+
     request->_tempFile = WLED_FS.open(finalname, "w");
     DEBUG_PRINTF_P(PSTR("Uploading %s\n"), finalname.c_str());
     if (finalname.equals(FPSTR(getPresetsFileName()))) presetsModifiedTime = toki.second();

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -198,15 +198,16 @@ static void handleUpload(AsyncWebServerRequest *request, const String& filename,
     if (isFinal) request->send(401, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_unlock_cfg));
     return;
   }
+
+  if (filename.indexOf(FPSTR(s_wsec)) >= 0) {
+    request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // skip wsec.json
+    return;
+  }
+
   if (!index) {
     String finalname = filename;
     if (finalname.charAt(0) != '/') {
       finalname = '/' + finalname; // prepend slash if missing
-    }
-
-    if (finalname.indexOf(FPSTR(s_wsec)) >= 0) {
-      request->send(403, FPSTR(CONTENT_TYPE_PLAIN), FPSTR(s_accessdenied)); // skip wsec.json
-      return;
     }
 
     request->_tempFile = WLED_FS.open(finalname, "w");

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -641,6 +641,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormValue(settingsScript,PSTR("PIN"),fpass);
     printSetFormCheckbox(settingsScript,PSTR("NO"),otaLock);
     printSetFormCheckbox(settingsScript,PSTR("OW"),wifiLock);
+    printSetFormCheckbox(settingsScript,PSTR("OU"),denyWsecUpload);
     printSetFormCheckbox(settingsScript,PSTR("AO"),aOtaEnabled);
     printSetFormCheckbox(settingsScript,PSTR("SU"),otaSameSubnet);
     char tmp_buf[128];


### PR DESCRIPTION
Currently it's possible for the `/upload` endpoint to overwrite `wsec.json` directly. This circumvents the `WLED_MAX_WIFI_COUNT` bounding and any other logic that occurs when wsec is updated the intended way via /settings. That makes it possible to upload otherwise invalid content to wsec.json like `{"nw":{"ins":[{},{},{},{},{},{},{} ...]}}` with lots empty objects which can cause the device to crash on boot up, effectively bricking it until the flash is wiped to get rid of the bad wsec.json file.

This change prevents it by checking for the wsec filename and returning `403` instead of allowing the upload, which is the same limitation already applied to /edit endpoint.

Does it compile? Yes

Does your feature/fix actually work? Yes, confirmed no longer able to overwrite wsec.json with the build from this branch.

Did you break anything else? Not to the best of my knowledge

Tested on actual hardware if possible? Yes, tested on ESP32 based Adafruit Mini Sparkle Motion device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security settings: added a checkbox to prevent uploading a sensitive security configuration file; choice is saved.
* **Bug Fixes**
  * Upload handling now rejects attempts to upload that sensitive security configuration when the new option is enabled, returning HTTP 403 "Access Denied" and preventing overwrite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->