### PR TITLE
Improve Boot preset handling

### DIFF
--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -520,7 +520,7 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     if (root["win"].isNull() && getVal(root["ps"], presetCycCurr, 1, 250) && presetCycCurr > 0 && presetCycCurr < 251 && presetCycCurr != currentPreset) {
       DEBUG_PRINTF_P(PSTR("Preset select: %d\n"), presetCycCurr);
       // b) preset ID only or preset that does not change state (use embedded cycling limits if they exist in getVal())
-      if (callMode == CALL_MODE_INIT) callMode = CALL_MODE_DIRECT_CHANGE // avoid propogating CALL_MODE_INIT, which may cause accidental recursion.
+      if (callMode == CALL_MODE_INIT) callMode = CALL_MODE_DIRECT_CHANGE; // avoid propogating CALL_MODE_INIT, which may cause accidental recursion.
       applyPreset(presetCycCurr, callMode); // async load from file system (only preset ID was specified)
       return stateResponse;
     } else presetCycCurr = currentPreset; // restore presetCycCurr

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -520,8 +520,9 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     if (root["win"].isNull() && getVal(root["ps"], presetCycCurr, 1, 250) && presetCycCurr > 0 && presetCycCurr < 251 && presetCycCurr != currentPreset) {
       DEBUG_PRINTF_P(PSTR("Preset select: %d\n"), presetCycCurr);
       // b) preset ID only or preset that does not change state (use embedded cycling limits if they exist in getVal())
-      if (callMode == CALL_MODE_INIT) callMode = CALL_MODE_DIRECT_CHANGE; // avoid propogating CALL_MODE_INIT, which may cause accidental recursion.
-      applyPreset(presetCycCurr, callMode); // async load from file system (only preset ID was specified)
+      // async load from file system (only preset ID was specified)
+      // avoid propogating CALL_MODE_INIT, which may cause accidental recursion
+      applyPreset(presetCycCurr, callMode == CALL_MODE_INIT ? CALL_MODE_DIRECT_CHANGE : callMode);
       return stateResponse;
     } else presetCycCurr = currentPreset; // restore presetCycCurr
   }

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -520,6 +520,7 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     if (root["win"].isNull() && getVal(root["ps"], presetCycCurr, 1, 250) && presetCycCurr > 0 && presetCycCurr < 251 && presetCycCurr != currentPreset) {
       DEBUG_PRINTF_P(PSTR("Preset select: %d\n"), presetCycCurr);
       // b) preset ID only or preset that does not change state (use embedded cycling limits if they exist in getVal())
+      if (callMode == CALL_MODE_INIT) callMode = CALL_MODE_DIRECT_CHANGE // avoid propogating CALL_MODE_INIT, which may cause accidental recursion.
       applyPreset(presetCycCurr, callMode); // async load from file system (only preset ID was specified)
       return stateResponse;
     } else presetCycCurr = currentPreset; // restore presetCycCurr

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -195,6 +195,10 @@ void handlePresets()
   } else {
     if (!fdo["seg"].isNull() || !fdo["on"].isNull() || !fdo["bri"].isNull() || !fdo["nl"].isNull() || !fdo["ps"].isNull() || !fdo[F("playlist")].isNull()) changePreset = true;
 
+    // TODO:
+    // Scenario 1: boot preset (CALL_MODE_INIT AND sets lor>0) - do not strip ps, allowing boot preset to chain 1 single preset
+    // Scenario 2: boot playlist (CALL_MODE_DIRECT_CHANGE AND sets lor>0) - continue, else re-queue. is CALL_MODE_DIRECT_CHANGE correct or do I need to pass through CALL_MODE_INIT or create a new special-case call mode
+    
     if (!(tmpMode == CALL_MODE_INIT || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~')))) // exception for CALL_MODE_INIT and button preset
       fdo.remove("ps"); // remove load request for presets to prevent recursive crash (if not called by button and contains preset cycling string "1~5~")
     deserializeState(fdo, CALL_MODE_NO_NOTIFY, tmpPreset); // may change presetToApply by calling applyPreset()

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -173,7 +173,7 @@ void handlePresets()
   } else
   #endif
   {
-    presetErrFlag = readObjectFromFileUsingId(getPresetsFileName(tmpPreset < 255), tmpPreset, pDoc) ? ERR_NONE : ERR_FS_PLOAD;
+  presetErrFlag = readObjectFromFileUsingId(getPresetsFileName(tmpPreset < 255), tmpPreset, pDoc) ? ERR_NONE : ERR_FS_PLOAD;
   }
   fdo = pDoc->as<JsonObject>();
 

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -176,12 +176,24 @@ void handlePresets()
   } else
   #endif
   {
-  presetErrFlag = readObjectFromFileUsingId(getPresetsFileName(tmpPreset < 255), tmpPreset, pDoc) ? ERR_NONE : ERR_FS_PLOAD;
+    presetErrFlag = readObjectFromFileUsingId(getPresetsFileName(tmpPreset < 255), tmpPreset, pDoc) ? ERR_NONE : ERR_FS_PLOAD;
   }
   fdo = pDoc->as<JsonObject>();
 
-  // only reset errorflag if previous error was preset-related
+  // only reset error flag if previous error was preset-related
   if ((errorFlag == ERR_NONE) || (errorFlag == ERR_FS_PLOAD)) errorFlag = presetErrFlag;
+
+  // is this the boot preset and will the preset set lor
+  const bool isBootPreset = (tmpMode==CALL_MODE_INIT || tmpPreset==bootPreset);
+  const bool presetWillSetLor = (!fdo["lor"].isNull() && fdo["lor"].as<int>() > REALTIME_OVERRIDE_NONE);
+  
+  // During setup, only allow the boot preset itself or safe boot-preset chains.
+  const bool shouldAllowPresetApply = (
+                                       setupComplete || isBootPreset ||
+                                       (currentPreset == bootPreset && realtimeOverride > REALTIME_OVERRIDE_NONE) ||
+                                       (currentPreset == bootPreset && currentPlaylist > 0 && presetWillSetLor)
+                                       );
+  if (!shouldAllowPresetApply) return;
 
   //HTTP API commands
   const char* httpwin = fdo["win"];
@@ -194,13 +206,12 @@ void handlePresets()
     changePreset = true;
   } else {
     if (!fdo["seg"].isNull() || !fdo["on"].isNull() || !fdo["bri"].isNull() || !fdo["nl"].isNull() || !fdo["ps"].isNull() || !fdo[F("playlist")].isNull()) changePreset = true;
-
-    // TODO:
-    // Scenario 1: boot preset (CALL_MODE_INIT AND sets lor>0) - do not strip ps, allowing boot preset to chain 1 single preset
-    // Scenario 2: boot playlist (CALL_MODE_DIRECT_CHANGE AND sets lor>0) - continue, else re-queue. is CALL_MODE_DIRECT_CHANGE correct or do I need to pass through CALL_MODE_INIT or create a new special-case call mode
     
-    if (!(tmpMode == CALL_MODE_INIT || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~')))) // exception for CALL_MODE_INIT and button preset
-      fdo.remove("ps"); // remove load request for presets to prevent recursive crash (if not called by button and contains preset cycling string "1~5~")
+    // only allow load requests from boot presets that set lor or button calls
+    const bool isButtonException = (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'))
+    
+    const bool shouldAllowLoadRequest = (isBootPreset && presetWillSetLor) || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'))
+    if (!shouldAllowLoadRequest) fdo.remove("ps"); // remove load request for presets to prevent recursive crash
     deserializeState(fdo, CALL_MODE_NO_NOTIFY, tmpPreset); // may change presetToApply by calling applyPreset()
   }
   if (!errorFlag && tmpPreset < 255 && changePreset) currentPreset = tmpPreset;

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -162,7 +162,7 @@ void handlePresets()
 
   presetToApply = 0; //clear request for preset
   callModeToApply = 0;
-  
+
   DEBUG_PRINTF_P(PSTR("Applying preset: %u\n"), (unsigned)tmpPreset);
 
   #if defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32C3)
@@ -282,4 +282,4 @@ void deletePreset(byte index) {
   writeObjectToFileUsingId(getPresetsFileName(), index, &empty);
   presetsModifiedTime = toki.second(); //unix time
   updateFSInfo();
-}
+}w

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -282,4 +282,5 @@ void deletePreset(byte index) {
   writeObjectToFileUsingId(getPresetsFileName(), index, &empty);
   presetsModifiedTime = toki.second(); //unix time
   updateFSInfo();
-}w
+}
+

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -194,7 +194,8 @@ void handlePresets()
     changePreset = true;
   } else {
     if (!fdo["seg"].isNull() || !fdo["on"].isNull() || !fdo["bri"].isNull() || !fdo["nl"].isNull() || !fdo["ps"].isNull() || !fdo[F("playlist")].isNull()) changePreset = true;
-    if (!(tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~')))
+
+    if (!(tmpMode == CALL_MODE_INIT || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~')))) // exception for CALL_MODE_INIT and button preset
       fdo.remove("ps"); // remove load request for presets to prevent recursive crash (if not called by button and contains preset cycling string "1~5~")
     deserializeState(fdo, CALL_MODE_NO_NOTIFY, tmpPreset); // may change presetToApply by calling applyPreset()
   }

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -283,4 +283,3 @@ void deletePreset(byte index) {
   presetsModifiedTime = toki.second(); //unix time
   updateFSInfo();
 }
-

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -160,6 +160,9 @@ void handlePresets()
 
   JsonObject fdo;
 
+  presetToApply = 0; //clear request for preset
+  callModeToApply = 0;
+  
   DEBUG_PRINTF_P(PSTR("Applying preset: %u\n"), (unsigned)tmpPreset);
 
   #if defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32C3)
@@ -177,16 +180,8 @@ void handlePresets()
   }
   fdo = pDoc->as<JsonObject>();
 
-  // only reset error flag if previous error was preset-related
+  // only reset errorflag if previous error was preset-related
   if ((errorFlag == ERR_NONE) || (errorFlag == ERR_FS_PLOAD)) errorFlag = presetErrFlag;
-
-  // if preset is boot preset and does not explicitly set lor, hold in queue for main loop to process
-  // this preserves existing behavior - new behavior where boot preset is loaded by main loop
-  // lor:0 can be used to load boot preset before any realtime data is received, resulting in a fast and consistent power on, but may be overridden by realtime, as soon as realtime starts. lor:1 and lor:2 can be used to prevent realtime data from taking over at boot.
-  if (tmpMode==CALL_MODE_INIT && fdo["lor"].isNull()) { //} && fdo["lor"].as<int>() == REALTIME_OVERRIDE_NONE) {
-    releaseJSONBufferLock();
-    return;
-  }
 
   //HTTP API commands
   const char* httpwin = fdo["win"];

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -180,20 +180,10 @@ void handlePresets()
   // only reset error flag if previous error was preset-related
   if ((errorFlag == ERR_NONE) || (errorFlag == ERR_FS_PLOAD)) errorFlag = presetErrFlag;
 
-  // is this the boot preset and will the preset set lor
-  const bool isBootPreset = (tmpMode==CALL_MODE_INIT || tmpPreset==bootPreset);
-  const bool presetWillSetLor = (!fdo["lor"].isNull() && fdo["lor"].as<int>() > REALTIME_OVERRIDE_NONE);
-
-  // During setup, only allow the boot preset itself or safe boot-preset chains.
-  const bool shouldAllowPresetApply = (
-                                       setupComplete || isBootPreset ||
-                                       (currentPreset == bootPreset && realtimeOverride > REALTIME_OVERRIDE_NONE) ||
-                                       (currentPreset == bootPreset && currentPlaylist > 0 && presetWillSetLor)
-                                       );
-  if (shouldAllowPresetApply) {
-    presetToApply = 0; //clear request for preset
-    callModeToApply = 0;
-  } else {
+  // if preset is boot preset and does not explicitly set lor, hold in queue for main loop to process
+  // this preserves existing behavior - new behavior where boot preset is loaded by main loop
+  // lor:0 can be used to load boot preset before any realtime data is received, resulting in a fast and consistent power on, but may be overridden by realtime, as soon as realtime starts. lor:1 and lor:2 can be used to prevent realtime data from taking over at boot.
+  if (tmpMode==CALL_MODE_INIT && fdo["lor"].isNull()) { //} && fdo["lor"].as<int>() == REALTIME_OVERRIDE_NONE) {
     releaseJSONBufferLock();
     return;
   }
@@ -209,11 +199,8 @@ void handlePresets()
     changePreset = true;
   } else {
     if (!fdo["seg"].isNull() || !fdo["on"].isNull() || !fdo["bri"].isNull() || !fdo["nl"].isNull() || !fdo["ps"].isNull() || !fdo[F("playlist")].isNull()) changePreset = true;
-    
-    // only allow load requests from boot presets that set lor or button calls
-    const bool isButtonException = (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'));
-    const bool shouldAllowLoadRequest = (isBootPreset && presetWillSetLor) || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'));
-    if (!shouldAllowLoadRequest) fdo.remove("ps"); // remove load request for presets to prevent recursive crash
+    if (!(tmpMode == CALL_MODE_INIT || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'))))
+      fdo.remove("ps"); // remove load request for presets to prevent recursive crash (if not called by boot preset or button which contains preset cycling string "1~5~")
     deserializeState(fdo, CALL_MODE_NO_NOTIFY, tmpPreset); // may change presetToApply by calling applyPreset()
   }
   if (!errorFlag && tmpPreset < 255 && changePreset) currentPreset = tmpPreset;

--- a/wled00/presets.cpp
+++ b/wled00/presets.cpp
@@ -160,9 +160,6 @@ void handlePresets()
 
   JsonObject fdo;
 
-  presetToApply = 0; //clear request for preset
-  callModeToApply = 0;
-
   DEBUG_PRINTF_P(PSTR("Applying preset: %u\n"), (unsigned)tmpPreset);
 
   #if defined(ARDUINO_ARCH_ESP32S2) || defined(ARDUINO_ARCH_ESP32C3)
@@ -186,14 +183,20 @@ void handlePresets()
   // is this the boot preset and will the preset set lor
   const bool isBootPreset = (tmpMode==CALL_MODE_INIT || tmpPreset==bootPreset);
   const bool presetWillSetLor = (!fdo["lor"].isNull() && fdo["lor"].as<int>() > REALTIME_OVERRIDE_NONE);
-  
+
   // During setup, only allow the boot preset itself or safe boot-preset chains.
   const bool shouldAllowPresetApply = (
                                        setupComplete || isBootPreset ||
                                        (currentPreset == bootPreset && realtimeOverride > REALTIME_OVERRIDE_NONE) ||
                                        (currentPreset == bootPreset && currentPlaylist > 0 && presetWillSetLor)
                                        );
-  if (!shouldAllowPresetApply) return;
+  if (shouldAllowPresetApply) {
+    presetToApply = 0; //clear request for preset
+    callModeToApply = 0;
+  } else {
+    releaseJSONBufferLock();
+    return;
+  }
 
   //HTTP API commands
   const char* httpwin = fdo["win"];
@@ -208,9 +211,8 @@ void handlePresets()
     if (!fdo["seg"].isNull() || !fdo["on"].isNull() || !fdo["bri"].isNull() || !fdo["nl"].isNull() || !fdo["ps"].isNull() || !fdo[F("playlist")].isNull()) changePreset = true;
     
     // only allow load requests from boot presets that set lor or button calls
-    const bool isButtonException = (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'))
-    
-    const bool shouldAllowLoadRequest = (isBootPreset && presetWillSetLor) || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'))
+    const bool isButtonException = (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'));
+    const bool shouldAllowLoadRequest = (isBootPreset && presetWillSetLor) || (tmpMode == CALL_MODE_BUTTON_PRESET && fdo["ps"].is<const char *>() && strchr(fdo["ps"].as<const char *>(),'~') != strrchr(fdo["ps"].as<const char *>(),'~'));
     if (!shouldAllowLoadRequest) fdo.remove("ps"); // remove load request for presets to prevent recursive crash
     deserializeState(fdo, CALL_MODE_NO_NOTIFY, tmpPreset); // may change presetToApply by calling applyPreset()
   }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -504,9 +504,17 @@ void WLED::setup()
   if (needsCfgSave) serializeConfigToFS(); // usermods required new parameters; need to wait for strip to be initialised #4752
 
   if (bootPreset > 0) {
-    handlePresets();
+    if (!presetNeedsSaving()) {
+      handlePlaylist(); // handle boot playlist at setup
+      yield();
+    }
+    handlePresets(); // handle boot preset (including playlist) at setup
+    // Allow a boot preset to chain to one numeric preset exactly once (if it sets lor)
+    // Allow a boot playlist is able to apply the first preset (if it sets lor)
+    // In both cases, pre-existing protection against recursion is preserved
+    // See logic inside of handlePresets()
     yield();
-    handlePresets(); // Allow a boot preset to chain to one numeric preset exactly once.
+    handlePresets(); 
   }
   
   if (strcmp(multiWiFi[0].clientSSID, DEFAULT_CLIENT_SSID) == 0 && !configBackupExists())

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -503,6 +503,12 @@ void WLED::setup()
 
   if (needsCfgSave) serializeConfigToFS(); // usermods required new parameters; need to wait for strip to be initialised #4752
 
+  if (bootPreset > 0) {
+    handlePresets();
+    yield();
+    handlePresets(); // Allow a boot preset to chain to one numeric preset exactly once.
+  }
+  
   if (strcmp(multiWiFi[0].clientSSID, DEFAULT_CLIENT_SSID) == 0 && !configBackupExists())
     showWelcomePage = true;
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -364,7 +364,6 @@ void WLED::disableWatchdog() {
 
 void WLED::setup()
 {
-  setupComplete = false; // flag to indicate setup is in progress
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detection
   #endif
@@ -602,8 +601,6 @@ void WLED::setup()
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 1); //enable brownout detector
   #endif
   markOTAvalid();
-  
-  setupComplete = true; // safety check setup function has completed
 }
 
 void WLED::beginStrip()

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -364,6 +364,7 @@ void WLED::disableWatchdog() {
 
 void WLED::setup()
 {
+  setupComplete = false; // flag to indicate setup is in progress
   #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DISABLE_BROWNOUT_DET)
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0); //disable brownout detection
   #endif
@@ -504,17 +505,9 @@ void WLED::setup()
   if (needsCfgSave) serializeConfigToFS(); // usermods required new parameters; need to wait for strip to be initialised #4752
 
   if (bootPreset > 0) {
-    if (!presetNeedsSaving()) {
-      handlePlaylist(); // handle boot playlist at setup
-      yield();
-    }
-    handlePresets(); // handle boot preset (including playlist) at setup
-    // Allow a boot preset to chain to one numeric preset exactly once (if it sets lor)
-    // Allow a boot playlist is able to apply the first preset (if it sets lor)
-    // In both cases, pre-existing protection against recursion is preserved
-    // See logic inside of handlePresets()
-    yield();
-    handlePresets(); 
+    handlePresets();  // handle boot preset
+    handlePlaylist(); // handle playlist if preset queued one
+    handlePresets();  // handle presets again to give a chance for anything queued by the boot preset or playlist
   }
   
   if (strcmp(multiWiFi[0].clientSSID, DEFAULT_CLIENT_SSID) == 0 && !configBackupExists())
@@ -609,6 +602,8 @@ void WLED::setup()
   WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 1); //enable brownout detector
   #endif
   markOTAvalid();
+  
+  setupComplete = true; // safety check setup function has completed
 }
 
 void WLED::beginStrip()

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -890,9 +890,6 @@ WLED_GLOBAL byte optionType;
 WLED_GLOBAL bool configNeedsWrite  _INIT(false);        // flag to initiate saving of config
 WLED_GLOBAL bool doReboot          _INIT(false);        // flag to initiate reboot from async handlers
 
-// setup status
-WLED_GLOBAL bool setupComplete _INIT(false); // flag for preset loading safety
-
 // status led
 #if defined(STATUSLED)
 WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -890,6 +890,9 @@ WLED_GLOBAL byte optionType;
 WLED_GLOBAL bool configNeedsWrite  _INIT(false);        // flag to initiate saving of config
 WLED_GLOBAL bool doReboot          _INIT(false);        // flag to initiate reboot from async handlers
 
+// setup status
+WLED_GLOBAL bool setupComplete _INIT(false); // flag for preset loading safety
+
 // status led
 #if defined(STATUSLED)
 WLED_GLOBAL unsigned long ledStatusLastMillis _INIT(0);


### PR DESCRIPTION
## Problem

Previously, boot preset application depended on the normal loop path. `handlePresets()` in the main loop is gated behind realtime mode checks:

```cpp
if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly))
```

If realtime mode became active before the first normal preset processing pass, the boot preset could be skipped or only partially applied. This was especially problematic for boot presets intended to set `LiveDataOverride` (`lor`).

---

## Solution

This PR adds `handlePresets()` and `handlePlaylist()` calls during `setup()`.

The startup-time calls are intentionally placed:

- after `UsermodManager::setup()`
- after any required config migration save (`serializeConfigToFS()`)
- before normal network and realtime activity begins

This placement avoids calling usermod JSON handlers before setup while ensuring boot presets are processed deterministically during startup.

---

## Behavior Changes

### Earlier and More Consistent “LEDs On” Timing

For users utilizing a boot preset with `on:true`, LEDs may now turn on earlier during boot.

Because the boot preset is now applied earlier in the startup sequence, lights may illuminate faster than before. During testing, this range varied greatly with a range of 100ms faster to almost 2s faster.

This is particularly beneficial for users powering controllers from a physical wall switch who expect lights to turn on immediately when power is applied.

Users who intentionally relied on the previous delayed or inconsistent timing — particularly setups sensitive to brownouts or power fluctuations — may need to adjust any related delays accordingly.

While the previous behavior could vary depending on timing and realtime state, the new behavior should provide more consistent startup timing across reboots and power-on events on the controller.

### Improvements to Boot Preset Capabilities

- The boot preset is now applied deterministically during setup(), rather than during the main loop.
- The boot preset or playlist can now reliably set `lor` during startup.
- The boot preset can now request another preset using JSON API `ps`

Example:

```json
{ "lor": 2, "ps": 250 }
```
This is useful for a boot preset to establish realtime override behavior first and then immediately advance to another preset.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable preset and playlist processing at startup to ensure expected state after boot.
  * Preset application behavior refined to avoid unintended removal of minimal preset markers and to prevent boot-initialization mode from affecting preset selection.
  * Improved handling when selecting presets that only trigger cycling markers for consistent results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5573)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->