### PR TITLE
Add moving skip to Chase 2

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -543,26 +543,40 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 /*
  * Alternating pixels running function.
  */
-static void running(uint32_t color1, uint32_t color2, bool theatre = false) {
+static void running(uint32_t color1, uint32_t color2, bool theatre = false, int skip = 0) {
   int width = (theatre ? 3 : 1) + (SEGMENT.intensity >> 4);  // window
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
   bool usePalette = color1 == SEGCOLOR(0);
 
+  // skip>0: each stripe has (width) lit LEDs with (skip) blacks between them, plus a (skip)-wide
+  // black gap at each color transition. stripe_len = width*pitch - skip; period = 2*width*pitch.
+  int pitch = skip + 1;
+  int stripe_len = width * pitch - skip;
+  int period = theatre ? width : (2 * width * pitch);
+
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col = color2;
+    uint32_t col;
     if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
     if (theatre) {
-      if ((i % width) == SEGENV.aux0) col = color1;
+      col = ((i % width) == SEGENV.aux0) ? color1 : color2;
     } else {
-      int pos = (i % (width<<1));
-      if ((pos < SEGENV.aux0-width) || ((pos >= SEGENV.aux0) && (pos < SEGENV.aux0+width))) col = color1;
+      int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
+      if (pos < stripe_len) {
+        col = (pos % pitch == 0) ? color1 : 0;                              // foreground stripe
+      } else if (pos < stripe_len + skip) {
+        col = 0;                                                              // black gap after foreground
+      } else if (pos < 2 * stripe_len + skip) {
+        col = (((pos - stripe_len - skip) % pitch) == 0) ? color2 : 0;      // background stripe
+      } else {
+        col = 0;                                                              // black gap after background
+      }
     }
     SEGMENT.setPixelColor(i,col);
   }
 
   if (it != SEGENV.step) {
-    SEGENV.aux0 = (SEGENV.aux0 +1) % (theatre ? width : (width<<1));
+    SEGENV.aux0 = (SEGENV.aux0 + 1) % period;
     SEGENV.step = it;
   }
 }
@@ -1160,9 +1174,9 @@ static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@
  * Alternating color/sec pixels running.
  */
 void mode_running_color(void) {
-  running(SEGCOLOR(0), SEGCOLOR(1));
+  running(SEGCOLOR(0), SEGCOLOR(1), false, SEGMENT.custom1 >> 4);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width;!,!;!";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!;!;;c1=0";
 
 
 /*


### PR DESCRIPTION
I have added a new slider to Chase 2 that generates values between 0 and 15. When this slider is at its default value of 0, it behaves exactly like the current version of Chase 2. When the slider is greater than 0, it is treated as a skip value. At any instance in time, the result looks the same as when a skip is specified in the segment definition. However, when the stripe moves by one LED, it moves to the next physical LED, rather than the next lit LED. This results is the skips rotatings as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Skip control parameter to the running color effect, enabling customization of striped rendering patterns with variable gaps between stripes.

* **Improvements**
  * Enhanced the running color effect with improved animation progression and refined LED color assignment logic for better visual stripe pattern rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->