### PR TITLE
Adding usermod palettes and fix UI palette display

### DIFF
--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -2280,9 +2280,9 @@ const char AudioReactive::_analogmic[]  PROGMEM = "analogmic";
 #endif
 const char AudioReactive::_digitalmic[] PROGMEM = "digitalmic";
 const char AudioReactive::_addPalettes[]          PROGMEM = "add-palettes";
-const char AudioReactive::_palName0[]              PROGMEM = "Audio Responsive Ratio";
-const char AudioReactive::_palName1[]              PROGMEM = "Audio Responsive Hue";
-const char AudioReactive::_palName2[]              PROGMEM = "Audio Responsive Spectrum";
+const char AudioReactive::_palName0[]              PROGMEM = "Ratio";
+const char AudioReactive::_palName1[]              PROGMEM = "Hue";
+const char AudioReactive::_palName2[]              PROGMEM = "Spectrum";
 const char AudioReactive::UDP_SYNC_HEADER[]    PROGMEM = "00002"; // new sync header version, as format no longer compatible with previous structure
 const char AudioReactive::UDP_SYNC_HEADER_v1[] PROGMEM = "00001"; // old sync header version - need to add backwards-compatibility feature
 

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1951,14 +1951,11 @@ class AudioReactive : public Usermod {
         }
 #endif
       }
-      if (palettes > 0 && root.containsKey(F("rmcpal"))) {
-        // handle removal of custom palettes from JSON call so we don't break things
-        removeAudioPalettes();
-      }
     }
 
     void onStateChange(uint8_t callMode) override {
-      if (initDone && enabled && addPalettes && palettes==0 && customPalettes.size()<WLED_MAX_CUSTOM_PALETTES) {
+      if (initDone && enabled && addPalettes && palettes==0
+          && (int)(usermodnPalettes.size() + MAX_PALETTES) <= WLED_MAX_USERMOD_PALETTES) {
         // if palettes were removed during JSON call re-add them
         createAudioPalettes();
       }
@@ -2187,24 +2184,23 @@ class AudioReactive : public Usermod {
 
 void AudioReactive::removeAudioPalettes(void) {
   DEBUG_PRINTLN(F("Removing audio palettes."));
-  while (palettes>0) {
-    customPalettes.pop_back();
-    DEBUG_PRINTLN(palettes);
-    palettes--;
-  }
-  DEBUG_PRINT(F("Total # of palettes: ")); DEBUG_PRINTLN(customPalettes.size());
+  palettes -= (int8_t)removeUsermodnPalettes(_name);
+  if (palettes < 0) palettes = 0; // safeguard
+  DEBUG_PRINT(F("Total # of usermod palettes: ")); DEBUG_PRINTLN(usermodnPalettes.size());
 }
 
 void AudioReactive::createAudioPalettes(void) {
-  DEBUG_PRINT(F("Total # of palettes: ")); DEBUG_PRINTLN(customPalettes.size());
+  DEBUG_PRINT(F("Total # of usermod palettes: ")); DEBUG_PRINTLN(usermodnPalettes.size());
   if (palettes) return;
   DEBUG_PRINTLN(F("Adding audio palettes."));
-  for (int i=0; i<MAX_PALETTES; i++)
-    if (customPalettes.size() < WLED_MAX_CUSTOM_PALETTES) {
-      customPalettes.push_back(CRGBPalette16(CRGB(BLACK)));
+  for (int i=0; i<MAX_PALETTES; i++) {
+    if ((int)usermodnPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
+      // reuse _name ("AudioReactive") as base; palIndex 0/1/2... builds "AudioReactive 1" etc.
+      usermodnPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i}); // start black, filled each loop by fillAudioPalettes()
       palettes++;
       DEBUG_PRINTLN(palettes);
     } else break;
+  }
 }
 
 // credit @netmindz ar palette, adapted for usermod @blazoncek
@@ -2238,9 +2234,10 @@ CRGB AudioReactive::getCRGBForBand(int x, int pal) {
 
 void AudioReactive::fillAudioPalettes() {
   if (!palettes) return;
-  size_t lastCustPalette = customPalettes.size();
-  if (int(lastCustPalette) >= palettes) lastCustPalette -= palettes;
-  for (int pal=0; pal<palettes; pal++) {
+  // Scan by name pointer identity to find the palettes we added, palIndex = 0/1/2... selects the getCRGBForBand variant, matching how the entries were created.
+  for (auto &ump : usermodnPalettes) {
+    if (ump.name != _name) continue;
+    const int pal = ump.palIndex;
     uint8_t tcp[16];  // Needs to be 4 times however many colors are being used.
                       // 3 colors = 12, 4 colors = 16, etc.
 
@@ -2248,26 +2245,26 @@ void AudioReactive::fillAudioPalettes() {
     tcp[1] = 0;
     tcp[2] = 0;
     tcp[3] = 0;
-    
+
     CRGB rgb = getCRGBForBand(1, pal);
     tcp[4] = 1;  // anchor of first color
     tcp[5] = rgb.r;
     tcp[6] = rgb.g;
     tcp[7] = rgb.b;
-    
+
     rgb = getCRGBForBand(128, pal);
     tcp[8] = 128;
     tcp[9] = rgb.r;
     tcp[10] = rgb.g;
     tcp[11] = rgb.b;
-    
+
     rgb = getCRGBForBand(255, pal);
     tcp[12] = 255;  // anchor of last color - must be 255
     tcp[13] = rgb.r;
     tcp[14] = rgb.g;
     tcp[15] = rgb.b;
 
-    customPalettes[lastCustPalette+pal].loadDynamicGradientPalette(tcp);
+    ump.palette.loadDynamicGradientPalette(tcp);
   }
 }
 

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -879,6 +879,9 @@ class AudioReactive : public Usermod {
 #endif
     static const char _digitalmic[];
     static const char _addPalettes[];
+    static const char _palName0[];
+    static const char _palName1[];
+    static const char _palName2[];
     static const char UDP_SYNC_HEADER[];
     static const char UDP_SYNC_HEADER_v1[];
 
@@ -2190,10 +2193,10 @@ void AudioReactive::removeAudioPalettes(void) {
 void AudioReactive::createAudioPalettes(void) {
   if (palettes) return;
   DEBUG_PRINTLN(F("Adding audio palettes."));
+  static const char *const palNames[MAX_PALETTES] PROGMEM = {_palName0, _palName1, _palName2};
   for (int i=0; i<MAX_PALETTES; i++) {
     if (usermodPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
-      // reuse _name ("AudioReactive") as base; palIndex 0/1/2... builds "AudioReactive 0" etc.
-      usermodPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i}); // start black, filled each loop by fillAudioPalettes()
+      usermodPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i, palNames[i]}); // start black, filled each loop by fillAudioPalettes()
       palettes++;
       DEBUG_PRINTLN(palettes);
     } else break;
@@ -2276,7 +2279,10 @@ const char AudioReactive::_inputLvl[]   PROGMEM = "inputLevel";
 const char AudioReactive::_analogmic[]  PROGMEM = "analogmic";
 #endif
 const char AudioReactive::_digitalmic[] PROGMEM = "digitalmic";
-const char AudioReactive::_addPalettes[]       PROGMEM = "add-palettes";
+const char AudioReactive::_addPalettes[]          PROGMEM = "add-palettes";
+const char AudioReactive::_palName0[]              PROGMEM = "Ratio";
+const char AudioReactive::_palName1[]              PROGMEM = "Hue";
+const char AudioReactive::_palName2[]              PROGMEM = "Spectrum";
 const char AudioReactive::UDP_SYNC_HEADER[]    PROGMEM = "00002"; // new sync header version, as format no longer compatible with previous structure
 const char AudioReactive::UDP_SYNC_HEADER_v1[] PROGMEM = "00001"; // old sync header version - need to add backwards-compatibility feature
 

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1955,7 +1955,7 @@ class AudioReactive : public Usermod {
 
     void onStateChange(uint8_t callMode) override {
       if (initDone && enabled && addPalettes && palettes==0
-          && (int)(usermodnPalettes.size() + MAX_PALETTES) <= WLED_MAX_USERMOD_PALETTES) {
+          && (int)(usermodPalettes.size() + MAX_PALETTES) <= WLED_MAX_USERMOD_PALETTES) {
         // if palettes were removed during JSON call re-add them
         createAudioPalettes();
       }
@@ -2184,19 +2184,17 @@ class AudioReactive : public Usermod {
 
 void AudioReactive::removeAudioPalettes(void) {
   DEBUG_PRINTLN(F("Removing audio palettes."));
-  palettes -= (int8_t)removeUsermodnPalettes(_name);
+  palettes -= (int8_t)removeusermodPalettes(_name);
   if (palettes < 0) palettes = 0; // safeguard
-  DEBUG_PRINT(F("Total # of usermod palettes: ")); DEBUG_PRINTLN(usermodnPalettes.size());
 }
 
 void AudioReactive::createAudioPalettes(void) {
-  DEBUG_PRINT(F("Total # of usermod palettes: ")); DEBUG_PRINTLN(usermodnPalettes.size());
   if (palettes) return;
   DEBUG_PRINTLN(F("Adding audio palettes."));
   for (int i=0; i<MAX_PALETTES; i++) {
-    if ((int)usermodnPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
-      // reuse _name ("AudioReactive") as base; palIndex 0/1/2... builds "AudioReactive 1" etc.
-      usermodnPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i}); // start black, filled each loop by fillAudioPalettes()
+    if ((int)usermodPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
+      // reuse _name ("AudioReactive") as base; palIndex 0/1/2... builds "AudioReactive 0" etc.
+      usermodPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i}); // start black, filled each loop by fillAudioPalettes()
       palettes++;
       DEBUG_PRINTLN(palettes);
     } else break;
@@ -2235,7 +2233,7 @@ CRGB AudioReactive::getCRGBForBand(int x, int pal) {
 void AudioReactive::fillAudioPalettes() {
   if (!palettes) return;
   // Scan by name pointer identity to find the palettes we added, palIndex = 0/1/2... selects the getCRGBForBand variant, matching how the entries were created.
-  for (auto &ump : usermodnPalettes) {
+  for (auto &ump : usermodPalettes) {
     if (ump.name != _name) continue;
     const int pal = ump.palIndex;
     uint8_t tcp[16];  // Needs to be 4 times however many colors are being used.

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1954,8 +1954,7 @@ class AudioReactive : public Usermod {
     }
 
     void onStateChange(uint8_t callMode) override {
-      if (initDone && enabled && addPalettes && palettes==0
-          && (int)(usermodPalettes.size() + MAX_PALETTES) <= WLED_MAX_USERMOD_PALETTES) {
+      if (initDone && enabled && addPalettes && palettes==0) {
         // if palettes were removed during JSON call re-add them
         createAudioPalettes();
       }
@@ -2192,7 +2191,7 @@ void AudioReactive::createAudioPalettes(void) {
   if (palettes) return;
   DEBUG_PRINTLN(F("Adding audio palettes."));
   for (int i=0; i<MAX_PALETTES; i++) {
-    if ((int)usermodPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
+    if (usermodPalettes.size() < WLED_MAX_USERMOD_PALETTES) {
       // reuse _name ("AudioReactive") as base; palIndex 0/1/2... builds "AudioReactive 0" etc.
       usermodPalettes.push_back({CRGBPalette16(CRGB(BLACK)), _name, (uint8_t)i}); // start black, filled each loop by fillAudioPalettes()
       palettes++;

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -2280,9 +2280,9 @@ const char AudioReactive::_analogmic[]  PROGMEM = "analogmic";
 #endif
 const char AudioReactive::_digitalmic[] PROGMEM = "digitalmic";
 const char AudioReactive::_addPalettes[]          PROGMEM = "add-palettes";
-const char AudioReactive::_palName0[]              PROGMEM = "Ratio";
-const char AudioReactive::_palName1[]              PROGMEM = "Hue";
-const char AudioReactive::_palName2[]              PROGMEM = "Spectrum";
+const char AudioReactive::_palName0[]              PROGMEM = "Audio Responsive Ratio";
+const char AudioReactive::_palName1[]              PROGMEM = "Audio Responsive Hue";
+const char AudioReactive::_palName2[]              PROGMEM = "Audio Responsive Spectrum";
 const char AudioReactive::UDP_SYNC_HEADER[]    PROGMEM = "00002"; // new sync header version, as format no longer compatible with previous structure
 const char AudioReactive::UDP_SYNC_HEADER_v1[] PROGMEM = "00001"; // old sync header version - need to add backwards-compatibility feature
 

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -2184,7 +2184,7 @@ class AudioReactive : public Usermod {
 
 void AudioReactive::removeAudioPalettes(void) {
   DEBUG_PRINTLN(F("Removing audio palettes."));
-  palettes -= (int8_t)removeusermodPalettes(_name);
+  palettes -= (int8_t)removeUsermodPalettes(_name);
   if (palettes < 0) palettes = 0; // safeguard
 }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -231,7 +231,7 @@ void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
   // then come user custom palettes (IDs <=200) and usermod palettes (IDs 201-255), both growing downward from their respective base IDs
   // palette 0 is a varying palette depending on effect and may be replaced by segment's color if so
   // instructed in color_from_palette()
-  const int umCount   = usermodnPalettes.size();
+  const int umCount   = usermodPalettes.size();
   const int custCount = customPalettes.size();
   if (pal >= FIXED_PALETTE_COUNT) {
     if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range (IDs 201-255)
@@ -276,7 +276,7 @@ void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
       break;}
     default: //progmem palettes
       if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod palette
-        targetPalette = usermodnPalettes[WLED_USERMOD_PALETTE_ID_BASE - pal].palette;
+        targetPalette = usermodPalettes[WLED_USERMOD_PALETTE_ID_BASE - pal].palette;
       } else if (pal >= FIXED_PALETTE_COUNT) { // user custom palette
         targetPalette = customPalettes[WLED_CUSTOM_PALETTE_ID_BASE - pal];
       } else if (pal < DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT) { // palette 6 - 12, fastled palettes
@@ -597,7 +597,7 @@ Segment &Segment::setMode(uint8_t fx, bool loadDefaults) {
 Segment &Segment::setPalette(uint8_t pal) {
   if (pal >= FIXED_PALETTE_COUNT) {
     if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range
-      if ((WLED_USERMOD_PALETTE_ID_BASE - pal) >= (int)usermodnPalettes.size()) pal = 0;
+      if ((WLED_USERMOD_PALETTE_ID_BASE - pal) >= (int)usermodPalettes.size()) pal = 0;
     } else { // custom range
       if ((WLED_CUSTOM_PALETTE_ID_BASE - pal) >= (int)customPalettes.size()) pal = 0;
     }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -231,6 +231,7 @@ void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
   // then come user custom palettes (IDs <=200) and usermod palettes (IDs 201-255), both growing downward from their respective base IDs
   // palette 0 is a varying palette depending on effect and may be replaced by segment's color if so
   // instructed in color_from_palette()
+  if (pal == 0) pal = _default_palette; // _default_palette is set in setMode(), differs depending on effect
   const int umCount   = usermodPalettes.size();
   const int custCount = customPalettes.size();
   if (pal >= FIXED_PALETTE_COUNT) {
@@ -240,8 +241,6 @@ void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
       if ((WLED_CUSTOM_PALETTE_ID_BASE - pal) >= custCount) pal = 0;
     }
   }
-  //default palette. Differs depending on effect
-  if (pal == 0) pal = _default_palette; // _default_palette is set in setMode()
   switch (pal) {
     case 0: //default palette. Exceptions for specific effects above
       targetPalette = PartyColors_gc22;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -228,10 +228,18 @@ void Segment::resetIfRequired() {
 void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
   // there is one randomly generated palette (1) followed by 4 palettes created from segment colors (2-5)
   // those are followed by 7 fastled palettes (6-12) and 59 gradient palettes (13-71)
-  // then come the custom palettes (255,254,...) growing downwards from 255 (255 being 1st custom palette)
+  // then come user custom palettes (IDs <=200) and usermod palettes (IDs 201-255), both growing downward from their respective base IDs
   // palette 0 is a varying palette depending on effect and may be replaced by segment's color if so
   // instructed in color_from_palette()
-  if (pal >= FIXED_PALETTE_COUNT && pal <= 255-customPalettes.size()) pal = 0; // out of bounds palette
+  const int umCount   = usermodnPalettes.size();
+  const int custCount = customPalettes.size();
+  if (pal >= FIXED_PALETTE_COUNT) {
+    if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range (IDs 201-255)
+      if ((WLED_USERMOD_PALETTE_ID_BASE - pal) >= umCount) pal = 0;
+    } else { // custom range
+      if ((WLED_CUSTOM_PALETTE_ID_BASE - pal) >= custCount) pal = 0;
+    }
+  }
   //default palette. Differs depending on effect
   if (pal == 0) pal = _default_palette; // _default_palette is set in setMode()
   switch (pal) {
@@ -267,8 +275,10 @@ void Segment::loadPalette(CRGBPalette16 &targetPalette, uint8_t pal) {
       }
       break;}
     default: //progmem palettes
-      if (pal > 255 - customPalettes.size()) {
-        targetPalette = customPalettes[255-pal]; // we checked bounds above
+      if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod palette
+        targetPalette = usermodnPalettes[WLED_USERMOD_PALETTE_ID_BASE - pal].palette;
+      } else if (pal >= FIXED_PALETTE_COUNT) { // user custom palette
+        targetPalette = customPalettes[WLED_CUSTOM_PALETTE_ID_BASE - pal];
       } else if (pal < DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT) { // palette 6 - 12, fastled palettes
         targetPalette = *fastledPalettes[pal - DYNAMIC_PALETTE_COUNT];
       } else {
@@ -585,7 +595,13 @@ Segment &Segment::setMode(uint8_t fx, bool loadDefaults) {
 }
 
 Segment &Segment::setPalette(uint8_t pal) {
-  if (pal <= 255-customPalettes.size() && pal > FIXED_PALETTE_COUNT) pal = 0; // not built in palette or custom palette
+  if (pal >= FIXED_PALETTE_COUNT) {
+    if (pal > WLED_CUSTOM_PALETTE_ID_BASE) { // usermod range
+      if ((WLED_USERMOD_PALETTE_ID_BASE - pal) >= (int)usermodnPalettes.size()) pal = 0;
+    } else { // custom range
+      if ((WLED_CUSTOM_PALETTE_ID_BASE - pal) >= (int)customPalettes.size()) pal = 0;
+    }
+  }
   if (pal != palette) {
     //DEBUG_PRINTF_P(PSTR("- Starting palette transition: %d\n"), pal);
     startTransition(strip.getTransition(), blendingStyle != TRANSITION_FADE); // start transition prior to change (no need to copy segment)

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -312,13 +312,13 @@ void loadCustomPalettes() {
   }
 }
 
-size_t removeUsermodnPalettes(const char *name) {
-  size_t before = usermodnPalettes.size();
-  for (int i = usermodnPalettes.size() - 1; i >= 0; i--) {
-    if (usermodnPalettes[i].name == name)
-      usermodnPalettes.erase(usermodnPalettes.begin() + i);
+size_t removeusermodPalettes(const char *name) {
+  size_t before = usermodPalettes.size();
+  for (int i = usermodPalettes.size() - 1; i >= 0; i--) {
+    if (usermodPalettes[i].name == name)
+      usermodPalettes.erase(usermodPalettes.begin() + i);
   }
-  return before - usermodnPalettes.size();
+  return before - usermodPalettes.size();
 }
 
 // convert HSV (16bit hue) to RGB (32bit with white = 0), optimized for speed

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -312,7 +312,7 @@ void loadCustomPalettes() {
   }
 }
 
-size_t removeusermodPalettes(const char *name) {
+size_t removeUsermodPalettes(const char *name) {
   size_t before = usermodPalettes.size();
   for (int i = usermodPalettes.size() - 1; i >= 0; i--) {
     if (usermodPalettes[i].name == name)

--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -312,6 +312,15 @@ void loadCustomPalettes() {
   }
 }
 
+size_t removeUsermodnPalettes(const char *name) {
+  size_t before = usermodnPalettes.size();
+  for (int i = usermodnPalettes.size() - 1; i >= 0; i--) {
+    if (usermodnPalettes[i].name == name)
+      usermodnPalettes.erase(usermodnPalettes.begin() + i);
+  }
+  return before - usermodnPalettes.size();
+}
+
 // convert HSV (16bit hue) to RGB (32bit with white = 0), optimized for speed
 WLED_O2_ATTR void hsv2rgb_spectrum(const CHSV32& hsv, CRGBW& rgb) {
   unsigned p, q, t;

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -64,12 +64,12 @@ CRGBPalette16 generateRandomPalette();
 // Palette registered by a usermod at fixed IDs (255, 254, 253... 201), palette name will be name + index (e.g. "AudioReactive 1"), see util.cpp
 struct UsermodnPalette {
   CRGBPalette16 palette;
-  const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeusermodPalettes()
+  const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeUsermodPalettes()
   uint8_t       palIndex;  // index of the palette for a usermod
 };
 
 void loadCustomPalettes();
-size_t removeusermodPalettes(const char *name); // remove all entries from usermodPalettes whose name pointer matches 'name'
+size_t removeUsermodPalettes(const char *name); // remove all entries from usermodPalettes whose name pointer matches 'name'
 extern std::vector<CRGBPalette16> customPalettes;
 extern std::vector<UsermodnPalette> usermodPalettes;
 inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + usermodPalettes.size() + customPalettes.size(); }

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -61,20 +61,18 @@ void adjust_color(CRGBW& rgb, int32_t hueShift, int32_t satChange,int32_t valueC
 [[gnu::hot, gnu::pure]] uint32_t ColorFromPalette(const CRGBPalette16 &pal, unsigned index, uint8_t brightness = (uint8_t)255U, TBlendType blendType = LINEARBLEND);
 CRGBPalette16 generateHarmonicRandomPalette(const CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette();
-// Palette registered by a usermod at fixed IDs (255, 254, 253... 201)
-// palette name name will be um_name + index (e.g. "AudioReactive 1"), see util.cpp
+// Palette registered by a usermod at fixed IDs (255, 254, 253... 201), palette name will be name + index (e.g. "AudioReactive 1"), see util.cpp
 struct UsermodnPalette {
   CRGBPalette16 palette;
-  const char   *name;      // PROGMEM base name string (must not be nullptr)
-  uint8_t       palIndex; // index of the palette for a usermod
+  const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeusermodPalettes()
+  uint8_t       palIndex;  // index of the palette for a usermod
 };
 
 void loadCustomPalettes();
-// Remove all entries from usermodnPalettes whose name pointer matches 'name'.
-size_t removeUsermodnPalettes(const char *name);
+size_t removeusermodPalettes(const char *name); // remove all entries from usermodPalettes whose name pointer matches 'name'
 extern std::vector<CRGBPalette16> customPalettes;
-extern std::vector<UsermodnPalette> usermodnPalettes;
-inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + usermodnPalettes.size() + customPalettes.size(); }
+extern std::vector<UsermodnPalette> usermodPalettes;
+inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + usermodPalettes.size() + customPalettes.size(); }
 
 void hsv2rgb_spectrum(const CHSV32& hsv, CRGBW& rgb);
 void hsv2rgb_spectrum(const CHSV& hsv, CRGB& rgb);

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -61,9 +61,20 @@ void adjust_color(CRGBW& rgb, int32_t hueShift, int32_t satChange,int32_t valueC
 [[gnu::hot, gnu::pure]] uint32_t ColorFromPalette(const CRGBPalette16 &pal, unsigned index, uint8_t brightness = (uint8_t)255U, TBlendType blendType = LINEARBLEND);
 CRGBPalette16 generateHarmonicRandomPalette(const CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette();
+// Palette registered by a usermod at fixed IDs (255, 254, 253... 201)
+// palette name name will be um_name + index (e.g. "AudioReactive 1"), see util.cpp
+struct UsermodnPalette {
+  CRGBPalette16 palette;
+  const char   *name;      // PROGMEM base name string (must not be nullptr)
+  uint8_t       palIndex; // index of the palette for a usermod
+};
+
 void loadCustomPalettes();
+// Remove all entries from usermodnPalettes whose name pointer matches 'name'.
+size_t removeUsermodnPalettes(const char *name);
 extern std::vector<CRGBPalette16> customPalettes;
-inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + customPalettes.size(); }
+extern std::vector<UsermodnPalette> usermodnPalettes;
+inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + usermodnPalettes.size() + customPalettes.size(); }
 
 void hsv2rgb_spectrum(const CHSV32& hsv, CRGBW& rgb);
 void hsv2rgb_spectrum(const CHSV& hsv, CRGB& rgb);

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -62,7 +62,7 @@ void adjust_color(CRGBW& rgb, int32_t hueShift, int32_t satChange,int32_t valueC
 CRGBPalette16 generateHarmonicRandomPalette(const CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette();
 // Palette registered by a usermod at fixed IDs (255, 254, 253... 201), palette name will be name + index (e.g. "AudioReactive 1"), see util.cpp
-struct UsermodnPalette {
+struct UsermodPalette {
   CRGBPalette16 palette;
   const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeUsermodPalettes()
   uint8_t       palIndex;  // index of the palette for a usermod
@@ -71,7 +71,7 @@ struct UsermodnPalette {
 void loadCustomPalettes();
 size_t removeUsermodPalettes(const char *name); // remove all entries from usermodPalettes whose name pointer matches 'name'
 extern std::vector<CRGBPalette16> customPalettes;
-extern std::vector<UsermodnPalette> usermodPalettes;
+extern std::vector<UsermodPalette> usermodPalettes;
 inline size_t getPaletteCount() { return FIXED_PALETTE_COUNT + usermodPalettes.size() + customPalettes.size(); }
 
 void hsv2rgb_spectrum(const CHSV32& hsv, CRGBW& rgb);

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -62,12 +62,12 @@ void adjust_color(CRGBW& rgb, int32_t hueShift, int32_t satChange,int32_t valueC
 CRGBPalette16 generateHarmonicRandomPalette(const CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette();
 // Palette registered by a usermod at fixed IDs (255, 254, 253... 201).
-// Display name is palName (if non-null) or falls back to name + index (e.g. "AudioReactive 1"), see util.cpp
+// Display name is "name: palName" (if palName non-null) or falls back to "name index" (e.g. "AudioReactive 1"), see util.cpp
 struct UsermodPalette {
   CRGBPalette16 palette;
   const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeUsermodPalettes()
   uint8_t       palIndex;  // index of the palette for a usermod
-  const char   *palName;   // optional PROGMEM display name for this palette; if nullptr, falls back to "name index"
+  const char   *palName;   // optional PROGMEM display name; if set, shown as "name: palName" (e.g. "AudioReactive: Audio Responsive Hue"), otherwise falls back to "name index"
 };
 
 void loadCustomPalettes();

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -61,11 +61,13 @@ void adjust_color(CRGBW& rgb, int32_t hueShift, int32_t satChange,int32_t valueC
 [[gnu::hot, gnu::pure]] uint32_t ColorFromPalette(const CRGBPalette16 &pal, unsigned index, uint8_t brightness = (uint8_t)255U, TBlendType blendType = LINEARBLEND);
 CRGBPalette16 generateHarmonicRandomPalette(const CRGBPalette16 &basepalette);
 CRGBPalette16 generateRandomPalette();
-// Palette registered by a usermod at fixed IDs (255, 254, 253... 201), palette name will be name + index (e.g. "AudioReactive 1"), see util.cpp
+// Palette registered by a usermod at fixed IDs (255, 254, 253... 201).
+// Display name is palName (if non-null) or falls back to name + index (e.g. "AudioReactive 1"), see util.cpp
 struct UsermodPalette {
   CRGBPalette16 palette;
   const char   *name;      // PROGMEM base name string (must not be nullptr), this name is used in removeUsermodPalettes()
   uint8_t       palIndex;  // index of the palette for a usermod
+  const char   *palName;   // optional PROGMEM display name for this palette; if nullptr, falls back to "name index"
 };
 
 void loadCustomPalettes();

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -10,8 +10,16 @@ constexpr size_t FASTLED_PALETTE_COUNT = 7;   //  6-12 = sizeof(fastledPalettes)
 constexpr size_t GRADIENT_PALETTE_COUNT = 59; // 13-72 = sizeof(gGradientPalettes) / sizeof(gGradientPalettes[0]);
 constexpr size_t DYNAMIC_PALETTE_COUNT = 6;   //  0- 5 = dynamic palettes (0=default(virtual),1=random,2=primary,3=primary+secondary,4=primary+secondary+tertiary,5=primary+secondary(+tertiary if not black)
 constexpr size_t FIXED_PALETTE_COUNT = DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT + GRADIENT_PALETTE_COUNT; // total number of fixed palettes
+
+// Palette ID space layout (palette IDs are uint8_t, 0-255):
+//   0  .. FIXED_PALETTE_COUNT-1            : fixed built-in palettes
+//   72 .. WLED_CUSTOM_PALETTE_ID_BASE(200) : user custom palettes (index 0 = ID 200, growing downward)
+//   201.. WLED_USERMOD_PALETTE_ID_BASE(255): usermod-registered palettes (index 0 = ID 255, growing downward)
+constexpr uint8_t WLED_USERMOD_PALETTE_ID_BASE = 255; // highest ID for usermod palettes
+constexpr uint8_t WLED_CUSTOM_PALETTE_ID_BASE  = 200; // highest ID for user custom palettes
+constexpr size_t  WLED_MAX_USERMOD_PALETTES     = WLED_USERMOD_PALETTE_ID_BASE - WLED_CUSTOM_PALETTE_ID_BASE; // 55 slots (IDs 201-255)
 #ifndef ESP8266
-  #define WLED_MAX_CUSTOM_PALETTES (255 - FIXED_PALETTE_COUNT) // allow up to 255 total palettes, user is warned about stability issues when adding more than 10
+  #define WLED_MAX_CUSTOM_PALETTES (WLED_CUSTOM_PALETTE_ID_BASE - FIXED_PALETTE_COUNT + 1) // 129 slots (IDs 72-200)
 #else
   #define WLED_MAX_CUSTOM_PALETTES 10 // ESP8266: limit custom palettes to 10
 #endif

--- a/wled00/data/cpal/cpal.htm
+++ b/wled00/data/cpal/cpal.htm
@@ -460,7 +460,11 @@
 				rm.className = 'sml';
 				rm.title = 'Delete palette';
 				rm.innerHTML = '&#10006;';
-				rm.onclick = () => { requestJson({rmcpal:i}); setTimeout(refr, 500); };
+				rm.onclick = () => { 
+					requestJson({rmcpal:i}); // send remove command
+					setTimeout(refr, 500);   // slight delay to allow ESP to process deletion before fetching updated list
+					localStorage.removeItem('wledPalx'); // invalidate main UI cache
+				};
 
 				const name = isEmpty(p.palette) ? 'Empty slot' : 'Custom' + i;
 				const css = isEmpty(p.palette) ? '#666' : cssArr(p.palette);

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -989,20 +989,35 @@ function populatePalettes()
 		);
 	}
 	gId('pallist').innerHTML=html;
-	// append custom palettes (when loading for the 1st time)
+	// append usermod palettes (fixed ID space: 255 down to 201)
 	let li = lastinfo;
-	if (!isEmpty(li) && li.cpalcount) {
-		for (let j = 0; j<li.cpalcount; j++) {
-			const pd = palettesData[255-j];
-			if (pd && pd.length === 16 && pd.every(e => e[1] === 128 && e[2] === 128 && e[3] === 128)) continue; // skip all gray gap-placeholder entries
+	if (!isEmpty(li) && li.umpalcount && li.umpalnames) {
+		for (let j = 0; j < li.umpalcount; j++) {
 			let div = d.createElement("div");
 			gId('pallist').appendChild(div);
 			div.outerHTML = generateListItemHtml(
 				'palette',
 				255-j,
-				'~ Custom '+j+' ~',
+				li.umpalnames[j],
 				'setPalette',
 				`<div class="lstIprev" style="${genPalPrevCss(255-j)}"></div>`
+			);
+		}
+	}
+	// append user custom palettes (fixed ID space: 200 down to FIXED_PALETTE_COUNT+1)
+	if (!isEmpty(li) && li.cpalcount) {
+		for (let j = 0; j < li.cpalcount; j++) {
+			const id = 200 - j;
+			const pd = palettesData[id];
+			if (pd && pd.length === 16 && pd.every(e => e[1] === 128 && e[2] === 128 && e[3] === 128)) continue; // skip gray gap-placeholder entries
+			let div = d.createElement("div");
+			gId('pallist').appendChild(div);
+			div.outerHTML = generateListItemHtml(
+				'palette',
+				id,
+				'~ Custom '+j+' ~',
+				'setPalette',
+				`<div class="lstIprev" style="${genPalPrevCss(id)}"></div>`
 			);
 		}
 	}

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -2819,7 +2819,7 @@ function loadPalettesData() {
 		if (lsPalData) {
 			try {
 				var d = JSON.parse(lsPalData);
-				if (d && d.vid == lastinfo.vid) {
+				if (d && d.vid == lastinfo.vid && d.pcount == lastinfo.palcount) {
 					palettesData = d.p;
 					redrawPalPrev();
 					return resolve();
@@ -2831,7 +2831,8 @@ function loadPalettesData() {
 		getPalettesData(0, () => {
 			localStorage.setItem("wledPalx", JSON.stringify({
 				p: palettesData,
-				vid: lastinfo.vid
+				vid: lastinfo.vid,
+				pcount: lastinfo.palcount // total palette count, refresh cache if it changes
 			}));
 			redrawPalPrev();
 			setTimeout(resolve, 99); // delay optional

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1021,6 +1021,7 @@ function populatePalettes()
 			);
 		}
 	}
+	updateSelectedPalette(selectedPal); // update selection after adding usermod and custom palettes
 }
 
 function redrawPalPrev()

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -774,8 +774,18 @@ void serializeInfo(JsonObject root)
 
   root[F("fxcount")] = strip.getModeCount();
   root[F("palcount")] = getPaletteCount();
-  root[F("cpalcount")] = customPalettes.size();   // number of custom palettes (includes gray placeholders)
+  root[F("cpalcount")] = customPalettes.size();   // number of user custom palettes (includes gray placeholders)
+  root[F("umpalcount")] = usermodnPalettes.size(); // number of usermod-registered palettes
   root[F("cpalmax")] = WLED_MAX_CUSTOM_PALETTES;  // maximum number of custom palettes
+  // send usermod palette names so the UI can label them correctly
+  if (usermodnPalettes.size() > 0) {
+    JsonArray umpalnames = root.createNestedArray(F("umpalnames"));
+    for (size_t j = 0; j < usermodnPalettes.size(); j++) {
+      char buf[34];
+      extractModeName(WLED_USERMOD_PALETTE_ID_BASE - j, JSON_palette_names, buf, sizeof(buf) - 1);
+      umpalnames.add(buf);
+    }
+  }
 
   JsonArray ledmaps = root.createNestedArray(F("maps"));
   for (size_t i=0; i<WLED_MAX_LEDMAPS; i++) {
@@ -946,19 +956,28 @@ void serializePalettes(JsonObject root, int page)
   #endif
 
   const int customPalettesCount = customPalettes.size();
+  const int umPalettesCount     = usermodnPalettes.size();
   const int palettesCount = FIXED_PALETTE_COUNT; // palettesCount is number of palettes, not palette index
 
-  const int maxPage = (palettesCount + customPalettesCount) / itemPerPage;
+  const int maxPage = (palettesCount + umPalettesCount + customPalettesCount) / itemPerPage;
   if (page > maxPage) page = maxPage;
 
   const int start = itemPerPage * page;
-  int end = min(start + itemPerPage, palettesCount + customPalettesCount);
+  int end = min(start + itemPerPage, palettesCount + umPalettesCount + customPalettesCount);
 
   root[F("m")] = maxPage; // inform caller how many pages there are
   JsonObject palettes  = root.createNestedObject("p");
 
   for (int i = start; i < end; i++) {
-    JsonArray curPalette = palettes.createNestedArray(String(i >= palettesCount ? 255 - i + palettesCount : i));
+    // compute the palette ID for this sequential index
+    int paletteId;
+    if (i >= palettesCount + umPalettesCount) // user custom palette (IDs 200, 199, ...)
+      paletteId = WLED_CUSTOM_PALETTE_ID_BASE - (i - palettesCount - umPalettesCount);
+    else if (i >= palettesCount)              // usermod palette (IDs 255, 254, ...)
+      paletteId = WLED_USERMOD_PALETTE_ID_BASE - (i - palettesCount);
+    else
+      paletteId = i;                          // fixed palette
+    JsonArray curPalette = palettes.createNestedArray(String(paletteId));
     switch (i) {
       case 0: //default palette
         setPaletteColors(curPalette, PartyColors_gc22);
@@ -987,9 +1006,13 @@ void serializePalettes(JsonObject root, int page)
         curPalette.add("c1");
         break;
       default:
-        if (i >= palettesCount) // custom palettes
-          setPaletteColors(curPalette, customPalettes[i - palettesCount]);
-        else if (i < DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT) // palette 6 - 12, fastled palettes
+        if (i >= palettesCount + umPalettesCount) { // user custom palettes (lowest IDs in the custom range)
+          int custIdx = i - palettesCount - umPalettesCount;
+          setPaletteColors(curPalette, customPalettes[custIdx]);
+        } else if (i >= palettesCount) { // usermod palettes (IDs 255, 254, ...)
+          int umIdx = i - palettesCount;
+          setPaletteColors(curPalette, usermodnPalettes[umIdx].palette);
+        } else if (i < DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT) // palette 6 - 12, fastled palettes
           setPaletteColors(curPalette, *fastledPalettes[i - DYNAMIC_PALETTE_COUNT]);
         else {
           memcpy_P(tcp, (byte*)pgm_read_dword(&(gGradientPalettes[i - (DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT)])), sizeof(tcp));

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -775,12 +775,12 @@ void serializeInfo(JsonObject root)
   root[F("fxcount")] = strip.getModeCount();
   root[F("palcount")] = getPaletteCount();
   root[F("cpalcount")] = customPalettes.size();   // number of user custom palettes (includes gray placeholders)
-  root[F("umpalcount")] = usermodnPalettes.size(); // number of usermod-registered palettes
+  root[F("umpalcount")] = usermodPalettes.size(); // number of usermod-registered palettes
   root[F("cpalmax")] = WLED_MAX_CUSTOM_PALETTES;  // maximum number of custom palettes
   // send usermod palette names so the UI can label them correctly
-  if (usermodnPalettes.size() > 0) {
+  if (usermodPalettes.size() > 0) {
     JsonArray umpalnames = root.createNestedArray(F("umpalnames"));
-    for (size_t j = 0; j < usermodnPalettes.size(); j++) {
+    for (size_t j = 0; j < usermodPalettes.size(); j++) {
       char buf[34];
       extractModeName(WLED_USERMOD_PALETTE_ID_BASE - j, JSON_palette_names, buf, sizeof(buf) - 1);
       umpalnames.add(buf);
@@ -956,7 +956,7 @@ void serializePalettes(JsonObject root, int page)
   #endif
 
   const int customPalettesCount = customPalettes.size();
-  const int umPalettesCount     = usermodnPalettes.size();
+  const int umPalettesCount     = usermodPalettes.size();
   const int palettesCount = FIXED_PALETTE_COUNT; // palettesCount is number of palettes, not palette index
 
   const int maxPage = (palettesCount + umPalettesCount + customPalettesCount) / itemPerPage;
@@ -1011,7 +1011,7 @@ void serializePalettes(JsonObject root, int page)
           setPaletteColors(curPalette, customPalettes[custIdx]);
         } else if (i >= palettesCount) { // usermod palettes (IDs 255, 254, ...)
           int umIdx = i - palettesCount;
-          setPaletteColors(curPalette, usermodnPalettes[umIdx].palette);
+          setPaletteColors(curPalette, usermodPalettes[umIdx].palette);
         } else if (i < DYNAMIC_PALETTE_COUNT + FASTLED_PALETTE_COUNT) // palette 6 - 12, fastled palettes
           setPaletteColors(curPalette, *fastledPalettes[i - DYNAMIC_PALETTE_COUNT]);
         else {

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -325,7 +325,7 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
         dest[0] = '\0'; // empty string if requested index is out of bounds
         return 0;
       }
-      const UsermodnPalette &ump = usermodPalettes[umIdx];
+      const UsermodPalette &ump = usermodPalettes[umIdx];
       char base[33];
       strncpy_P(base, ump.name, sizeof(base) - 1);
       base[sizeof(base) - 1] = '\0';

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -321,7 +321,11 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
     if (mode > WLED_CUSTOM_PALETTE_ID_BASE) {
       // usermod palette (IDs 201-255)
       uint8_t umIdx = WLED_USERMOD_PALETTE_ID_BASE - mode;
-      const UsermodnPalette &ump = usermodnPalettes[umIdx];
+      if (umIdx >= usermodPalettes.size()) {
+        dest[0] = '\0'; // empty string if requested index is out of bounds
+        return 0;
+      }
+      const UsermodnPalette &ump = usermodPalettes[umIdx];
       char base[33];
       strncpy_P(base, ump.name, sizeof(base) - 1);
       base[sizeof(base) - 1] = '\0';

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -317,10 +317,23 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
     } else return 0;
   }
 
-  if (src == JSON_palette_names && mode > 255-customPalettes.size()) {
-    snprintf_P(dest, maxLen, PSTR("~ Custom %d ~"), 255-mode);
-    dest[maxLen] = '\0';
-    return strlen(dest);
+  if (src == JSON_palette_names) {
+    if (mode > WLED_CUSTOM_PALETTE_ID_BASE) {
+      // usermod palette (IDs 201-255)
+      uint8_t umIdx = WLED_USERMOD_PALETTE_ID_BASE - mode;
+      const UsermodnPalette &ump = usermodnPalettes[umIdx];
+      char base[33];
+      strncpy_P(base, ump.name, sizeof(base) - 1);
+      base[sizeof(base) - 1] = '\0';
+      snprintf(dest, maxLen + 1, "%s %u", base, (unsigned)ump.palIndex); // palette name is um name + index (e.g. "AudioReactive 1")
+      return strlen(dest);
+    }
+    if (mode >= FIXED_PALETTE_COUNT && mode <= WLED_CUSTOM_PALETTE_ID_BASE) {
+      // user custom palette (IDs FIXED_PALETTE_COUNT up to WLED_CUSTOM_PALETTE_ID_BASE=200)
+      snprintf_P(dest, maxLen, PSTR("~ Custom %d ~"), WLED_CUSTOM_PALETTE_ID_BASE - mode);
+      dest[maxLen] = '\0';
+      return strlen(dest);
+    }
   }
 
   unsigned qComma = 0;

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -326,10 +326,17 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
         return 0;
       }
       const UsermodPalette &ump = usermodPalettes[umIdx];
-      char base[33];
-      strncpy_P(base, ump.name, sizeof(base) - 1);
-      base[sizeof(base) - 1] = '\0';
-      snprintf(dest, maxLen + 1, "%s %u", base, (unsigned)ump.palIndex); // palette name is um name + index (e.g. "AudioReactive 1")
+      if (ump.palName) {
+        // usermod supplied a specific display name for this palette
+        strncpy_P(dest, ump.palName, maxLen);
+        dest[maxLen] = '\0';
+      } else {
+        // fallback: "UMName index" (e.g. "AudioReactive 1")
+        char base[33];
+        strncpy_P(base, ump.name, sizeof(base) - 1);
+        base[sizeof(base) - 1] = '\0';
+        snprintf(dest, maxLen + 1, "%s %u", base, (unsigned)ump.palIndex);
+      }
       return strlen(dest);
     }
     if (mode >= FIXED_PALETTE_COUNT && mode <= WLED_CUSTOM_PALETTE_ID_BASE) {

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -326,15 +326,17 @@ uint8_t extractModeName(uint8_t mode, const char *src, char *dest, uint8_t maxLe
         return 0;
       }
       const UsermodPalette &ump = usermodPalettes[umIdx];
+      char base[33];
+      strncpy_P(base, ump.name, sizeof(base) - 1);
+      base[sizeof(base) - 1] = '\0';
       if (ump.palName) {
-        // usermod supplied a specific display name for this palette
-        strncpy_P(dest, ump.palName, maxLen);
-        dest[maxLen] = '\0';
+        // usermod supplied a specific display name — prefix with the usermod name (e.g. "AudioReactive: Hue")
+        char palName[33];
+        strncpy_P(palName, ump.palName, sizeof(palName) - 1);
+        palName[sizeof(palName) - 1] = '\0';
+        snprintf(dest, maxLen + 1, "%s: %s", base, palName);
       } else {
         // fallback: "UMName index" (e.g. "AudioReactive 1")
-        char base[33];
-        strncpy_P(base, ump.name, sizeof(base) - 1);
-        base[sizeof(base) - 1] = '\0';
         snprintf(dest, maxLen + 1, "%s %u", base, (unsigned)ump.palIndex);
       }
       return strlen(dest);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -600,7 +600,7 @@ WLED_GLOBAL bool wasConnected _INIT(false);
 // color
 WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
 WLED_GLOBAL std::vector<CRGBPalette16> customPalettes;  // custom palettes (file-based, IDs grow downwards starting at 200)
-WLED_GLOBAL std::vector<UsermodnPalette> usermodPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
+WLED_GLOBAL std::vector<UsermodPalette> usermodPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
 WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wrapping of palette: 0: blend, wrap if moving (SEGMENT.speed>0); 1: blend, always wrap; 2: blend, never wrap; 3: don't blend or wrap
 
 // transitions

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -600,7 +600,7 @@ WLED_GLOBAL bool wasConnected _INIT(false);
 // color
 WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
 WLED_GLOBAL std::vector<CRGBPalette16> customPalettes;  // custom palettes (file-based, IDs grow downwards starting at 200)
-WLED_GLOBAL std::vector<UsermodnPalette> usermodnPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
+WLED_GLOBAL std::vector<UsermodnPalette> usermodPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
 WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wrapping of palette: 0: blend, wrap if moving (SEGMENT.speed>0); 1: blend, always wrap; 2: blend, never wrap; 3: don't blend or wrap
 
 // transitions

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -599,7 +599,8 @@ WLED_GLOBAL bool wasConnected _INIT(false);
 
 // color
 WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
-WLED_GLOBAL std::vector<CRGBPalette16> customPalettes;  // custom palettes
+WLED_GLOBAL std::vector<CRGBPalette16> customPalettes;  // custom palettes (file-based, IDs grow downwards starting at 200)
+WLED_GLOBAL std::vector<UsermodnPalette> usermodnPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
 WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wrapping of palette: 0: blend, wrap if moving (SEGMENT.speed>0); 1: blend, always wrap; 2: blend, never wrap; 3: don't blend or wrap
 
 // transitions


### PR DESCRIPTION
Usermods get their own palette "space" right after the built-in palettes, named by the usermod name (for example "AudioReactive 0". Custom palettes now start at palette ID 200 and downwards, keeping IDs consistent to not break presets when enabling/disabling AR palettes. 
Also added a fix to reload the palette gradients when the number of total palettes changes so the palette list should now always properly update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct "usermod" palette category with named usermod palettes visible in the UI and API and included in palette counts/exports.
  * Usermod palettes can occupy multiple slots and report per-slot names/variants.

* **Bug Fixes / Reliability**
  * Improved palette ID range handling and clamping to prevent invalid references.
  * More robust removal of palettes that avoids index-shift issues and reports deletions.

* **UI**
  * Palette lists and previews now show usermod entries separately; cache is cleared on delete to avoid stale previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->