### PR TITLE
Add Ethernet profiles for QuinLED Dig-Uno/Quad v4 and Dig-Octa 32-8L v4

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -399,8 +399,8 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_ESP32_POE_WROVER 11
 #define WLED_ETH_LILYGO_T_POE_PRO 12
 #define WLED_ETH_GLEDOPTO         13
-`#define` WLED_ETH_QUINLED_V4_UNOQUAD  14
-`#define` WLED_ETH_QUINLED_V4_OCTA     15
+#define WLED_ETH_QUINLED_V4_UNOQUAD  14
+#define WLED_ETH_QUINLED_V4_OCTA     15
 
 
 //Hue error codes

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -399,8 +399,8 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_ESP32_POE_WROVER 11
 #define WLED_ETH_LILYGO_T_POE_PRO 12
 #define WLED_ETH_GLEDOPTO         13
-#define WLED_ETH_QUINLED-v4-UnoQuad  14
-#define WLED_ETH_QUINLED-v4-Octa     15
+`#define` WLED_ETH_QUINLED_V4_UNOQUAD  14
+`#define` WLED_ETH_QUINLED_V4_OCTA     15
 
 
 //Hue error codes

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -382,7 +382,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        14
+#define WLED_NUM_ETH_TYPES        16
 
 
 #define WLED_ETH_NONE              0
@@ -399,6 +399,9 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_ESP32_POE_WROVER 11
 #define WLED_ETH_LILYGO_T_POE_PRO 12
 #define WLED_ETH_GLEDOPTO         13
+#define WLED_ETH_QUINLED-v4-UnoQuad  14
+#define WLED_ETH_QUINLED-v4-Octa     15
+
 
 //Hue error codes
 #define HUE_ERROR_INACTIVE        0

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -243,6 +243,9 @@ Static subnet mask:<br>
 			<option value="3">WESP32</option>
 			<option value="1">WT32-ETH01</option>
 			<option value="13">Gledopto</option>
+			<option value="14">QuinLED v4 Uno/Quad</option>
+			<option value="15">QuinLED v4 Octa</option>
+
 		</select><br><br>
 	</div>
 	<div class="sec">

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -236,16 +236,15 @@ Static subnet mask:<br>
 			<option value="11">ESP32-POE-WROVER</option>
 			<option value="7">KIT-VE</option>
 			<option value="12">LILYGO T-POE Pro</option>
-			<option value="8">QuinLED-Dig-Octa & T-ETH-POE</option>
-			<option value="4">QuinLED-ESP32</option>
+			<option value="4">QuinLED Uno/Quad</option>
+			<option value="8">QuinLED Octa & T-ETH-POE</option>
+			<option value="14">QuinLED v4 Uno/Quad</option>
+			<option value="15">QuinLED v4 Octa</option>
 			<option value="10">Serg74-ETH32</option>
 			<option value="5">TwilightLord-ESP32</option>
 			<option value="3">WESP32</option>
 			<option value="1">WT32-ETH01</option>
 			<option value="13">Gledopto</option>
-			<option value="14">QuinLED v4 Uno/Quad</option>
-			<option value="15">QuinLED v4 Octa</option>
-
 		</select><br><br>
 	</div>
 	<div class="sec">

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -175,9 +175,6 @@ const ethernet_settings ethernetBoards[] = {
     ETH_PHY_LAN8720,     // eth_type
     ETH_CLOCK_GPIO0_IN   // eth_clk_mode
   },
-
-
-
 };
 
 bool initEthernet()

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -155,6 +155,29 @@ const ethernet_settings ethernetBoards[] = {
     ETH_PHY_LAN8720,      // eth_type,
     ETH_CLOCK_GPIO0_IN	 // eth_clk_mode
   },
+ 
+ // WLED_ETH_QUINLED_V4 (14) - QuinLED Dig-Uno/Quad v4
+  {
+    0,                   // eth_address
+    -1,                  // eth_power
+    7,                   // eth_mdc
+    8,                   // eth_mdio
+    ETH_PHY_LAN8720,     // eth_type
+    ETH_CLOCK_GPIO0_IN   // eth_clk_mode
+  },
+ 
+ // WLED_ETH_QUINLED_OCTA_V4 (15) - QuinLED Dig-Octa 32-8L v4
+  {
+    0,                   // eth_address
+    -1,                  // eth_power
+    23,                  // eth_mdc
+    18,                  // eth_mdio
+    ETH_PHY_LAN8720,     // eth_type
+    ETH_CLOCK_GPIO0_IN   // eth_clk_mode
+  },
+
+
+
 };
 
 bool initEthernet()


### PR DESCRIPTION
I will soon be updating the QuinLED Dig-Uno and Dig-Quad to version v4 which uses a new ESP32 module and with that a new Ethernet configuration including external crystal and doing the same for the Dig-Octa brainboard also updating it to v4 with it's own configuration (sadly, since I'm using a different module there).

Sadly none of the existing profiles match my configuration used.

I'd like for these profiles to be included within WLED so that when the new boards are introduced they are immediately compatible with v16 of WLED!

I have tested the proposed configurations on prototype hardware and they are working correctly.

If there are any questions, please let me know, I'm always available on Discord user the user "Quindor".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two new Ethernet board types: QuinLED v4 Uno/Quad and QuinLED v4 Octa.
  * Ethernet device list updated so the new QuinLED v4 options appear in network settings.
  * Each new option includes matching presets for PHY, clock mode and GPIO pin configuration to simplify setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->