### PR TITLE
Refactor wled-tools discover_devices for deduplication and clarity

### DIFF
--- a/tools/wled-tools
+++ b/tools/wled-tools
@@ -135,11 +135,11 @@ EOF
 }
 
 # Discover devices using mDNS
-discover_devices() {
-    if ! command -v avahi-browse &> /dev/null; then
+discover_devices() {  
+    if ! command -v avahi-browse &> /dev/null; then  
         log "ERROR" "$RED" "'avahi-browse' is required but not installed, please install avahi-utils using your preferred package manager."
-        exit 1
-    fi
+        exit 1  
+    fi  
 
     # Map avahi responses to strings separated by 0x1F (unit separator), deduplicated
     mapfile -t raw_devices < <(
@@ -152,15 +152,14 @@ discover_devices() {
         '
     )
 
-    local devices_array=()
-    local hostname address port
-    for device in "${raw_devices[@]}"; do
-        IFS=$'\x1F' read -r hostname address port <<< "$device"
-        devices_array+=("$hostname" "$address" "$port")
-    done
+    local devices_array=()  
+    for device in "${raw_devices[@]}"; do  
+        IFS=$'\x1F' read -r hostname address port <<< "$device"  
+        devices_array+=("$hostname" "$address" "$port")  
+    done  
 
-    echo "${devices_array[@]}"
-}
+    echo "${devices_array[@]}"  
+}  
 
 # Backup one device
 backup_one() {

--- a/tools/wled-tools
+++ b/tools/wled-tools
@@ -135,23 +135,32 @@ EOF
 }
 
 # Discover devices using mDNS
-discover_devices() {  
-    if ! command -v avahi-browse &> /dev/null; then  
+discover_devices() {
+    if ! command -v avahi-browse &> /dev/null; then
         log "ERROR" "$RED" "'avahi-browse' is required but not installed, please install avahi-utils using your preferred package manager."
-        exit 1  
-    fi  
+        exit 1
+    fi
 
-    # Map avahi responses to strings seperated by 0x1F (unit separator)
-    mapfile -t raw_devices < <(avahi-browse _wled._tcp --terminate -r -p | awk -F';' '/^=/ {print $7"\x1F"$8"\x1F"$9}')  
+    # Map avahi responses to strings separated by 0x1F (unit separator), deduplicated
+    mapfile -t raw_devices < <(
+        avahi-browse _wled._tcp --terminate -r -p |
+        awk -F';' '
+            /^=/ {
+                key = $7 "\x1F" $8 "\x1F" $9
+                if (!seen[key]++) print key
+            }
+        '
+    )
 
-    local devices_array=()  
-    for device in "${raw_devices[@]}"; do  
-        IFS=$'\x1F' read -r hostname address port <<< "$device"  
-        devices_array+=("$hostname" "$address" "$port")  
-    done  
+    local devices_array=()
+    local hostname address port
+    for device in "${raw_devices[@]}"; do
+        IFS=$'\x1F' read -r hostname address port <<< "$device"
+        devices_array+=("$hostname" "$address" "$port")
+    done
 
-    echo "${devices_array[@]}"  
-}  
+    echo "${devices_array[@]}"
+}
 
 # Backup one device
 backup_one() {


### PR DESCRIPTION
I've discovered that when we have multiple network interfaces, possible on different VLANs, which see the same mDNS entries, avahi will emit multiple entries (since it also keys on interface).

This change will make awk deduplicate, by only emitting unique name/ip/port pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device discovery now removes duplicate entries so each discovered device appears only once in scan results.
  * Discovery output remains compatible with existing parsing — format and emitted triplets are preserved to avoid breaking downstream consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->