### PR TITLE
feat: Add Domraem Ethernet board support

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -395,7 +395,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        16
+#define WLED_NUM_ETH_TYPES        17
 
 
 #define WLED_ETH_NONE              0
@@ -414,6 +414,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_GLEDOPTO         13
 #define WLED_ETH_QUINLED_V4_UNOQUAD  14
 #define WLED_ETH_QUINLED_V4_OCTA     15
+#define WLED_ETH_DOMRAEM_ETHV1       16
 
 
 //Hue error codes

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -245,6 +245,7 @@ Static subnet mask:<br>
 			<option value="3">WESP32</option>
 			<option value="1">WT32-ETH01</option>
 			<option value="13">Gledopto</option>
+			<option value="16">Domraem_ETHV1</option>
 		</select><br><br>
 	</div>
 	<div class="sec">

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -175,6 +175,16 @@ const ethernet_settings ethernetBoards[] = {
     ETH_PHY_LAN8720,     // eth_type
     ETH_CLOCK_GPIO0_IN   // eth_clk_mode
   },
+ 
+ // WLED_ETH_DOMRAEM_ETHV1 (16) - Domraem ETHV1
+  {
+    0,                   // eth_address
+    5,                  // eth_power
+    23,                  // eth_mdc
+    33,                  // eth_mdio
+    ETH_PHY_LAN8720,     // eth_type
+    ETH_CLOCK_GPIO0_IN   // eth_clk_mode
+  },
 };
 
 // sanity checks for ethernet config table and WLED_ETH_DEFAULT


### PR DESCRIPTION
Add support for Domraem ESP32 Ethernet hardware.
PHY addr: 0, Power: GPIO5, MDC: GPIO23, MDIO: GPIO33.
This is a generic board configuration for ESP32 + LAN8720 Ethernet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Ethernet board type (Domraem_ETHV1), which is now available as an option in the Ethernet configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5610)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->