### PR TITLE
Net debug - Runtime Config

### DIFF
--- a/usermods/mpu6050_imu/mpu6050_imu.cpp
+++ b/usermods/mpu6050_imu/mpu6050_imu.cpp
@@ -49,9 +49,9 @@
 #undef DEBUG_PRINTLN
 #undef DEBUG_PRINTF
 #ifdef WLED_DEBUG
-  #define DEBUG_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUG_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUG_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUG_PRINT(x) DEBUGOUT(x)
+  #define DEBUG_PRINTLN(x) DEBUGOUTLN(x)
+  #define DEBUG_PRINTF(x...) DEBUGOUTF(x)
 #else
   #define DEBUG_PRINT(x)
   #define DEBUG_PRINTLN(x)

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -20,17 +20,10 @@
 #include "wled.h"
 #include "colors.h"
 #ifdef WLED_DEBUG
-  // enable additional debug output
-  #if defined(WLED_DEBUG_HOST)
-    #include "net_debug.h"
-    #define DEBUGOUT NetDebug
-  #else
-    #define DEBUGOUT Serial
-  #endif
-  #define DEBUGFX_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUGFX_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUGFX_PRINTF(x...) DEBUGOUT.printf(x)
-  #define DEBUGFX_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+  #define DEBUGFX_PRINT(x) DEBUGOUT(x)
+  #define DEBUGFX_PRINTLN(x) DEBUGOUTLN(x)
+  #define DEBUGFX_PRINTF(x...) DEBUGOUTF(x)
+  #define DEBUGFX_PRINTF_P(x...) DEBUGOUTF(x)
 #else
   #define DEBUGFX_PRINT(x)
   #define DEBUGFX_PRINTLN(x)

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -33,22 +33,14 @@ make_unique(Args&&... args)
 }
 #endif
 
-// enable additional debug output
-#if defined(WLED_DEBUG_HOST)
-  #include "net_debug.h"
-  #define DEBUGOUT NetDebug
-#else
-  #define DEBUGOUT Serial
-#endif
-
 #ifdef WLED_DEBUG_BUS
   #ifndef ESP8266
   #include <rom/rtc.h>
   #endif
-  #define DEBUGBUS_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUGBUS_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUGBUS_PRINTF(x...) DEBUGOUT.printf(x)
-  #define DEBUGBUS_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+  #define DEBUGBUS_PRINT(x) DEBUGOUT(x)
+  #define DEBUGBUS_PRINTLN(x) DEBUGOUTLN(x)
+  #define DEBUGBUS_PRINTF(x...) DEBUGOUTF(x)
+  #define DEBUGBUS_PRINTF_P(x...) DEBUGOUTF(x)
 #else
   #define DEBUGBUS_PRINT(x)
   #define DEBUGBUS_PRINTLN(x)

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -657,7 +657,6 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     CJSON(hueIP[i], if_hue_ip[i]);
 #endif
 
-//WLEDMM: add netdebug variables
 #ifdef WLED_ENABLE_NET_DEBUG
   JsonObject if_ndb = interfaces["ndb"];
   JsonArray if_ndb_ip = if_ndb["ip"];
@@ -1188,7 +1187,6 @@ void serializeConfig(JsonObject root) {
   }
 #endif
 
-//WLEDMM: add netdebug variables
 #ifdef WLED_ENABLE_NET_DEBUG
   JsonObject if_ndb = interfaces.createNestedObject("ndb");
   JsonArray if_ndb_ip = if_ndb.createNestedArray("ip");

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -658,7 +658,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 #endif
 
 //WLEDMM: add netdebug variables
-#ifdef WLED_DEBUG_HOST
+#ifdef WLED_ENABLE_NET_DEBUG
   JsonObject if_ndb = interfaces["ndb"];
   JsonArray if_ndb_ip = if_ndb["ip"];
   for (byte i = 0; i < 4; i++)
@@ -1189,7 +1189,7 @@ void serializeConfig(JsonObject root) {
 #endif
 
 //WLEDMM: add netdebug variables
-#ifdef WLED_DEBUG_HOST
+#ifdef WLED_ENABLE_NET_DEBUG
   JsonObject if_ndb = interfaces.createNestedObject("ndb");
   JsonArray if_ndb_ip = if_ndb.createNestedArray("ip");
   for (byte i = 0; i < 4; i++) {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -657,6 +657,15 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
     CJSON(hueIP[i], if_hue_ip[i]);
 #endif
 
+//WLEDMM: add netdebug variables
+#ifdef WLED_DEBUG_HOST
+  JsonObject if_ndb = interfaces["ndb"];
+  JsonArray if_ndb_ip = if_ndb["ip"];
+  for (byte i = 0; i < 4; i++)
+    CJSON(netDebugPrintIP[i], if_ndb_ip[i]);
+  CJSON(netDebugPrintPort, if_ndb["port"]);
+#endif
+
   JsonObject if_ntp = interfaces[F("ntp")];
   CJSON(ntpEnabled, if_ntp["en"]);
   getStringFromJson(ntpServerName, if_ntp[F("host")], 33); // "1.wled.pool.ntp.org"
@@ -1177,6 +1186,16 @@ void serializeConfig(JsonObject root) {
   for (unsigned i = 0; i < 4; i++) {
     if_hue_ip.add(hueIP[i]);
   }
+#endif
+
+//WLEDMM: add netdebug variables
+#ifdef WLED_DEBUG_HOST
+  JsonObject if_ndb = interfaces.createNestedObject("ndb");
+  JsonArray if_ndb_ip = if_ndb.createNestedArray("ip");
+  for (byte i = 0; i < 4; i++) {
+    if_ndb_ip.add(netDebugPrintIP[i]);
+  }
+  if_ndb["port"] = netDebugPrintPort;
 #endif
 
   JsonObject if_ntp = interfaces.createNestedObject("ntp");

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -718,7 +718,7 @@ function populateInfo(i)
 	cn += `v${i.ver} <i>"${vcn}"</i>${i.release ? '<br>('+i.release+')' : ''}<br><br><table>
 ${urows}
 ${urows===""?'':'<tr><td colspan=2><hr style="height:1px;border-width:0;color:gray;background-color:gray"></td></tr>'}
-${i.opt&0x100?inforow("Debug","<button class=\"btn btn-xs\" onclick=\"requestJson({'debug':"+(i.opt&0x0080?"false":"true")+"});\"><i class=\"icons "+(i.opt&0x0080?"on":"off")+"\">&#xe08f;</i></button>"):''}
+${i.opt&0x100?inforow("Net Debug","<button class=\"btn btn-xs\" onclick=\"requestJson({'debug':"+(i.opt&0x0080?"false":"true")+"});\"><i class=\"icons "+(i.opt&0x0080?"on":"off")+"\">&#xe08f;</i></button>"):''}
 ${inforow("Build",i.vid)}
 ${inforow("Signal strength",i.wifi.signal +"% ("+ i.wifi.rssi, " dBm)")}
 ${inforow("Uptime",getRuntimeStr(i.uptime))}

--- a/wled00/data/settings_sync.htm
+++ b/wled00/data/settings_sync.htm
@@ -284,6 +284,19 @@ Baud rate:
 </select><br>
 <i>Keep at 115200 to use Improv. Some boards may not support high rates.</i>
 </div>
+<div class="sec">
+<h3>Net Debug ☾</h3>
+<div id="NoNetDebug" class="hide">
+	<em style="color:#fa0;">This firmware build does not include Net Debug support.<br></em>
+</div>
+<div id="NetDebug">
+Netcat host IP:<br>
+<input name="N0" type="number" class="s" min="0" max="255" > .
+<input name="N1" type="number" class="s" min="0" max="255" > .
+<input name="N2" type="number" class="s" min="0" max="255" > .
+<input name="N3" type="number" class="s" min="0" max="255" ><br>
+Netcat host Port:<br>
+<input name="NP" type="number" min="0" max="99999" ><br>
 </div>
 <hr>
 <button type="button" onclick="B()">Back</button><button type="submit">Save</button>

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -368,7 +368,7 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 {
   bool stateResponse = root[F("v")] | false;
 
-  #if defined(WLED_DEBUG) && defined(WLED_DEBUG_HOST)
+  #if defined(WLED_DEBUG) && defined(WLED_ENABLE_NET_DEBUG)
   netDebugEnabled = root[F("debug")] | netDebugEnabled;
   #endif
 
@@ -856,7 +856,7 @@ void serializeInfo(JsonObject root)
   uint16_t os = 0;
   #ifdef WLED_DEBUG
   os  = 0x80;
-    #ifdef WLED_DEBUG_HOST
+    #ifdef WLED_ENABLE_NET_DEBUG
     os |= 0x0100;
     if (!netDebugEnabled) os &= ~0x0080;
     #endif

--- a/wled00/net_debug.cpp
+++ b/wled00/net_debug.cpp
@@ -1,23 +1,13 @@
 #include "wled.h"
 
-#ifdef WLED_DEBUG_HOST
+#ifdef WLED_DEBUG_HOST //WLEDMM: this looks unnecesarry as .h is not included anyway if no netdebug
 
 size_t NetworkDebugPrinter::write(uint8_t c) {
   if (!WLED_CONNECTED || !netDebugEnabled) return 0;
 
-  if (!debugPrintHostIP && !debugPrintHostIP.fromString(netDebugPrintHost)) {
-    #ifdef ESP8266
-      WiFi.hostByName(netDebugPrintHost, debugPrintHostIP, 750);
-    #else
-      #ifdef WLED_USE_ETHERNET
-        ETH.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #else
-        WiFi.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #endif
-    #endif
-  }
-
-  debugUdp.beginPacket(debugPrintHostIP, netDebugPrintPort);
+  //WLEDMM: init IP moved to initInterfaces
+  
+  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort); //WLEDMM: using netDebugPrintIP instead of debugPrintHostIP
   debugUdp.write(c);
   debugUdp.endPacket();
   return 1;
@@ -26,19 +16,9 @@ size_t NetworkDebugPrinter::write(uint8_t c) {
 size_t NetworkDebugPrinter::write(const uint8_t *buf, size_t size) {
   if (!WLED_CONNECTED || buf == nullptr || !netDebugEnabled) return 0;
 
-  if (!debugPrintHostIP && !debugPrintHostIP.fromString(netDebugPrintHost)) {
-    #ifdef ESP8266
-      WiFi.hostByName(netDebugPrintHost, debugPrintHostIP, 750);
-    #else
-      #ifdef WLED_USE_ETHERNET
-        ETH.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #else
-        WiFi.hostByName(netDebugPrintHost, debugPrintHostIP);
-      #endif
-    #endif
-  }
+  //WLEDMM: init IP moved to initInterfaces
 
-  debugUdp.beginPacket(debugPrintHostIP, netDebugPrintPort);
+  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort); //WLEDMM: using netDebugPrintIP instead of debugPrintHostIP
   size = debugUdp.write(buf, size);
   debugUdp.endPacket();
   return size;

--- a/wled00/net_debug.cpp
+++ b/wled00/net_debug.cpp
@@ -1,6 +1,6 @@
 #include "wled.h"
 
-#ifdef WLED_DEBUG_HOST //WLEDMM: this looks unnecesarry as .h is not included anyway if no netdebug
+#ifdef WLED_ENABLE_NET_DEBUG
 
 size_t NetworkDebugPrinter::write(uint8_t c) {
   if (!WLED_CONNECTED || !netDebugEnabled) return 0;

--- a/wled00/net_debug.cpp
+++ b/wled00/net_debug.cpp
@@ -5,9 +5,7 @@
 size_t NetworkDebugPrinter::write(uint8_t c) {
   if (!WLED_CONNECTED || !netDebugEnabled) return 0;
 
-  //WLEDMM: init IP moved to initInterfaces
-  
-  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort); //WLEDMM: using netDebugPrintIP instead of debugPrintHostIP
+  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort);
   debugUdp.write(c);
   debugUdp.endPacket();
   return 1;
@@ -16,9 +14,7 @@ size_t NetworkDebugPrinter::write(uint8_t c) {
 size_t NetworkDebugPrinter::write(const uint8_t *buf, size_t size) {
   if (!WLED_CONNECTED || buf == nullptr || !netDebugEnabled) return 0;
 
-  //WLEDMM: init IP moved to initInterfaces
-
-  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort); //WLEDMM: using netDebugPrintIP instead of debugPrintHostIP
+  debugUdp.beginPacket(netDebugPrintIP, netDebugPrintPort);
   size = debugUdp.write(buf, size);
   debugUdp.endPacket();
   return size;

--- a/wled00/net_debug.h
+++ b/wled00/net_debug.h
@@ -7,7 +7,7 @@
 class NetworkDebugPrinter : public Print {
   private:
     WiFiUDP debugUdp; // needs to be here otherwise UDP messages get truncated upon destruction
-    IPAddress debugPrintHostIP;
+    // IPAddress debugPrintHostIP;
   public:
     virtual size_t write(uint8_t c);
     virtual size_t write(const uint8_t *buf, size_t s);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -524,7 +524,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     #endif
 
     //WLEDMM: add netdebug variables
-    #ifdef WLED_DEBUG_HOST
+    #ifdef WLED_ENABLE_NET_DEBUG
       for (int i=0;i<4;i++){
         String a = "N"+String(i);
         netDebugPrintIP[i] = request->arg(a).toInt();

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -523,7 +523,6 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     reconnectHue();
     #endif
 
-    //WLEDMM: add netdebug variables
     #ifdef WLED_ENABLE_NET_DEBUG
       for (int i=0;i<4;i++){
         String a = "N"+String(i);

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -523,6 +523,15 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     reconnectHue();
     #endif
 
+    //WLEDMM: add netdebug variables
+    #ifdef WLED_DEBUG_HOST
+      for (int i=0;i<4;i++){
+        String a = "N"+String(i);
+        netDebugPrintIP[i] = request->arg(a).toInt();
+      }
+      netDebugPrintPort = request->arg("NP").toInt();
+    #endif
+
     t = request->arg(F("BD")).toInt();
     if (t >= 96 && t <= 15000) serialBaud = t;
     updateBaudRate(serialBaud *100);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -827,6 +827,35 @@ void WLED::initInterfaces()
   }
 #endif
 
+//WLEDMM: add netdebug variables
+#ifdef WLED_DEBUG_HOST
+  if (netDebugPrintIP[0] == 0) {
+    //WLEDMM: this code moved from net_debug.cpp as we store IP as IPAddress type
+    if (!netDebugPrintIP && !netDebugPrintIP.fromString(WLED_DEBUG_HOST)) {
+      #ifdef ESP8266
+        WiFi.hostByName(WLED_DEBUG_HOST, netDebugPrintIP, 750);
+      #else
+        #ifdef WLED_USE_ETHERNET
+          ETH.hostByName(WLED_DEBUG_HOST, netDebugPrintIP);
+        #else
+          WiFi.hostByName(WLED_DEBUG_HOST, netDebugPrintIP);
+        #endif
+      #endif
+    } else {
+      IPAddress ipAddress = Network.localIP();
+      netDebugPrintIP[0] = ipAddress[0];
+      netDebugPrintIP[1] = ipAddress[1];
+      netDebugPrintIP[2] = ipAddress[2];
+    }
+  }
+  if (netDebugPrintPort == 0) 
+    #ifdef WLED_DEBUG_PORT
+      netDebugPrintPort = WLED_DEBUG_PORT;
+    #else
+      netDebugPrintPort = 7868; //Default value
+    #endif
+#endif
+
 #ifndef WLED_DISABLE_ALEXA
   // init Alexa hue emulation
   if (alexaEnabled)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -384,7 +384,7 @@ void WLED::setup()
   #if defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && (defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3) || ARDUINO_USB_CDC_ON_BOOT)
   delay(2500);  // allow CDC USB serial to initialise
   #endif
-  #if !defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && !defined(WLED_DEBUG_HOST) && ARDUINO_USB_CDC_ON_BOOT
+  #if !defined(WLED_DEBUG) && defined(ARDUINO_ARCH_ESP32) && !defined(WLED_ENABLE_NET_DEBUG) && ARDUINO_USB_CDC_ON_BOOT
   Serial.setDebugOutput(false); // switch off kernel messages when using USBCDC
   #endif
   DEBUG_PRINTLN();
@@ -442,7 +442,7 @@ void WLED::setup()
   usePWMFixedNMI(); // link the NMI fix
 #endif
 
-#if defined(WLED_DEBUG) && !defined(WLED_DEBUG_HOST)
+#if defined(WLED_DEBUG) && !defined(WLED_ENABLE_NET_DEBUG)
   PinManager::allocatePin(hardwareTX, true, PinOwner::DebugOut); // TX (GPIO1 on ESP32) reserved for debug output
 #endif
 #ifdef WLED_ENABLE_DMX //reserve GPIO2 as hardcoded DMX pin
@@ -828,7 +828,7 @@ void WLED::initInterfaces()
 #endif
 
 //WLEDMM: add netdebug variables
-#ifdef WLED_DEBUG_HOST
+#ifdef WLED_ENABLE_NET_DEBUG
   if (netDebugPrintIP[0] == 0) {
     //WLEDMM: this code moved from net_debug.cpp as we store IP as IPAddress type
     if (!netDebugPrintIP && !netDebugPrintIP.fromString(WLED_DEBUG_HOST)) {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -827,10 +827,8 @@ void WLED::initInterfaces()
   }
 #endif
 
-//WLEDMM: add netdebug variables
 #ifdef WLED_ENABLE_NET_DEBUG
   if (netDebugPrintIP[0] == 0) {
-    //WLEDMM: this code moved from net_debug.cpp as we store IP as IPAddress type
     if (!netDebugPrintIP && !netDebugPrintIP.fromString(WLED_DEBUG_HOST)) {
       #ifdef ESP8266
         WiFi.hostByName(WLED_DEBUG_HOST, netDebugPrintIP, 750);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -973,12 +973,17 @@ WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);
 #endif
 WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
 
+// enable net debug output over UDP; use -D WLED_ENABLE_NET_DEBUG to activate.
+// Legacy: defining WLED_DEBUG_HOST='"ip_or_host"' also enables net debug and
+// pre-seeds the target IP at compile time.
+#if defined(WLED_DEBUG_HOST) && !defined(WLED_ENABLE_NET_DEBUG)
+  #define WLED_ENABLE_NET_DEBUG
+#endif
+
 // enable additional debug output
-//WLEDMM: switch between netdebug and serial
-#if defined(WLED_DEBUG_HOST)
+#if defined(WLED_ENABLE_NET_DEBUG)
   #include "net_debug.h"
   // On the host side, use netcat to receive the log statements: nc -l 7868 -u
-  // use -D WLED_DEBUG_HOST='"192.168.xxx.xxx"' or FQDN within quotes
   WLED_GLOBAL bool netDebugEnabled _INIT(false);
   WLED_GLOBAL int netDebugPrintPort _INIT(0);
   WLED_GLOBAL IPAddress netDebugPrintIP _INIT_N(((0, 0, 0, 0))); // IP address of the bridge
@@ -1008,26 +1013,25 @@ WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
   #define DEBUG_PRINTF_P(x...)
 #endif
 
-// WLEDMM: macros to print "user messages" to Serial
+// macros to print "user messages" to Serial
 // cannot do this on -S2, due to buggy USBCDC serial driver
-#if defined(WLED_DEBUG) || defined(WLED_DEBUG_HOST)
+#if defined(WLED_DEBUG) || defined(WLED_ENABLE_NET_DEBUG)
   // use DEBUG_PRINT
   #define USER_PRINT(x) DEBUG_PRINT(x)
   #define USER_PRINTLN(x) DEBUG_PRINTLN(x)
   #define USER_PRINTF(x...) DEBUG_PRINTF(x)
-  #ifdef WLED_DEBUG_HOST
+  #ifdef WLED_ENABLE_NET_DEBUG
     #define USER_FLUSH() {}
   #else
     #define USER_FLUSH() {DEBUGOUTFlush();}
   #endif
 #else
-  // if serial is availeable, we use Serial.print directly
+  // if serial is available, we use Serial.print directly
   #define USER_PRINT(x)      { if (canUseSerial()) DEBUGOUT(x); }
   #define USER_PRINTLN(x)    { if (canUseSerial()) DEBUGOUTLN(x); }
   #define USER_PRINTF(x...)  { if (canUseSerial()) DEBUGOUTF(x); }
   #define USER_FLUSH()       {DEBUGOUTFlush();}
 #endif
-// WLEDMM end
 
 
 #ifdef WLED_DEBUG_FS

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -974,29 +974,33 @@ WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);
 WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
 
 // enable additional debug output
+//WLEDMM: switch between netdebug and serial
 #if defined(WLED_DEBUG_HOST)
   #include "net_debug.h"
   // On the host side, use netcat to receive the log statements: nc -l 7868 -u
   // use -D WLED_DEBUG_HOST='"192.168.xxx.xxx"' or FQDN within quotes
-  #define DEBUGOUT NetDebug
-  WLED_GLOBAL bool netDebugEnabled _INIT(true);
-  WLED_GLOBAL char netDebugPrintHost[33] _INIT(WLED_DEBUG_HOST);
-  #ifndef WLED_DEBUG_PORT
-    #define WLED_DEBUG_PORT 7868
-  #endif
-  WLED_GLOBAL int netDebugPrintPort _INIT(WLED_DEBUG_PORT);
+  WLED_GLOBAL bool netDebugEnabled _INIT(false);
+  WLED_GLOBAL int netDebugPrintPort _INIT(0);
+  WLED_GLOBAL IPAddress netDebugPrintIP _INIT_N(((0, 0, 0, 0))); // IP address of the bridge
+  #define DEBUGOUT(x) netDebugEnabled?NetDebug.print(x):Serial.print(x)
+  #define DEBUGOUTLN(x) netDebugEnabled?NetDebug.println(x):Serial.println(x)
+  #define DEBUGOUTF(x...) netDebugEnabled?NetDebug.printf(x):Serial.printf(x)
+  #define DEBUGOUTFlush() netDebugEnabled?NetDebug.flush():Serial.flush()
 #else
-  #define DEBUGOUT Serial
+  #define DEBUGOUT(x) Serial.print(x)
+  #define DEBUGOUTLN(x) Serial.println(x)
+  #define DEBUGOUTF(x...) Serial.printf(x)
+  #define DEBUGOUTFlush() Serial.flush()
 #endif
 
 #ifdef WLED_DEBUG
   #ifndef ESP8266
   #include <rom/rtc.h>
   #endif
-  #define DEBUG_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUG_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUG_PRINTF(x...) DEBUGOUT.printf(x)
-  #define DEBUG_PRINTF_P(x...) DEBUGOUT.printf_P(x)
+  #define DEBUG_PRINT(x) DEBUGOUT(x)
+  #define DEBUG_PRINTLN(x) DEBUGOUTLN(x)
+  #define DEBUG_PRINTF(x...) DEBUGOUTF(x)
+  #define DEBUG_PRINTF_P(x...) DEBUGOUTF(x)
 #else
   #define DEBUG_PRINT(x)
   #define DEBUG_PRINTLN(x)
@@ -1004,10 +1008,32 @@ WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
   #define DEBUG_PRINTF_P(x...)
 #endif
 
+// WLEDMM: macros to print "user messages" to Serial
+// cannot do this on -S2, due to buggy USBCDC serial driver
+#if defined(WLED_DEBUG) || defined(WLED_DEBUG_HOST)
+  // use DEBUG_PRINT
+  #define USER_PRINT(x) DEBUG_PRINT(x)
+  #define USER_PRINTLN(x) DEBUG_PRINTLN(x)
+  #define USER_PRINTF(x...) DEBUG_PRINTF(x)
+  #ifdef WLED_DEBUG_HOST
+    #define USER_FLUSH() {}
+  #else
+    #define USER_FLUSH() {DEBUGOUTFlush();}
+  #endif
+#else
+  // if serial is availeable, we use Serial.print directly
+  #define USER_PRINT(x)      { if (canUseSerial()) DEBUGOUT(x); }
+  #define USER_PRINTLN(x)    { if (canUseSerial()) DEBUGOUTLN(x); }
+  #define USER_PRINTF(x...)  { if (canUseSerial()) DEBUGOUTF(x); }
+  #define USER_FLUSH()       {DEBUGOUTFlush();}
+#endif
+// WLEDMM end
+
+
 #ifdef WLED_DEBUG_FS
-  #define DEBUGFS_PRINT(x) DEBUGOUT.print(x)
-  #define DEBUGFS_PRINTLN(x) DEBUGOUT.println(x)
-  #define DEBUGFS_PRINTF(x...) DEBUGOUT.printf(x)
+  #define DEBUGFS_PRINT(x) DEBUGOUT(x)
+  #define DEBUGFS_PRINTLN(x) DEBUGOUTLN(x)
+  #define DEBUGFS_PRINTF(x...) DEBUGOUTF(x)
 #else
   #define DEBUGFS_PRINT(x)
   #define DEBUGFS_PRINTLN(x)

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -126,7 +126,7 @@ static void appendGPIOinfo(Print& settingsScript)
   settingsScript.print(2); // DMX hardcoded pin
   firstPin = false;
   #endif
-  #if defined(WLED_DEBUG) && !defined(WLED_DEBUG_HOST)
+  #if defined(WLED_DEBUG) && !defined(WLED_ENABLE_NET_DEBUG)
   if (!firstPin) settingsScript.print(',');
   settingsScript.print(hardwareTX); // debug output (TX) pin
   firstPin = false;
@@ -588,7 +588,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     #endif
 
     //WLEDMM: add netdebug variables
-    #ifdef WLED_DEBUG_HOST
+    #ifdef WLED_ENABLE_NET_DEBUG
       sappend('v',SET_F("N0"),netDebugPrintIP[0]);
       sappend('v',SET_F("N1"),netDebugPrintIP[1]);
       sappend('v',SET_F("N2"),netDebugPrintIP[2]);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -587,7 +587,6 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     settingsScript.print(F("toggle('Serial');"));
     #endif
 
-    //WLEDMM: add netdebug variables
     #ifdef WLED_ENABLE_NET_DEBUG
       sappend('v',SET_F("N0"),netDebugPrintIP[0]);
       sappend('v',SET_F("N1"),netDebugPrintIP[1]);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -586,6 +586,16 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     #ifndef WLED_ENABLE_ADALIGHT
     settingsScript.print(F("toggle('Serial');"));
     #endif
+
+    //WLEDMM: add netdebug variables
+    #ifdef WLED_DEBUG_HOST
+      sappend('v',SET_F("N0"),netDebugPrintIP[0]);
+      sappend('v',SET_F("N1"),netDebugPrintIP[1]);
+      sappend('v',SET_F("N2"),netDebugPrintIP[2]);
+      sappend('v',SET_F("N3"),netDebugPrintIP[3]);
+      sappend('v',SET_F("NP"),netDebugPrintPort);
+    #endif
+
   }
 
   if (subPage == SUBPAGE_TIME)


### PR DESCRIPTION
This pull request introduces significant improvements to the WLED network debug (Net Debug) system, shifting from hostname-based configuration to direct IP address and port configuration, and making Net Debug settings user-configurable through the web UI and JSON config. It also unifies and simplifies debug macro usage throughout the codebase.

**Key changes:**

### Net Debug System Overhaul

* Replaces the previous `WLED_DEBUG_HOST` (hostname-based) configuration with a new `WLED_ENABLE_NET_DEBUG` system that uses a direct IP address (`netDebugPrintIP`) and port (`netDebugPrintPort`) for UDP debug output, improving reliability and flexibility. Legacy `WLED_DEBUG_HOST` support is maintained for backward compatibility. [[1]](diffhunk://#diff-c921278adaae7a31dfc233a0045f050bf53cfd6a794e3e3802431ca4699bfab0R976-R1040) [[2]](diffhunk://#diff-db6477d829f659122c8069a5aaa0d5fcb80f9c0b052f7ba472d0d503079741f0L3-R8) [[3]](diffhunk://#diff-db6477d829f659122c8069a5aaa0d5fcb80f9c0b052f7ba472d0d503079741f0L29-R17) [[4]](diffhunk://#diff-2f7ea89a937fc05bec35a5a056ba742d00832da85456038e0001e50039227b64L10-R10)
* Updates the Net Debug UDP output logic to always use the configured IP and port, removing runtime DNS resolution and related member variables. [[1]](diffhunk://#diff-db6477d829f659122c8069a5aaa0d5fcb80f9c0b052f7ba472d0d503079741f0L3-R8) [[2]](diffhunk://#diff-db6477d829f659122c8069a5aaa0d5fcb80f9c0b052f7ba472d0d503079741f0L29-R17) [[3]](diffhunk://#diff-2f7ea89a937fc05bec35a5a056ba742d00832da85456038e0001e50039227b64L10-R10)
* Initializes Net Debug IP and port with sensible defaults if not set, using compile-time or runtime network information.

### Debug Macro and Output Refactoring

* Refactors all debug output macros (`DEBUG_PRINT`, `DEBUGFX_PRINT`, `DEBUGBUS_PRINT`, etc.) to use unified function-style macros (`DEBUGOUT(x)`, `DEBUGOUTLN(x)`, `DEBUGOUTF(x...)`), simplifying the code and ensuring consistent debug output routing. [[1]](diffhunk://#diff-c921278adaae7a31dfc233a0045f050bf53cfd6a794e3e3802431ca4699bfab0R976-R1040) [[2]](diffhunk://#diff-36b4a8cdc6e93d06634be652ad20021f20985c6099fa8df80c4e52fae2e9d29eL52-R54) [[3]](diffhunk://#diff-b8c18b57bc2d8d0b9bf60bf9cbfc8d79f681b53d70f6d7f342ac3c1c807cd412L23-R26) [[4]](diffhunk://#diff-79b3ffd5bec6c92a0c0d409d622728348ac969b4d3a6b3b944134ae373deb3d0L36-R43)
* Adjusts conditional logic throughout the codebase to use `WLED_ENABLE_NET_DEBUG` instead of `WLED_DEBUG_HOST`, clarifying feature toggling and pin allocation. [[1]](diffhunk://#diff-81fb86539a4966e6e5a2df3e463988478732991e5db8bdb763dc340ab0e2462bL387-R387) [[2]](diffhunk://#diff-81fb86539a4966e6e5a2df3e463988478732991e5db8bdb763dc340ab0e2462bL445-R445) [[3]](diffhunk://#diff-ea99264d317ef01ab535954ced6325bb08ff41b206092908bcaebbcd3487731bL129-R129)

### Configuration and Web UI Enhancements

* Adds Net Debug IP and port fields to the settings web UI (`settings_sync.htm`), enabling users to configure network debug output directly from the browser.
* Serializes and deserializes Net Debug IP and port in the JSON configuration, ensuring settings persist across reboots and can be managed via config files or API. [[1]](diffhunk://#diff-5b4546c6f75d5b191f45f9afae0d47f63384d2eff2b0b9f2f42715d7bd88152bR660-R667) [[2]](diffhunk://#diff-5b4546c6f75d5b191f45f9afae0d47f63384d2eff2b0b9f2f42715d7bd88152bR1190-R1198) [[3]](diffhunk://#diff-4b8fbb87a9fcc151310505a3e8799a0097ff5b4d9549be16eed8ef9420534074R526-R533) [[4]](diffhunk://#diff-ea99264d317ef01ab535954ced6325bb08ff41b206092908bcaebbcd3487731bR589-R597)

### JSON API and Info Output

* Updates JSON API and info output to reflect the new Net Debug system, including reporting Net Debug status and options correctly. [[1]](diffhunk://#diff-6b6413edc70eb5a8b8d037f55e51154ae77788f431721701e949d2f00cd99820L371-R371) [[2]](diffhunk://#diff-6b6413edc70eb5a8b8d037f55e51154ae77788f431721701e949d2f00cd99820L859-R859) [[3]](diffhunk://#diff-83fa1932c634f4dd0e2492cd52596d6e1b6eb76da4f60c0e6e2f9d46f3ff6548L721-R721)

These changes modernize and robustify the Net Debug system, make debug output more maintainable, and improve user configurability and transparency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated and simplified debug output macro implementations across core components

* **New Features**
  * Network debug configuration now available in Sync Settings, enabling users to configure network debug output with custom IP address (four octets) and port number

* **UI Changes**
  * Debug interface labels renamed from "Debug" to "Net Debug" throughout the settings interface
<!-- end of auto-generated comment: release notes by coderabbit.ai -->