### PR TITLE
save global on / off button override in cfg

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -58,6 +58,8 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   getStringFromJson(alexaInvocationName, id[F("inv")], 33);
 #endif
   CJSON(simplifiedUI, id[F("sui")]);
+  CJSON(powerButtonOnPreset, id[F("pon")]);
+  CJSON(powerButtonOffPreset, id[F("pof")]);
 
   JsonObject nw = doc["nw"];
 #ifndef WLED_DISABLE_ESPNOW
@@ -853,6 +855,8 @@ void serializeConfig(JsonObject root) {
   id[F("inv")] = alexaInvocationName;
 #endif
   id[F("sui")] = simplifiedUI;
+  id[F("pon")] = powerButtonOnPreset;
+  id[F("pof")] = powerButtonOffPreset;
 
   JsonObject nw = root.createNestedObject("nw");
 #ifndef WLED_DISABLE_ESPNOW

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -653,6 +653,13 @@ function parseInfo(i) {
 	d.title      = name;
 	simplifiedUI = i.simplifiedui;
 	ledCount     = i.leds.count;
+	if (typeof i.pon === "number") cfg.comp.on = i.pon;
+	if (typeof i.pof === "number") cfg.comp.off = i.pof;
+	try {
+		localStorage.setItem('wledUiCfg', JSON.stringify(cfg));
+	} catch (e) {
+		// ignore localStorage failures
+	}
 	//syncTglRecv   = i.str;
 	maxSeg       = i.leds.maxseg;
 	pmt          = i.fs.pmt;

--- a/wled00/data/settings_ui.htm
+++ b/wled00/data/settings_ui.htm
@@ -6,7 +6,7 @@
 	<title>UI Settings</title>
 	<style> html { visibility: hidden; } </style> <!-- prevent white & ugly display while loading, unhidden in loadResources() -->
 	<script>
-	var initial_ds, initial_st, initial_su, oldUrl;
+	var oldUrl;
 	var sett = null;
 	// load common.js with retry on error
 	(function loadFiles() {
@@ -131,7 +131,22 @@
 			gId('lserr').style.display = "inline";
 			gId('lserr').innerHTML = "&#9888; Settings JSON parsing failed. (" + e + ")";
 		}
+		if (!sett.comp) sett.comp = {};
+		if (d.Sf.ON && d.Sf.ON.value !== "") {
+			var serverOn = parseInt(d.Sf.ON.value, 10);
+			if (!Number.isNaN(serverOn) && sett.comp.on !== serverOn) sett.comp.on = serverOn;
+		}
+		if (d.Sf.OF && d.Sf.OF.value !== "") {
+			var serverOff = parseInt(d.Sf.OF.value, 10);
+			if (!Number.isNaN(serverOff) && sett.comp.off !== serverOff) sett.comp.off = serverOff;
+		}
 		genForm(sett);
+		// sync local storage silently with server values for ON/OFF overrides
+		try {
+			localStorage.setItem('wledUiCfg', JSON.stringify(sett));
+		} catch (e) {
+			// ignore write errors; localStorage may be unavailable
+		}
 		gId('dm').checked = (gId('theme_base').value === 'light');
 	}
 
@@ -143,6 +158,14 @@
 			var val = e.classList.contains('cb') ? e.checked : e.value;
 			set(e.id, sett, val);
 			console.log(`${e.id} set to ${val}`);
+		}
+		if (d.Sf.ON && d.Sf.ON.value !== "") {
+			if (!sett.comp) sett.comp = {};
+			sett.comp.on = parseInt(d.Sf.ON.value, 10) || 0;
+		}
+		if (d.Sf.OF && d.Sf.OF.value !== "") {
+			if (!sett.comp) sett.comp = {};
+			sett.comp.off = parseInt(d.Sf.OF.value, 10) || 0;
 		}
 		try {
 			localStorage.setItem('wledUiCfg', JSON.stringify(sett));
@@ -164,15 +187,11 @@
 	
 	function Save() {
 		SetLS();
-		if (d.Sf.DS.value != initial_ds || /*d.Sf.ST.checked != initial_st ||*/ d.Sf.SU.checked != initial_su) d.Sf.submit();
+		d.Sf.submit(); // always submit: ON/OF are server-backed fields that always need saving
 	}
-	
 	function S() {
 		getLoc();
 		loadJS(getURL('/settings/s.js?p=3'), false, undefined, ()=>{
-			initial_ds = d.Sf.DS.value;
-			//initial_st = d.Sf.ST.checked;
-			initial_su = d.Sf.SU.checked;
 			GetLS();
 		});	// If we set async false, file is loaded and executed, then next statement is processed
 		if (loc) d.Sf.action = getURL('/settings/ui');
@@ -247,8 +266,8 @@
 		<span class="l"></span>: <input type="checkbox" id="comp_segpwr" class="agi cb"><br>
 		<span class="l"></span>: <input type="checkbox" id="comp_segexp" class="agi cb"><br>
 		<span class="l"></span>: <input type="checkbox" id="comp_fxdef" class="agi cb"><br>
-		<span class="l"></span>: <input type="number" min=0 max=250 step=1 id="comp_on" class="agi"><br>
-		<span class="l"></span>: <input type="number" min=0 max=250 step=1 id="comp_off" class="agi"><br>
+		<span class="l"></span>: <input type="number" min=0 max=250 step=1 id="comp_on" name="ON" class="agi"><br>
+		<span class="l"></span>: <input type="number" min=0 max=250 step=1 id="comp_off" name="OF" class="agi"><br>
 		I hate dark mode: <input type="checkbox" id="dm" onchange="UI()"><br>
 		<span id="idonthateyou" style="display:none"><i>Why would you? </i>&#x1F97A;<br></span>
 		<span class="l"></span>: <input type="number" min=0.0 max=1.0 step=0.01 id="theme_alpha_tab" class="agi"><br>

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -748,6 +748,8 @@ void serializeInfo(JsonObject root)
   root[F("name")] = serverDescription;
   root[F("udpport")] = udpPort;
   root[F("simplifiedui")] = simplifiedUI;
+  root[F("pon")] = powerButtonOnPreset;
+  root[F("pof")] = powerButtonOffPreset;
   root["live"] = (bool)realtimeMode;
   root[F("liveseg")] = useMainSegmentOnly ? strip.getMainSegmentId() : -1;  // if using main segment only for live
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -429,6 +429,8 @@ WLED_GLOBAL char serverDescription[33] _INIT("WLED");  // Name of module - use d
 WLED_GLOBAL char serverDescription[33] _INIT(SERVERNAME);  // use predefined name
 #endif
 WLED_GLOBAL bool simplifiedUI          _INIT(false);   // enable simplified UI
+WLED_GLOBAL byte powerButtonOnPreset   _INIT(0);       // override preset for power-on
+WLED_GLOBAL byte powerButtonOffPreset  _INIT(0);       // override preset for power-off
 WLED_GLOBAL byte cacheInvalidate       _INIT(0);       // used to invalidate browser cache
 
 // Sync CONFIG

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -467,6 +467,8 @@ void getSettingsJS(byte subPage, Print& settingsScript)
   {
     printSetFormValue(settingsScript,PSTR("DS"),serverDescription);
     printSetFormCheckbox(settingsScript,PSTR("SU"),simplifiedUI);
+    printSetFormValue(settingsScript,PSTR("ON"),powerButtonOnPreset);
+    printSetFormValue(settingsScript,PSTR("OF"),powerButtonOffPreset);
   }
 
   if (subPage == SUBPAGE_SYNC)


### PR DESCRIPTION
as discussed in https://github.com/wled/WLED/issues/5562 this adds saving of the UI setting in config in addition to localstorage.

@softhack007 I am not too sure this is a good idea - at least as is: it prevents users from using different on/off presets on different devices. This could be solved with a checkmark to use "local override only", ignorie the cfg setting and use localstorage only.

the other way to solve #5562 would be to not store them in config but add a mechanism to tell the browser to clear relevant local storage after a factory reset, I am not sure how to do that though as it requires a variable the persists a reboot so it would need to go into the config or use RTC memory. Clearing browser cache for a UI induced factory reset would be possible by adding some code to settings_sec.htm but doing it for a button called factory reset seems a bit more tricky. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Power button preset configuration – users can now configure custom preset actions that automatically execute when the power button is pressed, with separate settings for on and off states enabling flexible personalized automation
  * Enhanced configuration synchronization between device and web interface ensuring settings persist consistently across restarts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5591)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->