### PR TITLE
fix: GIF disposal method 2 not applied in Image effect (pixel trails)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -263,7 +263,7 @@ lib_deps_compat =
 lib_deps =
   esp32async/AsyncTCP @ 3.4.7
   bitbank2/AnimatedGIF@^1.4.7
-  https://github.com/Aircoookie/GifDecoder.git#bc3af189b6b1e06946569f6b4287f0b79a860f8e
+  https://github.com/teetow/GifDecoder.git#80a2912eb18c5caf9176509669d674fb26a2f7ee
 build_flags =
   -D CONFIG_ASYNC_TCP_USE_WDT=0
   -D CONFIG_ASYNC_TCP_STACK_SIZE=8192


### PR DESCRIPTION
## Summary

GIF animations using disposal method 2 ("restore to background") show pixel trails in the WLED Image effect. Transparent areas of each new frame are obscured by leftover opaque pixels from the previous frame.

## Root cause

AnimatedGIF's disposal=2 handling in DecodeLZW only runs when a framebuffer is allocated (COOKED mode). WLED's GifDecoder wrapper uses RAW mode with no framebuffer, so disposal semantics are silently skipped.

The old inline workaround in GifDecoder_Impl.h GIFDraw() tried to replace transparent pixels with background color per-scanline, but this has wrong semantics (it modifies the current frame instead of clearing before the next frame) and silently no-ops when background index == transparent index (both commonly 0).

## Fix

This PR bumps the pinned GifDecoder commit to include a fix that tracks the previous frame disposal method and calls screenClearCallback() at the start of the next frame when disposal=2 was requested.

See: https://github.com/Aircoookie/GifDecoder/pull/1

Note: the GifDecoder PR must merge first; once it does, the pinned URL here should be updated from teetow/GifDecoder to Aircoookie/GifDecoder at the same commit SHA (80a2912).

## Testing

Verified on ESP32 32x16 LED matrix: GIF animations with disposal=2 and transparent regions no longer accumulate pixel trails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GIF decoder library dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->