### PR TITLE
fix: set valid default I2S pins for ESP32-C3 in audioreactive env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -548,6 +548,9 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
   ;-DARDUINO_USB_CDC_ON_BOOT=0   ;; for serial-to-USB chip
+  -D I2S_SDPIN=2   ; default AudioReactive I2S SD pin  (GPIO 2, valid on C3; change to match your mic wiring)
+  -D I2S_WSPIN=3   ; default AudioReactive I2S WS pin  (GPIO 3)
+  -D I2S_CKPIN=4   ; default AudioReactive I2S SCK pin (GPIO 4)
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 lib_deps = ${esp32c3.lib_deps}


### PR DESCRIPTION
## What                                                                                                                                                                                                        
                                                                                                                                                                                                                  
   AudioReactive crashes on ESP32-C3 with a watchdog bootloop and no WiFi AP when using default settings.                                                                                                         
                                                                                                                                                                                                                  
   ## Why
                                                                                                                                                                                                                  
   Default `i2ssdPin` is hardcoded to 32, but ESP32-C3 only has GPIOs 0–21. Pin allocation fails silently, GPIO 15 leaks as allocated, and `disableSoundProcessing` ends up `false` despite no working audio
   source (line 1475 overrides the check at 1472). Crash loop follows.

   ## Fix

   Define valid default pins for the C3 build env. Users can update them in the WLED settings UI to match their actual mic wiring.

   Tested on ESP32-C3-DevKitM-1, WLED 0.17.0-dev.
#5495 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio input hardware pin configuration for ESP32-C3 devices by establishing default audio interface pin mappings, ensuring proper audio hardware initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->