### PR TITLE
Track cmDNS-default state to restore Device-Name-based hostname

### DIFF
--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -101,6 +101,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     }
 
     strlcpy(cmDNS, request->arg(F("CM")).c_str(), 33);
+    cmDNSisDefault = false; // any explicit save means user-set (form has no way to re-enter the "x" sentinel)
 
     apBehavior = request->arg(F("AB")).toInt();
     char oldSSID[33]; strcpy(oldSSID, apSSID);

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -156,7 +156,7 @@ static void sanitizeHostname(char* hostname, size_t maxLen) {
  */
 void getWLEDhostname(char* hostname, size_t maxLen, bool preferMDNS) {
   if (maxLen <= 6) { strlcpy(hostname, "wled", maxLen); return; } // buffer too small (should not happen)
-  if (preferMDNS && (strlen(cmDNS) > 0) && (strcmp_P(cmDNS, PSTR(DEFAULT_MDNS_NAME)) != 0)) {     // avoid "x" = not set (use wled-MAC)
+  if (preferMDNS && (strlen(cmDNS) > 0) && !cmDNSisDefault) {     // user-customized mDNS name -> use as hostname; otherwise fall back to legacy "wled-<DeviceName>"
     strlcpy(hostname, cmDNS, maxLen);
     sanitizeHostname(hostname, maxLen);  // sanitize cmDNS name
     if (strlen(hostname) < 1) {          // if result is empty -> fall back to wled-MAC

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -532,8 +532,10 @@ void WLED::setup()
   }
   #endif
 
-  // fill in unique mdns default
-  if (strcmp(cmDNS, DEFAULT_MDNS_NAME) == 0) sprintf_P(cmDNS, PSTR("wled-%*s"), 6, escapedMac.c_str() + 6);
+  // fill in unique mdns default; remember whether we did so the hostname
+  // logic can distinguish auto-filled vs. user-set values
+  cmDNSisDefault = (strcmp(cmDNS, DEFAULT_MDNS_NAME) == 0);
+  if (cmDNSisDefault) sprintf_P(cmDNS, PSTR("wled-%*s"), 6, escapedMac.c_str() + 6);
 #ifndef WLED_DISABLE_MQTT
   if (mqttDeviceTopic[0] == 0) sprintf_P(mqttDeviceTopic, PSTR("wled/%*s"), 6, escapedMac.c_str() + 6);
   if (mqttClientID[0] == 0)    sprintf_P(mqttClientID, PSTR("WLED-%*s"), 6, escapedMac.c_str() + 6);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -331,6 +331,7 @@ WLED_GLOBAL char ntpServerName[33] _INIT("0.wled.pool.ntp.org");   // NTP server
 WLED_GLOBAL std::vector<WiFiConfig> multiWiFi;
 WLED_GLOBAL IPAddress dnsAddress _INIT_N(((  8,   8,  8,  8)));   // Google's DNS
 WLED_GLOBAL char cmDNS[33]       _INIT(MDNS_NAME);                // mDNS address (*.local, replaced by wledXXXXXX if default is used)
+WLED_GLOBAL bool cmDNSisDefault  _INIT(true);                     // true while cmDNS still holds the auto-filled wled-<MAC> default (user has not customized it)
 WLED_GLOBAL char apSSID[33]      _INIT("");                       // AP off by default (unless setup)
 #ifdef WLED_SAVE_RAM
 typedef class WiFiOptions {


### PR DESCRIPTION
PR #5424 made `getWLEDhostname()` prefer `cmDNS` over the legacy `serverDescription`-based hostname, but `cmDNS` is still overwritten at boot with "wled-<mac6>" when it holds the "x" default sentinel. The new hostname check (strcmp_P against `DEFAULT_MDNS_NAME`) sees the auto-filled value and treats it as user-configured, so users who never customized the mDNS field — and previously got ``wled-<DeviceName>`` as their network hostname — now get ``wled-<mac6>`` instead.

Track whether the auto-fill was applied via a new cmDNSisDefault flag, and use that in `getWLEDhostname()`. The flag is set at boot from the comparison against `DEFAULT_MDNS_NAME` and cleared when the user saves the WiFi settings form. All other consumers (MDNS.begin, ArduinoOTA.setHostname, captive portal, MQTT, bus_manager, improv) keep using the auto-filled `cmDNS` unchanged.

Fixes: #5563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Improved internal tracking of mDNS hostname configuration to better distinguish between auto-generated and user-configured values, enabling more accurate settings management going forward.

* **Refactor**
  * Enhanced hostname configuration state tracking for improved settings management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->