### PR TITLE
fix for serial port on esp32 (#5501)

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -11,6 +11,9 @@
 #include "soc/soc.h"
 #include "soc/rtc_cntl_reg.h"
 #endif
+#ifdef ARDUINO_ARCH_ESP32
+#include "driver/gpio.h"
+#endif
 
 extern "C" void usePWMFixedNMI();
 
@@ -368,13 +371,16 @@ void WLED::setup()
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detection
   #endif
 
-  #ifdef ARDUINO_ARCH_ESP32
-  pinMode(hardwareRX, INPUT_PULLDOWN); delay(1);        // suppress noise in case RX pin is floating (at low noise energy) - see issue #3128
-  #endif
   #ifdef WLED_BOOTUPDELAY
   delay(WLED_BOOTUPDELAY); // delay to let voltage stabilize, helps with boot issues on some setups
   #endif
   Serial.begin(115200);
+  #ifdef ARDUINO_ARCH_ESP32
+  // Pull down RX pin to suppress noise when floating, without breaking UART0 IOMUX mapping.
+  // pinMode() routes GPIO through the GPIO matrix and detaches UART0 RX - use gpio_pulldown_en() instead.
+  // See issue #3128.
+  gpio_pulldown_en((gpio_num_t)hardwareRX);
+  #endif
   #if !ARDUINO_USB_CDC_ON_BOOT
   Serial.setTimeout(50);  // this causes troubles on new MCUs that have a "virtual" USB Serial (HWCDC)
   #else


### PR DESCRIPTION
Possible fix for #5501
Tested on a real ESP32, and CI passes. It has not been tested on a real ESP8266.

This is my first pull request, so please feel free to reject it if anything is wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined ESP32 serial communication initialization during startup for improved stability and hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->