### PR TITLE
Name CI artifacts by WLED_RELEASE_NAME instead of PlatformIO env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         if [ -n "$bin" ]; then
           # Strip WLED_<version>_ prefix from WLED_<version>_<RELEASE_NAME>.bin
           base=$(basename "$bin" .bin)
-          release_name=$(echo "$base" | sed 's/^WLED_[^_]*_//')
+          release_name=$(echo "$base" | sed 's/^[^_]*_[^_]*_//')
           echo "name=firmware-$release_name" >> $GITHUB_OUTPUT
         else
           echo "name=firmware-${{ matrix.environment }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,9 +63,21 @@ jobs:
 
     - name: Build firmware
       run: pio run -e ${{ matrix.environment }}
+    - name: Get artifact name from bin filename
+      id: artifact_name
+      run: |
+        bin=$(ls build_output/release/*.bin 2>/dev/null | head -1)
+        if [ -n "$bin" ]; then
+          # Strip WLED_<version>_ prefix from WLED_<version>_<RELEASE_NAME>.bin
+          base=$(basename "$bin" .bin)
+          release_name=$(echo "$base" | sed 's/^WLED_[^_]*_//')
+          echo "name=firmware-$release_name" >> $GITHUB_OUTPUT
+        else
+          echo "name=firmware-${{ matrix.environment }}" >> $GITHUB_OUTPUT
+        fi
     - uses: actions/upload-artifact@v4
       with:
-        name: firmware-${{ matrix.environment }}
+        name: ${{ steps.artifact_name.outputs.name }}
         path: |
           build_output/release/*.bin
           build_output/release/*_ESP02*.bin.gz


### PR DESCRIPTION
PR build artifact zips are now named firmware-<RELEASE_NAME> (e.g. firmware-ESP32.zip) rather than firmware-<pio_env> (e.g. firmware-esp32dev.zip), making it easier for users to identify the correct build when testing PRs, so they don't have to handle two different naming conventions between release and PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifact naming now derives the release name from the first produced firmware binary, replacing the previous fixed scheme.
  * If no firmware binary is found, the pipeline falls back to an environment-based default name.
  * The artifact upload step now uses the computed name so released artifacts reflect actual outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->