### PR TITLE
Fix blending style options list filter for iOS

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -662,10 +662,9 @@ function parseInfo(i) {
 	mh = i.leds.matrix ? i.leds.matrix.h : 0;
 	isM = mw>0 && mh>0;
 	if (!bsOpts) bsOpts = Array.from(gId('bs').options).map(o => o.cloneNode(true)); // snapshot all options on first call
-	const bsSel = gId('bs'), bsCur = bsSel.value;
+	const bsSel = gId('bs');
 	// note: style.display='none' for option elements is not supported on all browsers (notably iOS)
 	bsSel.replaceChildren(...bsOpts.filter(o => isM || o.dataset.type !== "2D").map(o => o.cloneNode(true))); // allow all in matrix mode, filter 2D blends otherwise
-	if (!bsSel.value) bsSel.value = 0; // fall back to Fade if mode is no longer available
 	if (!isM) {
 			gId("filter2D").classList.add('hide'); // hide 2D effects in non-matrix mode
 	} else {
@@ -1461,7 +1460,9 @@ function readState(s,command=false)
 
 	tr = s.transition;
 	gId('tt').value = tr/10;
-	gId('bs').value = s.bs || 0;
+	const bsSel = gId('bs');
+	bsSel.value = s.bs || 0; // assign blending style
+	if (!bsSel.value) bsSel.value = 0; // fall back to Fade if option does not exist
 	if (tr===0) gId('bsp').classList.add('hide')
 	else gId('bsp').classList.remove('hide')
 

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -25,6 +25,7 @@ var pN = "", pI = 0, pNum = 0;
 var pmt = 1, pmtLS = 0;
 var lastinfo = {};
 var isM = false, mw = 0, mh=0;
+var bsOpts = null; // blending style options snapshot, used for dynamic filtering based on matrix mode (iOS compatibility)
 var ws, wsRpt=0;
 var cfg = {
 	theme:{base:"dark", bg:{url:"", rnd: false, rndGrayscale: false, rndBlur: false}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
@@ -660,12 +661,15 @@ function parseInfo(i) {
 	mw = i.leds.matrix ? i.leds.matrix.w : 0;
 	mh = i.leds.matrix ? i.leds.matrix.h : 0;
 	isM = mw>0 && mh>0;
+	if (!bsOpts) bsOpts = Array.from(gId('bs').options).map(o => o.cloneNode(true)); // snapshot all options on first call
+	const bsSel = gId('bs'), bsCur = bsSel.value;
+	// note: style.display='none' for option elements is not supported on all browsers (notably iOS)
+	bsSel.replaceChildren(...bsOpts.filter(o => isM || o.dataset.type !== "2D").map(o => o.cloneNode(true))); // allow all in matrix mode, filter 2D blends otherwise
+	if (!bsSel.value) bsSel.value = 0; // fall back to Fade if mode is no longer available
 	if (!isM) {
-		gId("filter2D").classList.add('hide');
-		gId('bs').querySelectorAll('option[data-type="2D"]').forEach((o,i)=>{o.style.display='none';});
+			gId("filter2D").classList.add('hide'); // hide 2D effects in non-matrix mode
 	} else {
-		gId("filter2D").classList.remove('hide');
-		gId('bs').querySelectorAll('option[data-type="2D"]').forEach((o,i)=>{o.style.display='';});
+			gId("filter2D").classList.remove('hide');
 	}
 	gId("updBt").style.display = (i.opt & 1) ? '':'none';
 //	if (i.noaudio) {


### PR DESCRIPTION
fixes #5498

tested and it fixes the issue on safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blending style handling between matrix and non-matrix modes so invalid or missing selections are reliably reset to a valid default.

* **Refactor**
  * Reworked option update logic to rebuild and filter blending choices more cleanly, improving reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->