### PR TITLE
fix(Fix_unreachable_netservices_v2): v16 compatibility fixes

### DIFF
--- a/usermods/Fix_unreachable_netservices_v2/library.json
+++ b/usermods/Fix_unreachable_netservices_v2/library.json
@@ -1,4 +1,5 @@
 {
   "name": "Fix_unreachable_netservices_v2",
+  "build": { "libArchive": false },
   "platforms": ["espressif8266"]
 }

--- a/usermods/Fix_unreachable_netservices_v2/usermod_Fix_unreachable_netservices.cpp
+++ b/usermods/Fix_unreachable_netservices_v2/usermod_Fix_unreachable_netservices.cpp
@@ -77,7 +77,7 @@ public:
     }
     if (m_updateConfig)
     {
-      serializeConfig();
+      serializeConfigToFS();
       m_updateConfig = false;
     }
   }


### PR DESCRIPTION
## Summary

Two issues prevent `Fix_unreachable_netservices_v2` from building under WLED v16:

- **Missing `libArchive: false` in `library.json`** — the v16 build system requires `"build": {"libArchive": false}` in every usermod's `library.json`. Without it the build fails immediately with `ERROR: libArchive=false is missing on usermod(s)`.

- **`serializeConfig()` no longer has a no-argument overload** — v16 changed `serializeConfig()` to require a `JsonObject` parameter. The correct no-argument replacement for saving config to the filesystem is `serializeConfigToFS()`.

## Test plan

- [x] `Fix_unreachable_netservices_v2` compiles cleanly in an ESP8266 build environment with both fixes applied
- [x] Verified `serializeConfigToFS()` is the correct equivalent — it allocates the JSON document internally and calls `serializeConfig(root)` + writes to LittleFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where network service configuration updates were not being properly persisted to storage.

* **Chores**
  * Updated library build configuration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5590)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->