### PR TITLE
Add sanity checks for ethernet config table and WLED_ETH_DEFAULT

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -177,6 +177,12 @@ const ethernet_settings ethernetBoards[] = {
   },
 };
 
+// sanity checks for ethernet config table and WLED_ETH_DEFAULT
+static_assert((sizeof(ethernetBoards)/sizeof(ethernetBoards[0])) == WLED_NUM_ETH_TYPES, "WLED_NUM_ETH_TYPES does not match size of ethernetBoards[] table.");
+#ifdef WLED_ETH_DEFAULT
+  static_assert(((WLED_ETH_DEFAULT) >= WLED_ETH_NONE) && ((WLED_ETH_DEFAULT) < WLED_NUM_ETH_TYPES), "WLED_ETH_DEFAULT is out of range.");
+#endif
+
 bool initEthernet()
 {
   static bool successfullyConfiguredEthernet = false;


### PR DESCRIPTION
Small helper for integrators by compile-time sanity checks:
* WLED_NUM_ETH_TYPES is aligned with the boards table
* WLED_ETH_DEFAULT is aligned with the boards table

Can be merged into 17.0.0, 16.0.0, and 0.15.x branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added compile-time validation for Ethernet configuration settings to ensure configuration consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5608)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->