### PR TITLE
auto-migration for sunrise/sunset legacy config

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -47,7 +47,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   //int rev_major = doc["rev"][0]; // 1
   //int rev_minor = doc["rev"][1]; // 0
 
-  long vid = doc[F("vid")]; // 2605010 note: "vid" can be used to detect an update from older versions but only on first call, it is written to the new VID after buses are initialized
+  long vid = doc[F("vid")] | VERSION; // 2605010 note: "vid" can be used to detect an update from older versions but only on first call, it is written to the new VID after buses are initialized
 
   JsonObject id = doc["id"];
   getStringFromJson(cmDNS, id[F("mdns")], 33);

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -47,7 +47,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   //int rev_major = doc["rev"][0]; // 1
   //int rev_minor = doc["rev"][1]; // 0
 
-  //long vid = doc[F("vid")]; // 2010020
+  long vid = doc[F("vid")]; // 2605010 note: "vid" can be used to detect an update from older versions but only on first call, it is written to the new VID after buses are initialized
 
   JsonObject id = doc["id"];
   getStringFromJson(cmDNS, id[F("mdns")], 33);
@@ -693,8 +693,18 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   JsonArray timersArray = tm["ins"];
   if (!timersArray.isNull()) {
     clearTimers();
+    bool legacySunriseLoaded = false;  // migration flag: pre 16.0 used hour=255 for both sunrise & sunset (type determined by array position)
     for (JsonObject timer : timersArray) {
       uint8_t h = timer[F("hour")] | 0;
+      // legacy migration for pre 16.0 (vid < 2605010): first occurrence = sunrise, second occurrence = sunset
+      if (vid < 2605010 && h == 255) {
+        if (legacySunriseLoaded) {
+          h = TH_SUNSET;   // second "255" entry is actually sunset
+        } else {
+          legacySunriseLoaded = true;
+        }
+      }
+
       int8_t m = timer[F("min")] | 0;
       uint8_t p = timer[F("macro")] | 0;
       uint8_t dow = timer[F("dow")] | 127;


### PR DESCRIPTION
on first boot after an update, VID in cfg.json can be used to determine compatibility.
first timer with hour=255 is sunrise, second one is sunset.

fixes #5551 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration file now correctly reads stored version info from the config, ensuring proper handling of versioned settings.
  * Added automatic migration for legacy timer entries so sunrise/sunset timers are recognized and converted, preventing duplicated or misassigned timed actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->