### PR TITLE
Add moving gap to Chase 2 version 2

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -543,34 +543,31 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 /*
  * Alternating pixels running function.
  */
-static void running(uint32_t color1, uint32_t color2, bool theatre = false, int skip = 0) {
-  int width = (theatre ? 3 : 1) + (SEGMENT.intensity >> 4);  // window
+static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip, int width) {
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
   bool usePalette = color1 == SEGCOLOR(0);
+  bool usePalette2 = usePalette && color2 == color1;
 
   // skip>0: each stripe has (width) lit LEDs with (skip) blacks between them, plus a (skip)-wide
   // black gap at each color transition. stripe_len = width*pitch - skip; period = 2*width*pitch.
   int pitch = skip + 1;
   int stripe_len = width * pitch - skip;
-  int period = theatre ? width : (2 * width * pitch);
+  int period = 2 * width * pitch;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col;
-    if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
-    if (theatre) {
-      col = ((i % width) == SEGENV.aux0) ? color1 : color2;
+    int col = color3;
+    int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
+    if (pos < stripe_len && (pos % pitch == 0)) {
+      if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
+      col = color1;                       // foreground stripe
+    } else if (pos < stripe_len + skip) {
+      // col already set
+    } else if (pos < 2 * stripe_len + skip && (pos % pitch == 0)) {
+      if (usePalette2) color2 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
+      col = color2;      // background stripe
     } else {
-      int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
-      if (pos < stripe_len) {
-        col = (pos % pitch == 0) ? color1 : 0;                              // foreground stripe
-      } else if (pos < stripe_len + skip) {
-        col = 0;                                                              // black gap after foreground
-      } else if (pos < 2 * stripe_len + skip) {
-        col = (((pos - stripe_len - skip) % pitch) == 0) ? color2 : 0;      // background stripe
-      } else {
-        col = 0;                                                              // black gap after background
-      }
+      // col already set
     }
     SEGMENT.setPixelColor(i,col);
   }
@@ -587,7 +584,9 @@ static void running(uint32_t color1, uint32_t color2, bool theatre = false, int 
  * Inspired by the Adafruit examples.
  */
 void mode_theater_chase(void) {
-  running(SEGCOLOR(0), SEGCOLOR(1), true);
+  uint32_t color = SEGCOLOR(0);
+  int skip = 2+(SEGMENT.intensity >> 4);
+  running(color, color, SEGCOLOR(1), skip, 1);
 }
 static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,!;!";
 
@@ -597,7 +596,9 @@ static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,
  * Inspired by the Adafruit examples.
  */
 void mode_theater_chase_rainbow(void) {
-  running(SEGMENT.color_wheel(SEGENV.step), SEGCOLOR(1), true);
+  uint32_t color = SEGMENT.color_wheel(SEGENV.step);  
+  int skip = 2+(SEGMENT.intensity >> 4);
+  running(color, color, SEGCOLOR(1), skip, 1);
 }
 static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainbow@!,Gap size;,!;!";
 
@@ -1174,9 +1175,11 @@ static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@
  * Alternating color/sec pixels running.
  */
 void mode_running_color(void) {
-  running(SEGCOLOR(0), SEGCOLOR(1), false, SEGMENT.custom1 >> 4);
+  int skip = SEGMENT.custom1 >> 4;
+  int width = 1+(SEGMENT.intensity >> 4);
+  running(SEGCOLOR(0), SEGCOLOR(1), SEGCOLOR(2), skip, width);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!;!;;c1=0";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!,!;!;;c1=0";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -544,6 +544,8 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
  * Alternating pixels running function.
  */
 static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip, int width) {
+  if (width < 1) width = 1;
+  if (skip < 0) skip = 0;
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
   bool usePalette = color1 == SEGCOLOR(0);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1175,11 +1175,11 @@ static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@
  * Alternating color/sec pixels running.
  */
 void mode_running_color(void) {
-  int gap = SEGMENT.custom1 >> 4;
+  int gap = SEGMENT.check2 ? SEGMENT.custom1 >> 4 : 0;
   int width = 1+(SEGMENT.intensity >> 4);
   running(SEGCOLOR(0), SEGCOLOR(1), SEGCOLOR(2), gap, width);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!,G;!;;c1=0";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Gap,,,,Gap;!,!,G;!;;c1=0";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -547,7 +547,8 @@ static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip,
   if (width < 1) width = 1;
   if (skip < 0) skip = 0;
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
-  uint32_t it = strip.now / cycleTime;  int pitch = skip + 1;
+  uint32_t it = strip.now / cycleTime;
+  int pitch = skip + 1;
   int stripe_len = width * pitch - skip;
   int period = 2 * width * pitch;
   int phase = SEGENV.aux0 % period;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -543,26 +543,40 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 /*
  * Alternating pixels running function.
  */
-static void running(uint32_t color1, uint32_t color2, bool theatre = false) {
+static void running(uint32_t color1, uint32_t color2, bool theatre = false, int skip = 0) {
   int width = (theatre ? 3 : 1) + (SEGMENT.intensity >> 4);  // window
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
   bool usePalette = color1 == SEGCOLOR(0);
 
+  // skip>0: each stripe has (width) lit LEDs with (skip) blacks between them, plus a (skip)-wide
+  // black gap at each color transition. stripe_len = width*pitch - skip; period = 2*width*pitch.
+  int pitch = skip + 1;
+  int stripe_len = width * pitch - skip;
+  int period = theatre ? width : (2 * width * pitch);
+
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col = color2;
+    uint32_t col;
     if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
     if (theatre) {
-      if ((i % width) == SEGENV.aux0) col = color1;
+      col = ((i % width) == SEGENV.aux0) ? color1 : color2;
     } else {
-      int pos = (i % (width<<1));
-      if ((pos < SEGENV.aux0-width) || ((pos >= SEGENV.aux0) && (pos < SEGENV.aux0+width))) col = color1;
+      int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
+      if (pos < stripe_len) {
+        col = (pos % pitch == 0) ? color1 : 0;                              // foreground stripe
+      } else if (pos < stripe_len + skip) {
+        col = 0;                                                              // black gap after foreground
+      } else if (pos < 2 * stripe_len + skip) {
+        col = (((pos - stripe_len - skip) % pitch) == 0) ? color2 : 0;      // background stripe
+      } else {
+        col = 0;                                                              // black gap after background
+      }
     }
     SEGMENT.setPixelColor(i,col);
   }
 
   if (it != SEGENV.step) {
-    SEGENV.aux0 = (SEGENV.aux0 +1) % (theatre ? width : (width<<1));
+    SEGENV.aux0 = (SEGENV.aux0 + 1) % period;
     SEGENV.step = it;
   }
 }
@@ -1160,9 +1174,9 @@ static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@
  * Alternating color/sec pixels running.
  */
 void mode_running_color(void) {
-  running(SEGCOLOR(0), SEGCOLOR(1));
+  running(SEGCOLOR(0), SEGCOLOR(1), false, SEGMENT.custom1 >> 4);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width;!,!;!";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!;!;;c1=0";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -1179,7 +1179,7 @@ void mode_running_color(void) {
   int width = 1+(SEGMENT.intensity >> 4);
   running(SEGCOLOR(0), SEGCOLOR(1), SEGCOLOR(2), gap, width);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Gap;!,!,!;!;;c1=0";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!,G;!;;c1=0";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -543,27 +543,27 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 /*
  * Alternating pixels running function.
  */
-static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip, int width) {
+static void running(uint32_t color1, uint32_t color2, uint32_t color3, int gap, int width) {
   if (width < 1) width = 1;
-  if (skip < 0) skip = 0;
+  if (gap < 0) gap = 0;
   uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
   uint32_t it = strip.now / cycleTime;
-  int pitch = skip + 1;
-  int stripe_len = width * pitch - skip;
+  int pitch = gap + 1;
+  int stripe_len = width * pitch - gap;
   int period = 2 * width * pitch;
-  int phase = SEGENV.aux0 % period;
+  SEGENV.aux0 %= period;
   bool usePalette = color1 == SEGCOLOR(0);
   bool usePalette2 = usePalette && color2 == color1;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
     int col = color3;
-    int pos = ((int)(i % period) - phase + period) % period;
+    int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
     if (pos < stripe_len && (pos % pitch == 0)) {
       if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
       col = color1;                       // foreground stripe
-    } else if (pos < stripe_len + skip) {
+    } else if (pos < stripe_len + gap) {
       // col already set
-    } else if (pos < 2 * stripe_len + skip && (pos % pitch == 0)) {
+    } else if (pos < 2 * stripe_len + gap && (pos % pitch == 0)) {
       if (usePalette2) color2 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
       col = color2;      // background stripe
     } else {
@@ -573,7 +573,7 @@ static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip,
   }
 
   if (it != SEGENV.step) {
-    SEGENV.aux0 = (phase + 1) % period;
+    ++SEGENV.aux0;
     SEGENV.step = it;
   }
 }
@@ -585,8 +585,8 @@ static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip,
  */
 void mode_theater_chase(void) {
   uint32_t color = SEGCOLOR(0);
-  int skip = 2+(SEGMENT.intensity >> 4);
-  running(color, color, SEGCOLOR(1), skip, 1);
+  int gap = 2+(SEGMENT.intensity >> 4);
+  running(color, color, SEGCOLOR(1), gap, 1);
 }
 static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,!;!";
 
@@ -597,8 +597,8 @@ static const char _data_FX_MODE_THEATER_CHASE[] PROGMEM = "Theater@!,Gap size;!,
  */
 void mode_theater_chase_rainbow(void) {
   uint32_t color = SEGMENT.color_wheel(SEGENV.step);  
-  int skip = 2+(SEGMENT.intensity >> 4);
-  running(color, color, SEGCOLOR(1), skip, 1);
+  int gap = 2+(SEGMENT.intensity >> 4);
+  running(color, color, SEGCOLOR(1), gap, 1);
 }
 static const char _data_FX_MODE_THEATER_CHASE_RAINBOW[] PROGMEM = "Theater Rainbow@!,Gap size;,!;!";
 
@@ -1175,11 +1175,11 @@ static const char _data_FX_MODE_CHASE_FLASH_RANDOM[] PROGMEM = "Chase Flash Rnd@
  * Alternating color/sec pixels running.
  */
 void mode_running_color(void) {
-  int skip = SEGMENT.custom1 >> 4;
+  int gap = SEGMENT.custom1 >> 4;
   int width = 1+(SEGMENT.intensity >> 4);
-  running(SEGCOLOR(0), SEGCOLOR(1), SEGCOLOR(2), skip, width);
+  running(SEGCOLOR(0), SEGCOLOR(1), SEGCOLOR(2), gap, width);
 }
-static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Skip;!,!,!;!;;c1=0";
+static const char _data_FX_MODE_RUNNING_COLOR[] PROGMEM = "Chase 2@!,Width,Gap;!,!,!;!;;c1=0";
 
 
 /*

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -546,10 +546,13 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip, int width) {
   if (width < 1) width = 1;
   if (skip < 0) skip = 0;
-  int pitch = skip + 1;
+  uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
+  uint32_t it = strip.now / cycleTime;  int pitch = skip + 1;
   int stripe_len = width * pitch - skip;
   int period = 2 * width * pitch;
   int phase = SEGENV.aux0 % period;
+  bool usePalette = color1 == SEGCOLOR(0);
+  bool usePalette2 = usePalette && color2 == color1;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
     int col = color3;

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -558,7 +558,7 @@ static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip,
   int period = 2 * width * pitch;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
-    int col = color3;
+    uint32_t col = color3;
     int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
     if (pos < stripe_len && (pos % pitch == 0)) {
       if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -546,20 +546,14 @@ static const char _data_FX_MODE_RAINBOW_CYCLE[] PROGMEM = "Rainbow@!,Size;;!";
 static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip, int width) {
   if (width < 1) width = 1;
   if (skip < 0) skip = 0;
-  uint32_t cycleTime = 50 + (255 - SEGMENT.speed);
-  uint32_t it = strip.now / cycleTime;
-  bool usePalette = color1 == SEGCOLOR(0);
-  bool usePalette2 = usePalette && color2 == color1;
-
-  // skip>0: each stripe has (width) lit LEDs with (skip) blacks between them, plus a (skip)-wide
-  // black gap at each color transition. stripe_len = width*pitch - skip; period = 2*width*pitch.
   int pitch = skip + 1;
   int stripe_len = width * pitch - skip;
   int period = 2 * width * pitch;
+  int phase = SEGENV.aux0 % period;
 
   for (unsigned i = 0; i < SEGLEN; i++) {
-    uint32_t col = color3;
-    int pos = ((int)(i % period) - (int)SEGENV.aux0 + period) % period;
+    int col = color3;
+    int pos = ((int)(i % period) - phase + period) % period;
     if (pos < stripe_len && (pos % pitch == 0)) {
       if (usePalette) color1 = SEGMENT.color_from_palette(i, true, PALETTE_SOLID_WRAP, 0);
       col = color1;                       // foreground stripe
@@ -575,7 +569,7 @@ static void running(uint32_t color1, uint32_t color2, uint32_t color3, int skip,
   }
 
   if (it != SEGENV.step) {
-    SEGENV.aux0 = (SEGENV.aux0 + 1) % period;
+    SEGENV.aux0 = (phase + 1) % period;
     SEGENV.step = it;
   }
 }


### PR DESCRIPTION
This PR is an alternate implementation for [PR-5504](https://github.com/wled/WLED/pull/5504). Only one or the other should be merged. Here is the description:

I have added a new slider to Chase 2 that generates values between 0 and 15. When this slider is at its default value of 0, it behaves exactly like the current version of Chase 2. When the slider is greater than 0, it is treated as a gap value. At any instance in time, the result looks the same as when a gap is specified in the segment definition. However, when the stripe moves by one LED, it moves to the next physical LED, rather than the next lit LED. This results is the gaps rotating as well.

In this PR, the gap color is controled by Cs (color 3) instead of always being black. I have also simplified the running() function so that the theater modes only differ from Chase 2 by the parameters that are passed. There is no special logic in the function to handle theater differently than chase. In this case, the theater BG color is the gap color and the theater width is the gap width.

In the previous PR the gap is called the skip value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Gap parameter to control stripe spacing.
  * Added a third color for off/filled regions to expand visual options.
  * Exposed Gap and Width in the Running Color effect metadata.

* **Refactor**
  * Reworked chase/running effects to a stripe-based model for finer control of width, spacing, motion, and color handling.
  * Safer parameter clamping and smoother, more predictable motion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->