### PR TITLE
Define default usermods

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -132,7 +132,6 @@ ldscript_4m1m = eagle.flash.4m1m.ld
 
 default_usermods = 
    audioreactive
-   multi_relay
    Temperature
 
 [scripts_defaults]

--- a/platformio.ini
+++ b/platformio.ini
@@ -130,6 +130,11 @@ ldscript_2m512k = eagle.flash.2m512.ld
 ldscript_2m1m = eagle.flash.2m1m.ld
 ldscript_4m1m = eagle.flash.4m1m.ld
 
+default_usermods = 
+   audioreactive
+   multi_relay
+   Temperature
+
 [scripts_defaults]
 extra_scripts =
   pre:pio-scripts/set_metadata.py
@@ -375,6 +380,7 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
   -D WLED_DISABLE_PARTICLESYSTEM2D
 lib_deps = ${esp8266.lib_deps}
 monitor_filters = esp8266_exception_decoder
+custom_usermods = ${common.default_usermods}
 
 [env:nodemcuv2_compat]
 extends = env:nodemcuv2
@@ -390,7 +396,7 @@ extends = env:nodemcuv2
 board_build.f_cpu = 160000000L
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP8266_160\" #-DWLED_DISABLE_2D
   -D WLED_DISABLE_PARTICLESYSTEM2D
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 
 [env:esp8266_2m]
 board = esp_wroom_02
@@ -418,7 +424,7 @@ board_build.f_cpu = 160000000L
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02_160\"
   -D WLED_DISABLE_PARTICLESYSTEM1D
   -D WLED_DISABLE_PARTICLESYSTEM2D
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 
 [env:esp01_1m_full]
 board = esp01_1m
@@ -458,7 +464,7 @@ board = esp32dev
 platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
 build_unflags = ${common.build_unflags}
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32\" #-D WLED_DISABLE_BROWNOUT_DET
               -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
 lib_deps = ${esp32_idf_V4.lib_deps}
@@ -477,7 +483,7 @@ build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags}
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_8M\" #-D WLED_DISABLE_BROWNOUT_DET
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
@@ -493,7 +499,7 @@ board_build.flash_mode = dio
 board = esp32dev
 platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_16M\" #-D WLED_DISABLE_BROWNOUT_DET
               -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
@@ -510,7 +516,7 @@ board = esp32-poe
 platform = ${esp32_idf_V4.platform}
 platform_packages = ${esp32_idf_V4.platform_packages}
 upload_speed = 921600
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32_Ethernet\" -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
   -D SR_DMTYPE=-1 -D AUDIOPIN=-1 -D I2S_SDPIN=-1 -D I2S_WSPIN=-1 -D I2S_CKPIN=-1 -D MCLK_PIN=-1 ;; force AR to not allocate any PINs at startup
@@ -527,7 +533,7 @@ board = ttgo-t7-v14-mini32
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = ${esp32.extended_partitions}
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_WROVER\"
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
@@ -542,7 +548,7 @@ platform_packages = ${esp32c3.platform_packages}
 framework = arduino
 board = esp32-c3-devkitm-1
 board_build.partitions = ${esp32.default_partitions}
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-C3\"
   -D WLED_WATCHDOG_TIMEOUT=0
   -DLOLIN_WIFI_FIX ; seems to work much better with this
@@ -565,7 +571,7 @@ board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
 platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_16MB_opi\"
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -587,7 +593,7 @@ board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
 platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_8MB_opi\"
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -621,7 +627,7 @@ platform_packages = ${esp32s3.platform_packages}
 board = esp32s3camlcd ;; this is the only standard board with "opi_opi"
 board_build.arduino.memory_type = opi_opi
 upload_speed = 921600
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2\"
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -662,7 +668,7 @@ board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM
 platform = ${esp32s3.platform}
 platform_packages = ${esp32s3.platform_packages}
 upload_speed = 921600
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_4M_qspi\"
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
@@ -682,7 +688,7 @@ board = lolin_s2_mini
 board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = qio
 board_build.f_flash = 80000000L
-custom_usermods = audioreactive
+custom_usermods = ${common.default_usermods}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S2\"
   -DARDUINO_USB_CDC_ON_BOOT=1


### PR DESCRIPTION
This pull request updates the `platformio.ini` configuration to centralize and standardize the definition of custom user modules across multiple build environments. The main change is the introduction of a `default_usermods` variable, which is then referenced throughout the configuration to ensure consistency and simplify future maintenance.

**Centralization of usermod configuration:**

* Added a new `default_usermods` variable under `[common]`, listing `audioreactive`, `multi_relay`, and `Temperature` as default user modules.
* Updated all build environments to use `custom_usermods = ${common.default_usermods}` instead of specifying user modules individually, replacing previous direct assignments like `custom_usermods = audioreactive`. [[1]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R383) [[2]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L393-R399) [[3]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L421-R427) [[4]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L461-R467) [[5]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L480-R486) [[6]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L496-R502) [[7]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L513-R519) [[8]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L530-R536) [[9]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L545-R551) [[10]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L568-R574) [[11]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L590-R596) [[12]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L624-R630) [[13]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L665-R671) [[14]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L685-R691)

This change improves maintainability by ensuring that updates to the default user modules only need to be made in a single location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized a shared default usermod list (now including audioreactive and Temperature) and updated multiple build environments to reference it, ensuring consistent inclusion of these core modules across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->