### PR TITLE
Fix incomplete support for Audio Source - Network only - 8266 Audio Reactive 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -375,6 +375,7 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
   -D WLED_DISABLE_PARTICLESYSTEM2D
 lib_deps = ${esp8266.lib_deps}
 monitor_filters = esp8266_exception_decoder
+custom_usermods = audioreactive
 
 [env:nodemcuv2_compat]
 extends = env:nodemcuv2
@@ -384,6 +385,7 @@ platform_packages = ${esp8266.platform_packages_compat}
 build_flags = ${common.build_flags} ${esp8266.build_flags_compat} -D WLED_RELEASE_NAME=\"ESP8266_compat\" #-DWLED_DISABLE_2D
   -D WLED_DISABLE_PARTICLESYSTEM2D
 ;; lib_deps = ${esp8266.lib_deps_compat} ;; experimental - use older NeoPixelBus 2.7.9
+custom_usermods = audioreactive
 
 [env:nodemcuv2_160]
 extends = env:nodemcuv2
@@ -402,6 +404,7 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
   -D WLED_DISABLE_PARTICLESYSTEM2D
   -D WLED_DISABLE_PARTICLESYSTEM1D
 lib_deps = ${esp8266.lib_deps}
+custom_usermods = audioreactive
 
 [env:esp8266_2m_compat]
 extends = env:esp8266_2m
@@ -411,6 +414,7 @@ platform_packages = ${esp8266.platform_packages_compat}
 build_flags = ${common.build_flags} ${esp8266.build_flags_compat} -D WLED_RELEASE_NAME=\"ESP02_compat\" #-DWLED_DISABLE_2D
   -D WLED_DISABLE_PARTICLESYSTEM1D
   -D WLED_DISABLE_PARTICLESYSTEM2D
+custom_usermods = audioreactive
 
 [env:esp8266_2m_160]
 extends = env:esp8266_2m

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -758,6 +758,8 @@ class AudioReactive : public Usermod {
   private:
 #ifdef ARDUINO_ARCH_ESP32
 
+    static constexpr uint8_t SR_DMTYPE_NETWORK_ONLY = 254;
+
     #ifndef AUDIOPIN
     int8_t audioPin = -1;
     #else
@@ -1439,7 +1441,7 @@ class AudioReactive : public Usermod {
           break;
         #endif
 
-        case 254: // dummy "network receive only" mode
+        case SR_DMTYPE_NETWORK_ONLY: // dummy "network receive only" mode
           if (audioSource) delete audioSource; audioSource = nullptr;
           disableSoundProcessing = true;
           audioSyncEnabled = 2; // force udp sound receive mode
@@ -1456,7 +1458,7 @@ class AudioReactive : public Usermod {
       }
       delay(250); // give microphone enough time to initialise
 
-      if (!audioSource && (dmType != 254)) enabled = false;// audio failed to initialise
+      if (!audioSource && (dmType != SR_DMTYPE_NETWORK_ONLY)) enabled = false;// audio failed to initialise
 #endif
       if (enabled) onUpdateBegin(false);                 // create FFT task, and initialize network
 
@@ -1464,14 +1466,18 @@ class AudioReactive : public Usermod {
 #ifdef ARDUINO_ARCH_ESP32
       if (audioSource && FFT_Task == nullptr) enabled = false;          // FFT task creation failed
       if((!audioSource) || (!audioSource->isInitialized())) {  // audio source failed to initialize. Still stay "enabled", as there might be input arriving via UDP Sound Sync 
-        if (dmType < 254) {
+        if (dmType == SR_DMTYPE_NETWORK_ONLY) {
+        #ifdef WLED_DEBUG
+          DEBUG_PRINTLN(F("AR: No sound input driver configured - network receive only."));
+        #else
+          DEBUGSR_PRINTLN(F("AR: No sound input driver configured - network receive only."));
+        #endif
+        } else {
         #ifdef WLED_DEBUG
           DEBUG_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
         #else
           DEBUGSR_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
         #endif
-        } else {
-          DEBUG_PRINTLN(F("AR: No sound input driver configured - network receive only."));
         }
         disableSoundProcessing = true;
       }
@@ -2127,7 +2133,9 @@ class AudioReactive : public Usermod {
       uiScript.print(F("addOption(dd,'Generic PDM',5);"));
     #endif
     uiScript.print(F("addOption(dd,'ES8388',6);"));
-      uiScript.print(F("addOption(dd,'None - network receive only',254);"));
+      uiScript.print(F("addOption(dd,'None - network receive only',"));
+      uiScript.print(SR_DMTYPE_NETWORK_ONLY);
+      uiScript.print(F(");"));
     
       uiScript.print(F("dd=addDropdown(ux,'config:AGC');"));
       uiScript.print(F("addOption(dd,'Off',0);"));

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1466,19 +1466,17 @@ class AudioReactive : public Usermod {
 #ifdef ARDUINO_ARCH_ESP32
       if (audioSource && FFT_Task == nullptr) enabled = false;          // FFT task creation failed
       if((!audioSource) || (!audioSource->isInitialized())) {  // audio source failed to initialize. Still stay "enabled", as there might be input arriving via UDP Sound Sync 
+#ifdef WLED_DEBUG
+        #define AR_INIT_DEBUG_PRINT DEBUG_PRINTLN
+#else
+        #define AR_INIT_DEBUG_PRINT DEBUGSR_PRINTLN
+#endif
         if (dmType == SR_DMTYPE_NETWORK_ONLY) {
-        #ifdef WLED_DEBUG
-          DEBUG_PRINTLN(F("AR: No sound input driver configured - network receive only."));
-        #else
-          DEBUGSR_PRINTLN(F("AR: No sound input driver configured - network receive only."));
-        #endif
+          AR_INIT_DEBUG_PRINT(F("AR: No sound input driver configured - network receive only."));
         } else {
-        #ifdef WLED_DEBUG
-          DEBUG_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-        #else
-          DEBUGSR_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-        #endif
+          AR_INIT_DEBUG_PRINT(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
         }
+        #undef AR_INIT_DEBUG_PRINT
         disableSoundProcessing = true;
       }
 #endif

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -140,6 +140,7 @@ static uint8_t binNum = 8;           // Used to select the bin for FFT based bea
 #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
 #define UM_AUDIOREACTIVE_USE_INTEGER_FFT // always use integer FFT on ESP32-S2 and ESP32-C3
 #endif
+#endif // UM_AUDIOREACTIVE_USE_ARDUINO_FFT
 
 #if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
 using FFTsampleType = float;
@@ -163,7 +164,6 @@ static FFTsampleType* windowFFT = nullptr;
 #include "audio_source.h"
 constexpr i2s_port_t I2S_PORT = I2S_NUM_0;       // I2S port to use (do not change !)
 constexpr int BLOCK_SIZE = 128;                  // I2S buffer size (samples)
-#endif // ARDUINO_ARCH_ESP32
 
 // globals
 static uint8_t inputLevel = 128;              // UI slider value

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -140,7 +140,6 @@ static uint8_t binNum = 8;           // Used to select the bin for FFT based bea
 #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
 #define UM_AUDIOREACTIVE_USE_INTEGER_FFT // always use integer FFT on ESP32-S2 and ESP32-C3
 #endif
-#endif
 
 #if !defined(UM_AUDIOREACTIVE_USE_INTEGER_FFT)
 using FFTsampleType = float;
@@ -164,6 +163,7 @@ static FFTsampleType* windowFFT = nullptr;
 #include "audio_source.h"
 constexpr i2s_port_t I2S_PORT = I2S_NUM_0;       // I2S port to use (do not change !)
 constexpr int BLOCK_SIZE = 128;                  // I2S buffer size (samples)
+#endif // ARDUINO_ARCH_ESP32
 
 // globals
 static uint8_t inputLevel = 128;              // UI slider value
@@ -1462,13 +1462,17 @@ class AudioReactive : public Usermod {
 
 
 #ifdef ARDUINO_ARCH_ESP32
-      if (FFT_Task == nullptr) enabled = false;          // FFT task creation failed
+      if (audioSource && FFT_Task == nullptr) enabled = false;          // FFT task creation failed
       if((!audioSource) || (!audioSource->isInitialized())) {  // audio source failed to initialize. Still stay "enabled", as there might be input arriving via UDP Sound Sync 
-      #ifdef WLED_DEBUG
-        DEBUG_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-      #else
-        DEBUGSR_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
-      #endif
+        if (dmType < 254) {
+        #ifdef WLED_DEBUG
+          DEBUG_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
+        #else
+          DEBUGSR_PRINTLN(F("AR: Failed to initialize sound input driver. Please check input PIN settings."));
+        #endif
+        } else {
+          DEBUG_PRINTLN(F("AR: No sound input driver configured - network receive only."));
+        }
         disableSoundProcessing = true;
       }
 #endif
@@ -2123,6 +2127,7 @@ class AudioReactive : public Usermod {
       uiScript.print(F("addOption(dd,'Generic PDM',5);"));
     #endif
     uiScript.print(F("addOption(dd,'ES8388',6);"));
+      uiScript.print(F("addOption(dd,'None - network receive only',254);"));
     
       uiScript.print(F("dd=addDropdown(ux,'config:AGC');"));
       uiScript.print(F("addOption(dd,'Off',0);"));


### PR DESCRIPTION
This pull request primarily enables the `audioreactive` usermod for several ESP8266 build environments and improves the robustness and user feedback of the audio reactive module, especially for network-only sound input configurations. It also adds a new option in the UI for network-only audio input and makes some minor code organization improvements.

**PlatformIO build configuration:**

* Enabled the `audioreactive` usermod by adding `custom_usermods = audioreactive` to multiple ESP8266 build environments in `platformio.ini`, ensuring the audio reactive features are available in these builds. [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R378) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R388) [[3]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R407) [[4]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R417)

**Audio reactive usermod enhancements:**

* Improved error handling and debug output in `audio_reactive.cpp` to distinguish between sound input driver initialization failures and intentional network-only (UDP Sound Sync) configurations. Now, if no audio input driver is configured (dmType 254), a specific debug message is shown, and sound processing is disabled accordingly.
* Added a new dropdown option labeled "None - network receive only" (value 254) to the sound input driver selection in the UI, allowing users to explicitly choose a network-only audio input mode.

**Code organization and minor fixes:**

* Fixed preprocessor block endings and improved code clarity in `audio_reactive.cpp` for ESP32 architectures. [[1]](diffhunk://#diff-324d72c291197e55f58651df47dd3723d831a1e5031c1aa319d9e7d20b217cbbL143) [[2]](diffhunk://#diff-324d72c291197e55f58651df47dd3723d831a1e5031c1aa319d9e7d20b217cbbR166)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "None - network receive only" audio input mode in the UI.

* **Bug Fixes**
  * Clarified initialization messages for network-only audio mode.
  * Adjusted failure handling so audio processing stays enabled for network-only setups unless a local source is required.

* **Chores**
  * Enabled audio-reactive support for additional ESP8266 build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->