### PR TITLE
ci: opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,10 @@ name: WLED Build
 # Only included into other workflows
 on:
   workflow_call:
-  
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   get_default_envs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,9 @@ on:
   # This can be used to allow manually triggering nightlies from the web interface
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   wled_build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   
   wled_build:

--- a/.github/workflows/usermods.yml
+++ b/.github/workflows/usermods.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     paths:
       - usermods/**
-    
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   get_usermod_envs:


### PR DESCRIPTION
Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true across all affected workflows to avoid deprecation warnings ahead of the June 2026 forced migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows across build, nightly, release, and user modifications pipelines to use Node.js 24 for JavaScript-based actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->