### PR TITLE
docs: add effect ID migration guide for 0.15 to 0.16 upgrade (refs #5…

### DIFF
--- a/docs/effect-id-migration.md
+++ b/docs/effect-id-migration.md
@@ -1,0 +1,25 @@
+# Effect ID Changes in WLED 0.16.0
+
+## Overview
+When upgrading from WLED 0.15.x to 0.16.0, presets that reference
+certain effects by ID may load an unexpected effect. This is because
+some effect IDs were reassigned in 0.16.0.
+
+## Known ID Changes
+
+| Old Effect (0.15.x) | Effect ID | New Effect (0.16.0) |
+|---------------------|-----------|----------------------|
+| Meteor Smooth       | 77        | Copy Segment         |
+
+## Symptoms
+If your preset was saved with "Meteor Smooth" in 0.15.x, it may
+activate "Copy Segment" after upgrading to 0.16.0, which can cause
+LEDs to strobe unexpectedly.
+
+## Fix
+Delete and recreate any affected presets after upgrading.
+
+## Workaround for Meteor Smooth
+The Meteor Smooth effect is still available in 0.16.0. Use the
+"Meteor" effect (ID 76) and enable the new "Smooth" checkbox option
+to replicate the previous behavior.


### PR DESCRIPTION
…506)
This PR adds documentation explaining the effect ID changes between 
WLED 0.15.x and 0.16.0 that cause presets to load unexpected effects 
after upgrading.

Refs #5506

In 0.15.x, "Meteor Smooth" used effect ID 77. In 0.16.0, ID 77 was 
reassigned to "Copy Segment", causing presets saved with "Meteor Smooth" 
to unexpectedly activate "Copy Segment" and strobe LEDs. This was 
confirmed by maintainer @softhack007 in the issue thread. The workaround 
(using Meteor effect ID 76 with the new Smooth checkbox) was confirmed 
by contributor @BobLoeffler68.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guide for WLED 0.16.0 upgrade. Documents effect ID reassignments that may cause existing presets to load different effects. Includes descriptions of potential symptoms, step-by-step fix instructions for affected presets, and workarounds to maintain desired effect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->