### PR TITLE
add placeholder to keep custom palette ID's consistent

### DIFF
--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -269,7 +269,10 @@ void loadCustomPalettes() {
     char fileName[32];
     sprintf_P(fileName, PSTR("/palette%d.json"), index);
     if (WLED_FS.exists(fileName)) {
-      emptyPaletteGap = 0; // reset gap counter if file exists
+      // add gray placeholders to preserve palette IDs for subsequent slots (is omitted in UI but shown in cpal.htm)
+      for (unsigned g = 0; g < emptyPaletteGap; g++)
+        customPalettes.push_back(CRGBPalette16(CRGB(128, 128, 128)));
+      emptyPaletteGap = 0;  // reset gap counter if file exists
       DEBUGFX_PRINTF_P(PSTR("Reading palette from %s\n"), fileName);
       if (readObjectFromFile(fileName, nullptr, &pDoc)) {
         JsonArray pal = pDoc[F("palette")];

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -993,6 +993,8 @@ function populatePalettes()
 	let li = lastinfo;
 	if (!isEmpty(li) && li.cpalcount) {
 		for (let j = 0; j<li.cpalcount; j++) {
+			const pd = palettesData[255-j];
+			if (pd && pd.length === 16 && pd.every(e => e[1] === 128 && e[2] === 128 && e[3] === 128)) continue; // skip all gray gap-placeholder entries
 			let div = d.createElement("div");
 			gId('pallist').appendChild(div);
 			div.outerHTML = generateListItemHtml(

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -774,7 +774,7 @@ void serializeInfo(JsonObject root)
 
   root[F("fxcount")] = strip.getModeCount();
   root[F("palcount")] = getPaletteCount();
-  root[F("cpalcount")] = customPalettes.size();   // number of custom palettes
+  root[F("cpalcount")] = customPalettes.size();   // number of custom palettes (includes gray placeholders)
   root[F("cpalmax")] = WLED_MAX_CUSTOM_PALETTES;  // maximum number of custom palettes
 
   JsonArray ledmaps = root.createNestedArray(F("maps"));


### PR DESCRIPTION
fix for #5533

when deleting custom palettes, they now keep their ID, leaving previously created presets unchanged. 
The "dummy" palettes inserted are gray, so if a custom palette that was used in a preset is deleted, it will end up as gray to indicate an empty palette. Also the "dummy" palettes are omitted in the custom palette list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved custom palette handling to properly manage missing palette files while maintaining correct palette indices and preventing placeholder entries from displaying in the palette list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->