### PR TITLE
Audioreactive bugfix: auto-suspend in all realtime modes, but stay active when "Use main segment only"

### DIFF
--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1300,7 +1300,12 @@ class AudioReactive : public Usermod {
 
       size_t packetSize = fftUdp.parsePacket();
 #ifdef ARDUINO_ARCH_ESP32
-      if ((packetSize > 0) && ((packetSize < 5) || (packetSize > UDPSOUND_MAX_PACKET))) fftUdp.flush(); // discard invalid packets (too small or too big) - only works on esp32
+      if ((packetSize > 0) && ((packetSize < 5) || (packetSize > UDPSOUND_MAX_PACKET)))
+        #if ESP_IDF_VERSION_MAJOR < 5
+        fftUdp.flush(); // discard invalid packets (too small or too big) - only works on esp32
+        #else
+        fftUdp.clear(); // function was renamed in newer frameworks
+        #endif
 #endif
       if ((packetSize > 5) && (packetSize <= UDPSOUND_MAX_PACKET)) {
         //DEBUGSR_PRINTLN("Received UDP Sync Packet");
@@ -1612,7 +1617,11 @@ class AudioReactive : public Usermod {
             have_new_sample = receiveAudioData();
             if (have_new_sample) last_UDPTime = millis();
 #ifdef ARDUINO_ARCH_ESP32
+            #if ESP_IDF_VERSION_MAJOR < 5
             else fftUdp.flush(); // Flush udp input buffers if we haven't read it - avoids hickups in receive mode. Does not work on 8266.
+            #else
+            else fftUdp.clear(); // function was remaned in newer framework versions
+            #endif
 #endif
             lastTime = millis();
           }

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1726,7 +1726,7 @@ class AudioReactive : public Usermod {
           );
       }
       micDataReal = 0.0f;                     // just to be sure
-      if (enabled) disableSoundProcessing = false;
+      if (enabled) disableSoundProcessing = false;  // allows FFT_Task to run at least once, even when loop() might disable again
       updateIsRunning = init;
     }
 

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1620,7 +1620,7 @@ class AudioReactive : public Usermod {
             #if ESP_IDF_VERSION_MAJOR < 5
             else fftUdp.flush(); // Flush udp input buffers if we haven't read it - avoids hickups in receive mode. Does not work on 8266.
             #else
-            else fftUdp.clear(); // function was remaned in newer framework versions
+            else fftUdp.clear(); // function was renamed in newer frameworks
             #endif
 #endif
             lastTime = millis();

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1533,14 +1533,9 @@ class AudioReactive : public Usermod {
       // We cannot wait indefinitely before processing audio data
       if (strip.isUpdating() && (millis() - lastUMRun < 2)) return;   // be nice, but not too nice
 
-      // suspend local sound processing when "real time mode" is active (E131, UDP, ADALIGHT, ARTNET)
-      if (  (realtimeOverride == REALTIME_OVERRIDE_NONE)  // please add other overrides here if needed
-          &&( (realtimeMode == REALTIME_MODE_GENERIC)
-            ||(realtimeMode == REALTIME_MODE_E131)
-            ||(realtimeMode == REALTIME_MODE_UDP)
-            ||(realtimeMode == REALTIME_MODE_ADALIGHT)
-            ||(realtimeMode == REALTIME_MODE_ARTNET) ) )  // please add other modes here if needed
-      {
+      // suspend local sound processing when "real time mode" is active (E131, UDP, ADALIGHT, ARTNET, DDP, DMX)
+      //  exception: sound input is still needed when useMainSegmentOnly - other segments are still running with local input.
+      if (realtimeMode && !realtimeOverride && !useMainSegmentOnly) {
         #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DEBUG)
         if ((disableSoundProcessing == false) && (audioSyncEnabled == 0)) {  // we just switched to "disabled"
           DEBUG_PRINTLN(F("[AR userLoop]  realtime mode active - audio processing suspended."));


### PR DESCRIPTION
* fixes a minor problem with newer realtime modes (DDP, TPM2NET and DMX) not causing auto-suspend of sound processing (thanks @blazoncek for the hint).
* ensure that AR audio stays active when "Use main segment only" (other segments are still controlled locally)
* small update for better compatibility with V5 builds

NB: the impact on users is minimal, especially on esp32 and esp32-s3 - audioreactive FFT does not use much CPU time on these boards (less than 20%). Any way the fix can be applied to 16.0.0, 17.0.0 and 0.15.5 in the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility across ESP-IDF framework versions for audio processing.
  * More reliable UDP buffer handling when discarding invalid packets and clearing unread input to prevent receive hiccups.
  * Simplified realtime-mode gating so local FFT/audio processing reliably suspends and resumes.
  * Ensure audio processing task runs at least once during device updates to avoid missed audio work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5599)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->