### PR TITLE
feat: Add Domraem brand Ethernet clock pin configuration

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -395,7 +395,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        16
+#define WLED_NUM_ETH_TYPES        17
 
 
 #define WLED_ETH_NONE              0
@@ -414,6 +414,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_GLEDOPTO         13
 #define WLED_ETH_QUINLED_V4_UNOQUAD  14
 #define WLED_ETH_QUINLED_V4_OCTA     15
+#define WLED_ETH_DOMRAEM_ETH      16
 
 
 //Hue error codes

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -245,6 +245,7 @@ Static subnet mask:<br>
 			<option value="3">WESP32</option>
 			<option value="1">WT32-ETH01</option>
 			<option value="13">Gledopto</option>
+			<option value="16">Domraem_ETH</option>
 		</select><br><br>
 	</div>
 	<div class="sec">

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -175,6 +175,15 @@ const ethernet_settings ethernetBoards[] = {
     ETH_PHY_LAN8720,     // eth_type
     ETH_CLOCK_GPIO0_IN   // eth_clk_mode
   },
+  // Domraem_ETH(16)
+  {
+    1,                   // eth_address
+    5,                  // eth_power
+    23,                  // eth_mdc
+    33,                  // eth_mdio
+    ETH_PHY_LAN8720,     // eth_type
+    ETH_CLOCK_GPIO0_IN   // eth_clk_mode
+  },
 };
 
 bool initEthernet()


### PR DESCRIPTION
Add support for Domraem Ethernet board with clock pins (GPIO0).
This configuration allows WLED to work properly with ESP32 + Ethernet hardware from Domraem brand, avoiding conflicts between ESP-NOW and Ethernet clock signals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Domraem_ETH Ethernet board, expanding compatible hardware options.
  * Exposed the new Ethernet option in the network settings so users can select Domraem_ETH from the Ethernet Type list.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5607)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->