### PR TITLE
refactor platformio.ini to eliminate copy-paste duplication

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,40 +41,6 @@ extra_configs =
 
 [common]
 # ------------------------------------------------------------------------------
-# PLATFORM:
-#   !! DO NOT confuse platformio's ESP8266 development platform with Arduino core for ESP8266
-#
-#   arduino core 2.6.3 = platformIO 2.3.2
-#   arduino core 2.7.0 = platformIO 2.5.0
-# ------------------------------------------------------------------------------
-arduino_core_2_6_3 = espressif8266@2.3.3
-arduino_core_2_7_4 = espressif8266@2.6.2
-arduino_core_3_0_0 = espressif8266@3.0.0
-arduino_core_3_0_2 = espressif8266@3.2.0
-arduino_core_3_1_0 = espressif8266@4.1.0
-arduino_core_3_1_2 = espressif8266@4.2.1
-
-# Development platforms
-arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
-arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
-
-# Platform to use for ESP8266
-platform_wled_default = ${common.arduino_core_3_1_2}
-# We use 2.7.4.7 for all, includes PWM flicker fix and Wstring optimization
-#platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.200502
-                    platformio/tool-esptool #@ ~1.413.0
-                    platformio/tool-esptoolpy #@ ~1.30000.0
-
-## previous platform for 8266, in case of problems with the new one
-## you'll need  makuna/NeoPixelBus@ 2.6.9 for arduino_core_3_0_2, which does not support Ucs890x
-;; platform_wled_default = ${common.arduino_core_3_0_2}
-;; platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
-;;                    platformio/toolchain-xtensa @ ~2.40802.200502
-;;                    platformio/tool-esptool @ ~1.413.0
-;;                    platformio/tool-esptoolpy @ ~1.30000.0
-
-# ------------------------------------------------------------------------------
 # FLAGS: DEBUG
 # esp8266 : see https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
 # esp32   : see https://docs.platformio.org/en/latest/platforms/espressif32.html#debug-level
@@ -192,8 +158,41 @@ lib_deps =
 extra_scripts = ${scripts_defaults.extra_scripts}
 
 [esp8266]
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+# ------------------------------------------------------------------------------
+# PLATFORM:
+#   !! DO NOT confuse platformio's ESP8266 development platform with Arduino core for ESP8266
+#
+#   arduino core 2.6.3 = platformIO 2.3.2
+#   arduino core 2.7.0 = platformIO 2.5.0
+# ------------------------------------------------------------------------------
+arduino_core_2_6_3 = espressif8266@2.3.3
+arduino_core_2_7_4 = espressif8266@2.6.2
+arduino_core_3_0_0 = espressif8266@3.0.0
+arduino_core_3_0_2 = espressif8266@3.2.0
+arduino_core_3_1_0 = espressif8266@4.1.0
+arduino_core_3_1_2 = espressif8266@4.2.1
+
+# Development platforms
+arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
+arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
+
+# Platform to use for ESP8266
+platform_wled_default = ${esp8266.arduino_core_3_1_2}
+# We use 2.7.4.7 for all, includes PWM flicker fix and Wstring optimization
+#platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+platform_packages = platformio/toolchain-xtensa @ ~2.100300.220621 #2.40802.200502
+                    platformio/tool-esptool #@ ~1.413.0
+                    platformio/tool-esptoolpy #@ ~1.30000.0
+
+## previous platform for 8266, in case of problems with the new one
+## you'll need  makuna/NeoPixelBus@ 2.6.9 for arduino_core_3_0_2, which does not support Ucs890x
+;; platform_wled_default = ${esp8266.arduino_core_3_0_2}
+;; platform_packages = tasmota/framework-arduinoespressif8266 @ 3.20704.7
+;;                    platformio/toolchain-xtensa @ ~2.40802.200502
+;;                    platformio/tool-esptool @ ~1.413.0
+;;                    platformio/tool-esptoolpy @ ~1.30000.0
+
+platform = ${esp8266.platform_wled_default}
 build_unflags = ${common.build_unflags}
 build_flags =
   -DESP8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -192,6 +192,8 @@ lib_deps =
 extra_scripts = ${scripts_defaults.extra_scripts}
 
 [esp8266]
+platform = ${common.platform_wled_default}
+platform_packages = ${common.platform_packages}
 build_unflags = ${common.build_unflags}
 build_flags =
   -DESP8266
@@ -222,6 +224,8 @@ lib_deps =
   ESPAsyncUDP
   ESP8266PWM
   ${env.lib_deps}
+
+monitor_filters = esp8266_exception_decoder
 
 ;; compatibilty flags - same as 0.14.0 which seems to work better on some 8266 boards. Not using PIO_FRAMEWORK_ARDUINO_MMU_CACHE16_IRAM48
 build_flags_compat =
@@ -269,6 +273,7 @@ platform_packages =
 build_unflags = ${common.build_unflags}
 build_flags = ${esp32_idf_V4.build_flags}
 lib_deps = ${esp32_idf_V4.lib_deps}
+monitor_filters = esp32_exception_decoder
 
 tiny_partitions = tools/WLED_ESP32_2MB_noOTA.csv
 default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
@@ -321,6 +326,7 @@ build_flags = -g
 lib_deps =
   ${esp32_idf_V4.lib_deps}
 board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
+monitor_filters = esp32_exception_decoder
 
 [esp32c3]
 ;; generic definitions for all ESP32-C3 boards
@@ -340,6 +346,7 @@ lib_deps =
   ${esp32_idf_V4.lib_deps}
 board_build.partitions = ${esp32.default_partitions}   ;; default partioning for 4MB Flash - can be overridden in build envs
 board_build.flash_mode = qio
+monitor_filters = esp32_exception_decoder
 
 [esp32s3]
 ;; generic definitions for all ESP32-S3 boards
@@ -359,6 +366,8 @@ build_flags = -g
 lib_deps =
   ${esp32_idf_V4.lib_deps}
 board_build.partitions = ${esp32.large_partitions}   ;; default partioning for 8MB flash - can be overridden in build envs
+upload_speed = 921600
+monitor_filters = esp32_exception_decoder
 
 
 # ------------------------------------------------------------------------------
@@ -366,15 +375,11 @@ board_build.partitions = ${esp32.large_partitions}   ;; default partioning for 8
 # ------------------------------------------------------------------------------
 
 [env:nodemcuv2]
+extends = esp8266
 board = nodemcuv2
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP8266\" #-DWLED_DISABLE_2D
   -D WLED_DISABLE_PARTICLESYSTEM2D
-lib_deps = ${esp8266.lib_deps}
-monitor_filters = esp8266_exception_decoder
 
 [env:nodemcuv2_compat]
 extends = env:nodemcuv2
@@ -393,15 +398,12 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
 custom_usermods = audioreactive
 
 [env:esp8266_2m]
+extends = esp8266
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP02\"
   -D WLED_DISABLE_PARTICLESYSTEM2D
   -D WLED_DISABLE_PARTICLESYSTEM1D
-lib_deps = ${esp8266.lib_deps}
 
 [env:esp8266_2m_compat]
 extends = env:esp8266_2m
@@ -421,17 +423,14 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
 custom_usermods = audioreactive
 
 [env:esp01_1m_full]
+extends = esp8266
 board = esp01_1m
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=\"ESP01\" -D WLED_DISABLE_OTA
   ; -D WLED_USE_REAL_MATH ;; may fix wrong sunset/sunrise times, at the cost of 7064 bytes FLASH and 975 bytes RAM
   -D WLED_DISABLE_PARTICLESYSTEM1D
   -D WLED_DISABLE_PARTICLESYSTEM2D
   -D WLED_DISABLE_PIXELFORGE
-lib_deps = ${esp8266.lib_deps}
 
 [env:esp01_1m_full_compat]
 extends = env:esp01_1m_full
@@ -454,15 +453,11 @@ build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_RELEASE_NAME=
 custom_usermods = audioreactive
 
 [env:esp32dev]
+extends = esp32
 board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
-build_unflags = ${common.build_unflags}
 custom_usermods = audioreactive
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32\" #-D WLED_DISABLE_BROWNOUT_DET
               -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-lib_deps = ${esp32_idf_V4.lib_deps}
-monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = dio
 
@@ -474,50 +469,33 @@ build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags}
               -D WLED_RELEASE_NAME=\"ESP32_DEBUG\"
 
 [env:esp32dev_8M]
-board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
-custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
+extends = env:esp32dev
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_8M\" #-D WLED_DISABLE_BROWNOUT_DET
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-lib_deps = ${esp32_idf_V4.lib_deps}
-monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.large_partitions}
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
 ; board_build.f_flash = 80000000L
-board_build.flash_mode = dio
 
 [env:esp32dev_16M]
-board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
-custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
+extends = env:esp32dev
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_16M\" #-D WLED_DISABLE_BROWNOUT_DET
               -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-lib_deps = ${esp32_idf_V4.lib_deps}
-monitor_filters = esp32_exception_decoder
 board_build.partitions = ${esp32.extreme_partitions}
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.f_flash = 80000000L
-board_build.flash_mode = dio
 
 [env:esp32_eth]
+extends = esp32
 board = esp32-poe
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
 upload_speed = 921600
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32.build_flags} -D WLED_RELEASE_NAME=\"ESP32_Ethernet\" -D RLYPIN=-1 -D WLED_USE_ETHERNET -D BTNPIN=-1
   -D SR_DMTYPE=-1 -D AUDIOPIN=-1 -D I2S_SDPIN=-1 -D I2S_WSPIN=-1 -D I2S_CKPIN=-1 -D MCLK_PIN=-1 ;; force AR to not allocate any PINs at startup
   -D DATA_PINS=4 ;; default led pin = 16 conflicts with pins used for ethernet
   ; -D WLED_DISABLE_ESPNOW ;; ESP-NOW requires wifi, may crash with ethernet only => uncomment if your board uses ETH_CLOCK_GPIO0_OUT, ETH_CLOCK_GPIO16_OUT, ETH_CLOCK_GPIO17_OUT
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
-lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = dio
 
@@ -528,20 +506,14 @@ board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 board_build.partitions = ${esp32.extended_partitions}
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_WROVER\"
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; this flag is mandatory for "classic ESP32" when building with arduino-esp32 >=2.0.3
   -DBOARD_HAS_PSRAM -mfix-esp32-psram-cache-issue ;; Older ESP32 (rev.<3) need a PSRAM fix (increases static RAM used) https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/external-ram.html
   -D DATA_PINS=25
-lib_deps = ${esp32_idf_V4.lib_deps}
-  
+
 [env:esp32c3dev]
 extends = esp32c3
-platform = ${esp32c3.platform}
-platform_packages = ${esp32c3.platform_packages}
-framework = arduino
 board = esp32-c3-devkitm-1
-board_build.partitions = ${esp32.default_partitions}
 custom_usermods = audioreactive
 build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-C3\"
   -D WLED_WATCHDOG_TIMEOUT=0
@@ -549,8 +521,6 @@ build_flags = ${common.build_flags} ${esp32c3.build_flags} -D WLED_RELEASE_NAME=
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; for virtual CDC USB
   ;-DARDUINO_USB_CDC_ON_BOOT=0   ;; for serial-to-USB chip
 upload_speed = 460800
-build_unflags = ${common.build_unflags}
-lib_deps = ${esp32c3.lib_deps}
 board_build.flash_mode = dio ; safe default, required for OTA updates to 0.16 from older version which used dio (must match the bootloader!)
 
 [env:esp32c3dev_qio]
@@ -560,45 +530,34 @@ board_build.flash_mode = qio ; qio is faster and works on almost all boards (som
 
 [env:esp32s3dev_16MB_opi]
 ;; ESP32-S3 development board, with 16MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)
+extends = esp32s3
 board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
 board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
-upload_speed = 921600
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_16MB_opi\"
   -D WLED_WATCHDOG_TIMEOUT=0
   ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   -D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
-lib_deps = ${esp32s3.lib_deps}
 board_build.partitions = ${esp32.extreme_partitions}
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
 
 [env:esp32s3dev_8MB_opi]
 ;; ESP32-S3 development board, with 8MB FLASH and >= 8MB PSRAM (memory_type: qio_opi)
+extends = esp32s3
 board = esp32-s3-devkitc-1 ;; generic dev board; the next line adds PSRAM support
 board_build.arduino.memory_type = qio_opi     ;; use with PSRAM: 8MB or 16MB
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
-upload_speed = 921600
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_8MB_opi\"
   -D WLED_WATCHDOG_TIMEOUT=0
   ;-D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
   -D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
-lib_deps = ${esp32s3.lib_deps}
-board_build.partitions = ${esp32.large_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
 
 [env:esp32s3dev_8MB_qspi]
 ;; generic ESP32-S3 board with 8MB FLASH and PSRAM (memory_type: qio_qspi). Try this one if esp32s3dev_8MB_opi does not work on your board
@@ -611,18 +570,14 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   -D ARDUINO_USB_CDC_ON_BOOT=1 ;; -D ARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   ;; -DLOLIN_WIFI_FIX ;; uncomment if you have WiFi connectivity problems
-monitor_filters = esp32_exception_decoder
 
 [env:esp32S3_wroom2]
 ;; For ESP32-S3 WROOM-2, a.k.a. ESP32-S3 DevKitC-1 v1.1
 ;; with >= 16MB FLASH and >= 8MB PSRAM (memory_type: opi_opi)
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
+extends = esp32s3
 board = esp32s3camlcd ;; this is the only standard board with "opi_opi"
 board_build.arduino.memory_type = opi_opi
-upload_speed = 921600
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2\"
   -D WLED_WATCHDOG_TIMEOUT=0
   -D ARDUINO_USB_CDC_ON_BOOT=0  ;; -D ARDUINO_USB_MODE=1 ;; for boards with serial-to-USB chip
@@ -632,12 +587,9 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
   -D BTNPIN=0 -D RLYPIN=16 -D IRPIN=17 -D AUDIOPIN=-1
   ;;-D WLED_DEBUG
   -D SR_DMTYPE=1 -D I2S_SDPIN=13 -D I2S_CKPIN=14 -D I2S_WSPIN=15 -D MCLK_PIN=4  ;; I2S mic
-lib_deps = ${esp32s3.lib_deps}
-
 board_build.partitions = ${esp32.extreme_partitions}
 board_upload.flash_size = 16MB
 board_upload.maximum_size = 16777216
-monitor_filters = esp32_exception_decoder
 
 [env:esp32S3_wroom2_32MB]
 ;; For ESP32-S3 WROOM-2 with 32MB Flash, and >= 8MB PSRAM (memory_type: opi_opi)
@@ -654,36 +606,27 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=
 board_build.partitions = tools/WLED_ESP32_32MB.csv
 board_upload.flash_size = 32MB
 board_upload.maximum_size = 33554432
-monitor_filters = esp32_exception_decoder
 
 [env:esp32s3_4M_qspi]
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
-board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM 
-platform = ${esp32s3.platform}
-platform_packages = ${esp32s3.platform_packages}
-upload_speed = 921600
+extends = esp32s3
+board = lolin_s3_mini ;; -S3 mini, 4MB flash 2MB PSRAM
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_4M_qspi\"
   -DARDUINO_USB_CDC_ON_BOOT=1 ;; -DARDUINO_USB_MODE=1      ;; for boards with USB-OTG connector only (USBCDC or "TinyUSB")
   -DBOARD_HAS_PSRAM
   -DLOLIN_WIFI_FIX ; seems to work much better with this
   -D WLED_WATCHDOG_TIMEOUT=0
-lib_deps = ${esp32s3.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
-monitor_filters = esp32_exception_decoder
 
 [env:lolin_s2_mini]
-platform = ${esp32s2.platform}
-platform_packages = ${esp32s2.platform_packages}
+extends = esp32s2
 board = lolin_s2_mini
-board_build.partitions = ${esp32.default_partitions}
 board_build.flash_mode = qio
 board_build.f_flash = 80000000L
 custom_usermods = audioreactive
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S2\"
   -DARDUINO_USB_CDC_ON_BOOT=1
   -DARDUINO_USB_MSC_ON_BOOT=0
@@ -698,18 +641,11 @@ build_flags = ${common.build_flags} ${esp32s2.build_flags} -D WLED_RELEASE_NAME=
   -D HW_PIN_DATASPI=11
   -D HW_PIN_MISOSPI=9
 ;  -D STATUSLED=15
-lib_deps = ${esp32s2.lib_deps}
 
 
 [env:usermods]
-board = esp32dev
-platform = ${esp32_idf_V4.platform}
-platform_packages = ${esp32_idf_V4.platform_packages}
-build_unflags = ${common.build_unflags}
+extends = env:esp32dev
 build_flags = ${common.build_flags} ${esp32_idf_V4.build_flags} -D WLED_RELEASE_NAME=\"ESP32_USERMODS\"
   -DTOUCH_CS=9
-lib_deps = ${esp32_idf_V4.lib_deps}
-monitor_filters = esp32_exception_decoder
-board_build.flash_mode = dio
 custom_usermods = *   ; Expands to all usermods in usermods folder
 board_build.partitions = ${esp32.extreme_partitions}  ; We're gonna need a bigger boat

--- a/platformio_override.sample.ini
+++ b/platformio_override.sample.ini
@@ -13,8 +13,8 @@ default_envs = WLED_generic8266_1M, esp32dev_V4_dio80  # put the name(s) of your
 [env:WLED_generic8266_1M]
 extends = env:esp01_1m_full  # when you want to extend the existing environment (define only updated options)
 ; board = esp01_1m  # uncomment when ou need different board
-; platform = ${common.platform_wled_default}  # uncomment and change when you want particular platform
-; platform_packages = ${common.platform_packages}
+; platform = ${esp8266.platform_wled_default}  # uncomment and change when you want particular platform
+; platform_packages = ${esp8266.platform_packages}
 ; board_build.ldscript = ${common.ldscript_1m128k}
 ; upload_speed = 921600 # fast upload speed (remove ';' if your board supports fast upload speed)
 # Sample libraries used for various usermods. Uncomment when using particular usermod.
@@ -214,8 +214,8 @@ build_flags =
 
 [env:esp07]
 board = esp07
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}
@@ -223,8 +223,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:d1_mini]
 board = d1_mini
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 upload_speed = 921600
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
@@ -234,8 +234,8 @@ monitor_filters = esp8266_exception_decoder
 
 [env:heltec_wifi_kit_8]
 board = d1_mini
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}
@@ -243,8 +243,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:h803wf]
 board = d1_mini
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=1 -D WLED_DISABLE_INFRARED
@@ -294,8 +294,8 @@ board_build.arduino.memory_type = qio_qspi ;; use with PSRAM: 2MB or  4MB
 
 [env:esp8285_4CH_MagicHome]
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_DISABLE_OTA
@@ -303,8 +303,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:esp8285_H801]
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_DISABLE_OTA
@@ -312,8 +312,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:d1_mini_5CH_Shojo_PCB]
 board = d1_mini
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_USE_SHOJO_PCB ;; NB: WLED_USE_SHOJO_PCB is not used anywhere in the source code. Not sure why its needed.
@@ -322,8 +322,8 @@ lib_deps = ${esp8266.lib_deps}
 [env:d1_mini_debug]
 board = d1_mini
 build_type = debug
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} ${common.debug_flags}
@@ -334,8 +334,8 @@ board = d1_mini
 upload_protocol = espota
 # exchange for your WLED IP
 upload_port = "10.10.1.27"
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}
@@ -343,8 +343,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:anavi_miracle_controller]
 board = d1_mini
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=12 -D IRPIN=-1 -D RLYPIN=2
@@ -412,22 +412,22 @@ build_flags = ${common.build_flags} ${esp32.build_flags} -D DATA_PINS=27 -D BTNP
 
 [env:sp501e]
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
+platform = ${esp8266.platform_wled_default}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=3 -D BTNPIN=1
 lib_deps = ${esp8266.lib_deps}
 
 [env:sp511e]
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
+platform = ${esp8266.platform_wled_default}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D DATA_PINS=3 -D BTNPIN=2 -D IRPIN=5 -D WLED_MAX_BUTTONS=3
 lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_RGBCW]        ;7w and 5w(GU10) bulbs
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=-1 -D RLYPIN=-1 -D DATA_PINS=4,12,14,13,5
@@ -436,8 +436,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_15w_RGBCW]        ;15w bulb
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=-1 -D RLYPIN=-1 -D DATA_PINS=4,12,14,5,13
@@ -446,8 +446,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_3Pin_Controller]        ;small controller with only data
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=0 -D RLYPIN=-1 -D DATA_PINS=1 -D WLED_DISABLE_INFRARED
@@ -455,8 +455,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_4Pin_Controller]       ; With clock and data interface
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=0 -D RLYPIN=12 -D DATA_PINS=1 -D WLED_DISABLE_INFRARED
@@ -464,8 +464,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:Athom_5Pin_Controller]      ;Analog light strip controller
 board = esp8285
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D BTNPIN=0 -D RLYPIN=-1 DATA_PINS=4,12,14,13 -D WLED_DISABLE_INFRARED
@@ -473,8 +473,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:MY9291]
 board = esp01_1m
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_1m128k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags} -D WLED_DISABLE_OTA -D USERMOD_MY9291
@@ -487,8 +487,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:codm-controller-0_6]
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_2m512k}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}
@@ -496,8 +496,8 @@ lib_deps = ${esp8266.lib_deps}
 
 [env:codm-controller-0_6-rev2]
 board = esp_wroom_02
-platform = ${common.platform_wled_default}
-platform_packages = ${common.platform_packages}
+platform = ${esp8266.platform_wled_default}
+platform_packages = ${esp8266.platform_packages}
 board_build.ldscript = ${common.ldscript_4m1m}
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp8266.build_flags}


### PR DESCRIPTION
Centralise platform, platform_packages, build_unflags, lib_deps and monitor_filters into the per-chipset abstract sections ([esp8266], [esp32], [esp32s2], [esp32c3], [esp32s3]) and have concrete envs inherit via extends rather than repeating the same values.

- [esp8266]: add platform, platform_packages, monitor_filters
- [esp32]: add monitor_filters
- [esp32s2]: add monitor_filters
- [esp32c3]: add monitor_filters
- [esp32s3]: add upload_speed, monitor_filters
- esp8266 envs (nodemcuv2, esp8266_2m, esp01_1m_full): extends = esp8266
- esp32dev: extends = esp32
- esp32dev_8M, esp32dev_16M: extends = env:esp32dev
- esp32_eth, usermods: extends = esp32 / env:esp32dev
- esp32_wrover: drop redundant build_unflags, lib_deps (already extends esp32_idf_V4)
- esp32c3dev: drop redundant platform, platform_packages, framework, build_unflags, lib_deps, board_build.partitions (already extends esp32c3)
- esp32s3 envs: extends = esp32s3
- lolin_s2_mini: extends = esp32s2

No functional changes. Verified with pio run across all five chipset families (ESP8266, ESP32, C3, S3, S2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated build environment configs to use shared platform groups for ESP8266, ESP32, ESP32-S2, ESP32-S3, and ESP32-C3, reducing duplication.
  * Centralized monitor filter settings and standardized inheritance across environments.

* **Chores**
  * Increased default upload speed for ESP32-S3 devices.
  * Updated sample override templates to explicitly reference ESP8266 platform/package variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->