### PR TITLE
Add identifier string for DMX realtime mode

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -761,6 +761,7 @@ void serializeInfo(JsonObject root)
     case REALTIME_MODE_ARTNET:   root["lm"] = F("Art-Net"); break;
     case REALTIME_MODE_TPM2NET:  root["lm"] = F("tpm2.net"); break;
     case REALTIME_MODE_DDP:      root["lm"] = F("DDP"); break;
+    case REALTIME_MODE_DMX:      root["lm"] = F("DMX"); break;
   }
 
   root[F("lip")] = realtimeIP[0] == 0 ? "" : realtimeIP.toString();


### PR DESCRIPTION
Fix https://github.com/wled/WLED/issues/5509

Rebased on main, replaces #5511