### PR TITLE
docs: add DMX output board compatibility notes (fixes #1715, #4239)

### DIFF
--- a/docs/dmx-output.md
+++ b/docs/dmx-output.md
@@ -1,0 +1,21 @@
+# DMX Output Board Compatibility
+
+## Boards Without DMX Output Support
+
+The following ESP32 variants do NOT support DMX serial output in WLED:
+
+- ESP32-C3
+- ESP32-S2
+
+This is because WLED uses the SparkFun DMX driver for ESP32 boards,
+which requires Serial2. These boards do not have Serial2 available.
+
+## Recommended Alternatives
+
+If you need DMX output on a small board, use ESP32-S3 Mini or
+ESP32-S3 Zero instead.
+
+## Additional Hardware
+
+DMX output requires an RS485 transceiver such as the MAX485 chip
+connected between your ESP board and your DMX fixtures.

--- a/docs/dmx-output.md
+++ b/docs/dmx-output.md
@@ -17,5 +17,7 @@ ESP32-S3 Zero instead.
 
 ## Additional Hardware
 
-DMX output requires an RS485 transceiver such as the MAX485 chip
-connected between your ESP board and your DMX fixtures.
+DMX output requires an RS485 transceiver connected between your ESP 
+board and your DMX fixtures. The MAX485 is a commonly used example, 
+but other DMX-capable RS485 transceivers such as SN75176-class parts 
+are also valid when wired correctly.


### PR DESCRIPTION
This PR adds documentation clarifying which ESP32 board variants 
support DMX serial output and which do not.

Closes #1715
Closes #4239

The ESP32-C3 and ESP32-S2 do not support DMX output because the 
SparkFun DMX driver requires Serial2, which is unavailable on 
these boards. This information was confirmed by maintainer 
@softhack007 in issue #4239. ESP32-S3 is recommended as an 
alternative for users needing DMX output on a small form-factor board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added DMX output compatibility documentation: lists ESP32-C3 and ESP32-S2 as not supporting DMX output, recommends ESP32-S3 Mini or ESP32-S3 Zero for small hardware, and details hardware setup requirements.
  * Notes that DMX output requires an RS485 transceiver (example: MAX485) wired between the ESP board and DMX fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->