### PR TITLE
Automatically download the right bin for the latest release and install

### DIFF
--- a/wled00/data/settings_sec.htm
+++ b/wled00/data/settings_sec.htm
@@ -62,7 +62,7 @@
 	</div>
 	<div class="sec" id="OTA">
 		<h3>Software Update</h3>
-		<button type="button" onclick="U()">Manual OTA Update</button><br>
+		<button type="button" onclick="U()">Update WLED</button><br>
 		<div id="aOTA">Enable ArduinoOTA: <input type="checkbox" name="AO"></div>
 		Only allow update from same network/WiFi: <input type="checkbox" name="SU"><br>
 		<i class="warn">&#9888; If you are using multiple VLANs (i.e. IoT or guest network) either set PIN or disable this option.<br>

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -25,14 +25,28 @@
 				.then(data => {
 					deviceInfo = data;
 					document.querySelector('.installed-version').textContent = `${data.brand} ${data.ver} (${data.vid})`;
+					const repoUrl = data.repo && data.repo !== "unknown" ? "https://github.com/" + data.repo + "/releases/latest" : null;
 					document.querySelector('.release-name').textContent = data.release;
 					// assemble update URL and update release badge
-					if (data.repo && data.repo !== "unknown") {
-						const repoUrl = "https://github.com/" + data.repo + "/releases/latest";
+					if (repoUrl) {
 						const badgeUrl = "https://img.shields.io/github/release/" + data.repo + ".svg?style=flat-square";
 						document.querySelector('.release-repo').href = repoUrl;
 						document.querySelector('.release-badge').src = badgeUrl;
 						toggle('release-download'); // only show release download item after receiving a valid data.repo
+						// fetch latest release from GitHub to build direct bin download link
+						fetch(`https://api.github.com/repos/${data.repo}/releases/latest`)
+							.then(r => r.json())
+							.then(gh => {
+								const ver = gh.tag_name.replace(/^v/, '');
+								const suffix = `_${ver}_${data.release}.bin`;
+								const asset = gh.assets.find(a => a.name.endsWith(suffix));
+								if (asset) {
+									const binUrl = asset.browser_download_url.replace(/^https?:\/\/[^/]+/, 'https://download.wled.me');
+									const el = document.querySelector('.release-name');
+									el.innerHTML = `<a href="${binUrl}">${data.release}</a>`;
+								}
+							})
+							.catch(() => {}); // silently ignore if GitHub API unavailable
 					} else {
 						gId('Norelease-download').classList.add("hide"); // repo invalid -> hide everything
 					}
@@ -121,20 +135,22 @@
 		<p>
 		Installed version: <span class="sip installed-version">Loading...</span><br>
 		Release: <span class="sip release-name">Loading...</span><br>
-		<span id="Norelease-download">Latest binary: Checking...<br></span>
+		<span id="Norelease-download">Latest release: Checking...<br></span>
 		<span id="release-download" class="hide">
-		Download the latest binary: <a class="release-repo" href="https://github.com/wled/WLED/releases/latest" target="_blank" rel="noopener noreferrer"
+		Latest release: <a class="release-repo" href="https://github.com/wled/WLED/releases/latest" target="_blank" rel="noopener noreferrer"
 		style="vertical-align: text-bottom; display: inline-flex;">
-		<img class="release-badge" alt="badge"></a><br> <!-- start with an empty placeholder, src will be filled after fetching /json/info -->
-		<button type="button" id="autoUpdBtn" onclick="autoUpdate()">Auto-update from GitHub</button>
+		<img class="release-badge" alt="View latest"></a><br>
+		<button type="button" id="autoUpdBtn" onclick="autoUpdate()">Auto update</button>
 		<span id="autoUpdStatus" style="display:block;margin-top:4px;font-size:13px;"></span>
 		</span>
 		</p>
+		<hr class="sml">
+		<h3>Manual upload</h3>
 		<input type="hidden" name="skipValidation" value="" id="sV">
 		<input type='file' name='update' required><br> <!--should have accept='.bin', but it prevents file upload from android app-->
 		<input type='checkbox' onchange="sV.value=checked?1:''" id="skipValidation">
 		<label for='skipValidation'>Ignore firmware validation</label><br>
-		<button type="submit">Update WLED!</button><br>
+		<button type="submit">Upload</button><br>
 		<span id="rev">
 			<hr class="sml">
 			<button type="button" onclick="cR()">Revert update</button><br>

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -137,7 +137,7 @@
 		Release: <span class="sip release-name">Loading...</span><br>
 		<span id="Norelease-download">Latest release: Checking...<br></span>
 		<span id="release-download" class="hide">
-		Latest release: <a class="release-repo" href="https://github.com/wled/WLED/releases/latest" target="_blank" rel="noopener noreferrer"
+		Latest version: <a class="release-repo" href="https://github.com/wled/WLED/releases/latest" target="_blank" rel="noopener noreferrer"
 		style="vertical-align: text-bottom; display: inline-flex;">
 		<img class="release-badge" alt="View latest"></a><br>
 		<button type="button" id="autoUpdBtn" onclick="autoUpdate()">Auto update</button>

--- a/wled00/data/update.htm
+++ b/wled00/data/update.htm
@@ -7,6 +7,7 @@
 	<script>
 		function B() { window.history.back(); }
 		var cnfr = false;
+		var deviceInfo = null;
 		function cR() {
 			if (!cnfr) {
 				var bt = gId('rev');
@@ -22,6 +23,7 @@
 			fetch(getURL('/json/info'))
 				.then(response => response.json())
 				.then(data => {
+					deviceInfo = data;
 					document.querySelector('.installed-version').textContent = `${data.brand} ${data.ver} (${data.vid})`;
 					document.querySelector('.release-name').textContent = data.release;
 					// assemble update URL and update release badge
@@ -60,6 +62,48 @@
 			gId('bootupd').classList.add("hide");
 			toggle('upd');			
 		}
+		async function autoUpdate() {
+			const btn = gId('autoUpdBtn');
+			const status = gId('autoUpdStatus');
+			btn.disabled = true;
+			status.textContent = '';
+			try {
+				const info = deviceInfo;
+				if (!info || !info.repo || info.repo === 'unknown') {
+					status.textContent = 'No release repository available for this build.';
+					btn.disabled = false;
+					return;
+				}
+				status.textContent = 'Checking GitHub for latest release...';
+				const ghResp = await fetch(`https://api.github.com/repos/${info.repo}/releases/latest`);
+				if (!ghResp.ok) throw new Error(`GitHub API error: ${ghResp.status}`);
+				const ghRelease = await ghResp.json();
+				const releaseVer = ghRelease.tag_name.replace(/^v/, '');
+				const assetSuffix = `_${releaseVer}_${info.release}.bin`;
+				const asset = ghRelease.assets.find(a => a.name.endsWith(assetSuffix));
+				if (!asset) {
+					const available = ghRelease.assets.map(a => a.name).join(', ');
+					status.textContent = `Firmware not found (*${assetSuffix}). Available: ${available}`;
+					btn.disabled = false;
+					return;
+				}
+				status.textContent = `Downloading ${asset.name} (${Math.round(asset.size/1024)} KB)...`;
+				const fwUrl = asset.browser_download_url.replace(/^https?:\/\/[^/]+/, 'https://download.wled.me');
+				const fwResp = await fetch(fwUrl);
+				if (!fwResp.ok) throw new Error(`Download failed: ${fwResp.status}`);
+				const blob = await fwResp.blob();
+				const file = new File([blob], asset.name, {type: 'application/octet-stream'});
+				const dt = new DataTransfer();
+				dt.items.add(file);
+				document.querySelector('input[name="update"]').files = dt.files;
+				status.textContent = `Downloaded ${asset.name}. Uploading to device...`;
+				hideforms();
+				gId('upd').submit();
+			} catch(e) {
+				status.textContent = 'Auto-update failed: ' + e.message;
+				btn.disabled = false;
+			}
+		}
 	</script>
 	<style>
 		@import url("style.css");
@@ -82,6 +126,8 @@
 		Download the latest binary: <a class="release-repo" href="https://github.com/wled/WLED/releases/latest" target="_blank" rel="noopener noreferrer"
 		style="vertical-align: text-bottom; display: inline-flex;">
 		<img class="release-badge" alt="badge"></a><br> <!-- start with an empty placeholder, src will be filled after fetching /json/info -->
+		<button type="button" id="autoUpdBtn" onclick="autoUpdate()">Auto-update from GitHub</button>
+		<span id="autoUpdStatus" style="display:block;margin-top:4px;font-size:13px;"></span>
 		</span>
 		</p>
 		<input type="hidden" name="skipValidation" value="" id="sV">


### PR DESCRIPTION
This pull request enhances the WLED software update page by introducing an "Auto-update from GitHub" feature. This allows users to automatically fetch and install the latest compatible firmware release directly from GitHub, streamlining the update process and providing real-time status feedback.

<img width="872" height="750" alt="Screenshot From 2026-05-04 11-16-14" src="https://github.com/user-attachments/assets/12e0da5e-1aa6-4900-8d7c-683b450dcd98" />


**New auto-update functionality:**

* Added a new `autoUpdate` async function that:
  - Checks for the latest firmware release on GitHub based on the device's repository and release info.
  - Finds and downloads the appropriate firmware asset.
  - Automatically uploads the firmware to the device and provides status updates or error messages.
* Introduced a new "Auto-update from GitHub" button and a status display area to the update page UI, allowing users to initiate and monitor the update process.

**Supporting changes:**

* Stored device info from `/json/info` in a global `deviceInfo` variable for use in the auto-update logic. [[1]](diffhunk://#diff-bf11572cb75c4bf48872790bbb20db8ffc9a4839a1c32858da5680203ebed3b0R10) [[2]](diffhunk://#diff-bf11572cb75c4bf48872790bbb20db8ffc9a4839a1c32858da5680203ebed3b0R26)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Auto update" button that fetches, downloads, and installs the latest firmware release automatically, with status messages and error handling; disables while running.

* **UI Improvements**
  * Renamed settings button to "Update WLED" and changed the update page's manual submit label to "Upload".
  * Updated text/placeholders for the latest-release area and added an auto-update status element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->