### PR TITLE
Fix custom tooltip showing "null" on sliders with child elements

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -3181,7 +3181,7 @@ function mergeDeep(target, ...sources)
 function tooltip(cont=null)
 {
 	d.querySelectorAll((cont?cont+" ":"")+"[title]").forEach((element)=>{
-		element.addEventListener("pointerover", ()=>{
+		element.addEventListener("pointerenter", ()=>{
 			// save title
 			element.setAttribute("data-title", element.getAttribute("title"));
 			const tooltip = d.createElement("span");
@@ -3206,7 +3206,7 @@ function tooltip(cont=null)
 			tooltip.classList.add("visible");
 		});
 
-		element.addEventListener("pointerout", ()=>{
+		element.addEventListener("pointerleave", ()=>{
 			d.querySelectorAll('.tooltip').forEach((tooltip)=>{
 				tooltip.classList.remove("visible");
 				d.body.removeChild(tooltip);


### PR DESCRIPTION
closes #5578 

**Summary**

- Switch the custom tooltip handler in index.js from pointerover/pointerout to pointerenter/pointerleave so it fires exactly once per real entry/exit.

**Problem**

The custom tooltip implementation at `wled00/data/index.js` saves an element's title attribute to data-title on hover, removes title (to suppress the native browser tooltip), and restores it from data-title on exit.

Because pointerover bubbles, the handler fired again whenever the cursor crossed onto a child element (e.g. moving from the sliderwrap div onto its <input> or .sliderdisplay child). On that second invocation getAttribute("title") returned null (it had already been removed), and setAttribute("data-title", null) stored the literal string "null". Subsequent hovers then displayed a tooltip reading "null".

This was reproducible on the Value/Brightness slider on the Colors tab, and could affect any element with a title attribute that contains child nodes the cursor can land on.

**Fix**

pointerenter/pointerleave do not bubble — they fire only on the actual entry to and exit from the listening element, regardless of internal cursor movement. This makes the handler idempotent for a single hover and matches the intended semantics.

**AI Disclaimer:** Claude Code was used to find and fix this bug and create this PR description. However it's not "vibe coded" as I understand the code completely and have reviewed and tested it manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip event handling to prevent unintended tooltip triggers and dismissals in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->