### PR TITLE
rename CW LED descriptions to more commonly used CCT

### DIFF
--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -358,19 +358,19 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
     {TYPE_FW1906,        "D",  PSTR("RGBCCT FW1906/WS2811")},
     {TYPE_WS2805,        "D",  PSTR("RGBCCT WS2805")},
     {TYPE_SM16825,       "D",  PSTR("RGBCCT SM16825")},
-    {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
-    {TYPE_TM1814,        "D",  PSTR("TM1814")},
-    {TYPE_TM1829,        "D",  PSTR("TM1829")},
-    {TYPE_UCS8903,       "D",  PSTR("UCS8903")},
-    {TYPE_APA106,        "D",  PSTR("APA106/PL9823")},
-    {TYPE_TM1914,        "D",  PSTR("TM1914")},
+    {TYPE_WS2812_1CH_X3, "D",  PSTR("White WS2811")},
+    {TYPE_TM1814,        "D",  PSTR("RGBW TM1814")},
+    {TYPE_TM1829,        "D",  PSTR("RGB TM1829")},
+    {TYPE_UCS8903,       "D",  PSTR("RGB UCS8903")},
+    {TYPE_APA106,        "D",  PSTR("RGB APA106/PL9823")},
+    {TYPE_TM1914,        "D",  PSTR("RGB TM1914")},
     //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
-    {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored
-    {TYPE_WS2801,        "2P", PSTR("WS2801")},
-    {TYPE_APA102,        "2P", PSTR("APA102")},
-    {TYPE_LPD8806,       "2P", PSTR("LPD8806")},
-    {TYPE_LPD6803,       "2P", PSTR("LPD6803")},
-    {TYPE_P9813,         "2P", PSTR("PP9813")},
+    {TYPE_WS2812_WWA,    "D",  PSTR("WWA WS281x")}, // amber ignored
+    {TYPE_WS2801,        "2P", PSTR("RGB WS2801")},
+    {TYPE_APA102,        "2P", PSTR("RGB APA102")},
+    {TYPE_LPD8806,       "2P", PSTR("RGB LPD8806")},
+    {TYPE_LPD6803,       "2P", PSTR("RGB LPD6803")},
+    {TYPE_P9813,         "2P", PSTR("RGB P9813")},
   };
 }
 
@@ -611,7 +611,7 @@ std::vector<LEDType> BusPwm::getLEDTypes() {
     {TYPE_ANALOG_2CH, "AA",     PSTR("PWM CCT")},
     {TYPE_ANALOG_3CH, "AAA",    PSTR("PWM RGB")},
     {TYPE_ANALOG_4CH, "AAAA",   PSTR("PWM RGBW")},
-    {TYPE_ANALOG_5CH, "AAAAA",  PSTR("PWM RGB+CCT")},
+    {TYPE_ANALOG_5CH, "AAAAA",  PSTR("PWM RGBCCT")},
     //{TYPE_ANALOG_6CH, "AAAAAA", PSTR("PWM RGB+DCCT")}, // unimplementable ATM
   };
 }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -364,7 +364,6 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
     {TYPE_WS2805,        "D",  PSTR("WS2805 RGBCCT")},
     {TYPE_SM16825,       "D",  PSTR("SM16825 RGBCCT")},
     {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
-    //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
     {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored
     {TYPE_WS2801,        "2P", PSTR("WS2801 RGB")},
     {TYPE_APA102,        "2P", PSTR("APA102 RGB")},

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -359,10 +359,10 @@ std::vector<LEDType> BusDigital::getLEDTypes() {
     {TYPE_UCS8903,       "D",  PSTR("UCS8903")},
     {TYPE_APA106,        "D",  PSTR("APA106/PL9823")},
     {TYPE_TM1914,        "D",  PSTR("TM1914")},
-    {TYPE_FW1906,        "D",  PSTR("FW1906 GRBCW")},
+    {TYPE_FW1906,        "D",  PSTR("RGBCCT FW1906/WS2811")},
     {TYPE_UCS8904,       "D",  PSTR("UCS8904 RGBW")},
-    {TYPE_WS2805,        "D",  PSTR("WS2805 RGBCW")},
-    {TYPE_SM16825,       "D",  PSTR("SM16825 RGBCW")},
+    {TYPE_WS2805,        "D",  PSTR("WS2805 RGBCCT")},
+    {TYPE_SM16825,       "D",  PSTR("SM16825 RGBCCT")},
     {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
     //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
     {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -351,26 +351,26 @@ void BusDigital::setColorOrder(uint8_t colorOrder) {
 // credit @willmmiles & @netmindz https://github.com/wled/WLED/pull/4056
 std::vector<LEDType> BusDigital::getLEDTypes() {
   return {
-    {TYPE_WS2812_RGB,    "D",  PSTR("RGB WS281x")},
-    {TYPE_WS2811_400KHZ, "D",  PSTR("RGB 400kHz")},
-    {TYPE_SK6812_RGBW,   "D",  PSTR("RGBW SK6812/WS2814")},
-    {TYPE_UCS8904,       "D",  PSTR("RGBW UCS8904")},
-    {TYPE_FW1906,        "D",  PSTR("RGBCCT FW1906/WS2811")},
-    {TYPE_WS2805,        "D",  PSTR("RGBCCT WS2805")},
-    {TYPE_SM16825,       "D",  PSTR("RGBCCT SM16825")},
-    {TYPE_WS2812_1CH_X3, "D",  PSTR("White WS2811")},
-    {TYPE_TM1814,        "D",  PSTR("RGBW TM1814")},
-    {TYPE_TM1829,        "D",  PSTR("RGB TM1829")},
-    {TYPE_UCS8903,       "D",  PSTR("RGB UCS8903")},
-    {TYPE_APA106,        "D",  PSTR("RGB APA106/PL9823")},
-    {TYPE_TM1914,        "D",  PSTR("RGB TM1914")},
+    {TYPE_WS2812_RGB,    "D",  PSTR("WS281x RGB")},
+    {TYPE_WS2811_400KHZ, "D",  PSTR("400kHz RGB")},
+    {TYPE_TM1829,        "D",  PSTR("TM1829 RGB")},
+    {TYPE_UCS8903,       "D",  PSTR("UCS8903 RGB")},
+    {TYPE_APA106,        "D",  PSTR("APA106/PL9823 RGB")},
+    {TYPE_TM1914,        "D",  PSTR("TM1914 RGB")},
+    {TYPE_SK6812_RGBW,   "D",  PSTR("SK6812/WS2814 RGBW")},
+    {TYPE_UCS8904,       "D",  PSTR("UCS8904 RGBW")},
+    {TYPE_TM1814,        "D",  PSTR("TM1814 RGBW")},
+    {TYPE_FW1906,        "D",  PSTR("FW1906/WS2811 RGBCCT")},
+    {TYPE_WS2805,        "D",  PSTR("WS2805 RGBCCT")},
+    {TYPE_SM16825,       "D",  PSTR("SM16825 RGBCCT")},
+    {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
     //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
-    {TYPE_WS2812_WWA,    "D",  PSTR("WWA WS281x")}, // amber ignored
-    {TYPE_WS2801,        "2P", PSTR("RGB WS2801")},
-    {TYPE_APA102,        "2P", PSTR("RGB APA102")},
-    {TYPE_LPD8806,       "2P", PSTR("RGB LPD8806")},
-    {TYPE_LPD6803,       "2P", PSTR("RGB LPD6803")},
-    {TYPE_P9813,         "2P", PSTR("RGB P9813")},
+    {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored
+    {TYPE_WS2801,        "2P", PSTR("WS2801 RGB")},
+    {TYPE_APA102,        "2P", PSTR("APA102 RGB")},
+    {TYPE_LPD8806,       "2P", PSTR("LPD8806 RGB")},
+    {TYPE_LPD6803,       "2P", PSTR("LPD6803 RGB")},
+    {TYPE_P9813,         "2P", PSTR("P9813 RGB")},
   };
 }
 

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -351,19 +351,19 @@ void BusDigital::setColorOrder(uint8_t colorOrder) {
 // credit @willmmiles & @netmindz https://github.com/wled/WLED/pull/4056
 std::vector<LEDType> BusDigital::getLEDTypes() {
   return {
-    {TYPE_WS2812_RGB,    "D",  PSTR("WS281x")},
-    {TYPE_SK6812_RGBW,   "D",  PSTR("SK6812/WS2814 RGBW")},
+    {TYPE_WS2812_RGB,    "D",  PSTR("RGB WS281x")},
+    {TYPE_WS2811_400KHZ, "D",  PSTR("RGB 400kHz")},
+    {TYPE_SK6812_RGBW,   "D",  PSTR("RGBW SK6812/WS2814")},
+    {TYPE_UCS8904,       "D",  PSTR("RGBW UCS8904")},
+    {TYPE_FW1906,        "D",  PSTR("RGBCCT FW1906/WS2811")},
+    {TYPE_WS2805,        "D",  PSTR("RGBCCT WS2805")},
+    {TYPE_SM16825,       "D",  PSTR("RGBCCT SM16825")},
+    {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
     {TYPE_TM1814,        "D",  PSTR("TM1814")},
-    {TYPE_WS2811_400KHZ, "D",  PSTR("400kHz")},
     {TYPE_TM1829,        "D",  PSTR("TM1829")},
     {TYPE_UCS8903,       "D",  PSTR("UCS8903")},
     {TYPE_APA106,        "D",  PSTR("APA106/PL9823")},
     {TYPE_TM1914,        "D",  PSTR("TM1914")},
-    {TYPE_FW1906,        "D",  PSTR("RGBCCT FW1906/WS2811")},
-    {TYPE_UCS8904,       "D",  PSTR("UCS8904 RGBW")},
-    {TYPE_WS2805,        "D",  PSTR("WS2805 RGBCCT")},
-    {TYPE_SM16825,       "D",  PSTR("SM16825 RGBCCT")},
-    {TYPE_WS2812_1CH_X3, "D",  PSTR("WS2811 White")},
     //{TYPE_WS2812_2CH_X3, "D",  PSTR("WS281x CCT")}, // not implemented
     {TYPE_WS2812_WWA,    "D",  PSTR("WS281x WWA")}, // amber ignored
     {TYPE_WS2801,        "2P", PSTR("WS2801")},

--- a/wled00/bus_manager.h
+++ b/wled00/bus_manager.h
@@ -184,10 +184,9 @@ class Bus {
               type == TYPE_NET_DDP_RGBW || type == TYPE_NET_ARTNET_RGBW;                   // network types with white channel
     }
     static constexpr bool hasCCT(uint8_t type) {
-      return  type == TYPE_WS2812_2CH_X3 || type == TYPE_WS2812_WWA ||
+      return  type == TYPE_WS2812_WWA    || type == TYPE_SM16825 ||
               type == TYPE_ANALOG_2CH    || type == TYPE_ANALOG_5CH ||
-              type == TYPE_FW1906        || type == TYPE_WS2805     ||
-              type == TYPE_SM16825;
+              type == TYPE_FW1906        || type == TYPE_WS2805;
     }
     static constexpr bool  isTypeValid(uint8_t type)  { return (type > 15 && type < 128); }
     static constexpr bool  isDigital(uint8_t type)    { return (type >= TYPE_DIGITAL_MIN && type <= TYPE_DIGITAL_MAX) || is2Pin(type); }

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1315,7 +1315,6 @@ class PolyBus {
       if (offset > 3) offset = 3;
       switch (busType) {
         case TYPE_WS2812_1CH_X3:
-        case TYPE_WS2812_2CH_X3:
         case TYPE_WS2812_RGB:
         case TYPE_WS2812_WWA:
           t = I_8266_U0_NEO_3 + offset; break;
@@ -1358,7 +1357,6 @@ class PolyBus {
       // Now determine actual bus type with the chosen offset
       switch (busType) {
         case TYPE_WS2812_1CH_X3:
-        case TYPE_WS2812_2CH_X3:
         case TYPE_WS2812_RGB:
         case TYPE_WS2812_WWA:
           t = I_32_RN_NEO_3 + offset; break;

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #ifndef BusWrapper_h
 #define BusWrapper_h
 
@@ -50,7 +50,7 @@
 #define I_8266_U1_UCS_4 26
 #define I_8266_DM_UCS_4 27
 #define I_8266_BB_UCS_4 28
-//FW1906 GRBCW
+//FW1906 GRBCCT
 #define I_8266_U0_FW6_5 29
 #define I_8266_U1_FW6_5 30
 #define I_8266_DM_FW6_5 31
@@ -60,7 +60,7 @@
 #define I_8266_U1_APA106_3 34
 #define I_8266_DM_APA106_3 35
 #define I_8266_BB_APA106_3 36
-//WS2805 (RGBCW)
+//WS2805 (RGBCCT)
 #define I_8266_U0_2805_5 37
 #define I_8266_U1_2805_5 38
 #define I_8266_DM_2805_5 39
@@ -70,7 +70,7 @@
 #define I_8266_U1_TM1914_3 42
 #define I_8266_DM_TM1914_3 43
 #define I_8266_BB_TM1914_3 44
-//SM16825 (RGBCW)
+//SM16825 (RGBCCT)
 #define I_8266_U0_SM16825_5 45
 #define I_8266_U1_SM16825_5 46
 #define I_8266_DM_SM16825_5 47
@@ -98,19 +98,19 @@
 //UCS8904 (RGBW)
 #define I_32_RN_UCS_4 25
 #define I_32_I2_UCS_4 26
-//FW1906 GRBCW
+//FW1906 GRBCCT 6 color channels
 #define I_32_RN_FW6_5 29
 #define I_32_I2_FW6_5 30
 //APA106
 #define I_32_RN_APA106_3 33
 #define I_32_I2_APA106_3 34
-//WS2805 (RGBCW)
+//WS2805 (RGBCCT)
 #define I_32_RN_2805_5 37
 #define I_32_I2_2805_5 38
 //TM1914 (RGB)
 #define I_32_RN_TM1914_3 41
 #define I_32_I2_TM1914_3 42
-//SM16825 (RGBCW)
+//SM16825 (RGBCCT)
 #define I_32_RN_SM16825_5 45
 #define I_32_I2_SM16825_5 46
 
@@ -180,12 +180,12 @@
 #define B_8266_U1_APA106_3 NeoPixelBus<NeoRbgFeature, NeoEsp8266Uart1Apa106Method> //3 chan, esp8266, gpio2
 #define B_8266_DM_APA106_3 NeoPixelBus<NeoGrbFeature, NeoEsp8266DmaApa106Method>  //3 chan, esp8266, gpio3
 #define B_8266_BB_APA106_3 NeoPixelBus<NeoGrbFeature, NeoEsp8266BitBangApa106Method> //3 chan, esp8266, bb (any pin but 16)
-//FW1906 GRBCW
+//FW1906 GRBCCT
 #define B_8266_U0_FW6_5 NeoPixelBus<NeoGrbcwxFeature, NeoEsp8266Uart0Ws2813Method>   //esp8266, gpio1
 #define B_8266_U1_FW6_5 NeoPixelBus<NeoGrbcwxFeature, NeoEsp8266Uart1Ws2813Method>   //esp8266, gpio2
 #define B_8266_DM_FW6_5 NeoPixelBus<NeoGrbcwxFeature, NeoEsp8266Dma800KbpsMethod>   //esp8266, gpio3
 #define B_8266_BB_FW6_5 NeoPixelBus<NeoGrbcwxFeature, NeoEsp8266BitBang800KbpsMethod>   //esp8266, bb
-//WS2805 GRBCW
+//WS2805 GRBCCT
 #define B_8266_U0_2805_5 NeoPixelBus<NeoGrbwwFeature, NeoEsp8266Uart0Ws2805Method> //esp8266, gpio1
 #define B_8266_U1_2805_5 NeoPixelBus<NeoGrbwwFeature, NeoEsp8266Uart1Ws2805Method> //esp8266, gpio2
 #define B_8266_DM_2805_5 NeoPixelBus<NeoGrbwwFeature, NeoEsp8266DmaWs2805Method> //esp8266, gpio3
@@ -195,7 +195,7 @@
 #define B_8266_U1_TM1914_3 NeoPixelBus<NeoRgbTm1914Feature, NeoEsp8266Uart1Tm1914Method>
 #define B_8266_DM_TM1914_3 NeoPixelBus<NeoRgbTm1914Feature, NeoEsp8266DmaTm1914Method>
 #define B_8266_BB_TM1914_3 NeoPixelBus<NeoRgbTm1914Feature, NeoEsp8266BitBangTm1914Method>
-//Sm16825 (RGBWC)
+//Sm16825 (RGBCCT)
 #define B_8266_U0_SM16825_5 NeoPixelBus<NeoRgbwcSm16825eFeature, NeoEsp8266Uart0Ws2813Method>
 #define B_8266_U1_SM16825_5 NeoPixelBus<NeoRgbwcSm16825eFeature, NeoEsp8266Uart1Ws2813Method>
 #define B_8266_DM_SM16825_5 NeoPixelBus<NeoRgbwcSm16825eFeature, NeoEsp8266Dma800KbpsMethod>
@@ -285,11 +285,11 @@
 #define B_32_RN_APA106_3 NeoPixelBus<NeoGrbFeature, NeoEsp32RmtMethod(Apa106)>
 #define B_32_I2_APA106_3 NeoPixelBus<NeoGrbFeature, X1Apa106Method>
 #define B_32_IP_APA106_3 NeoPixelBus<NeoGrbFeature, X8Apa106Method> // parallel I2S
-//FW1906 GRBCW
+//FW1906 GRBCCT 6 color channels
 #define B_32_RN_FW6_5 NeoPixelBus<NeoGrbcwxFeature, NeoEsp32RmtMethod(Ws2812x)>
 #define B_32_I2_FW6_5 NeoPixelBus<NeoGrbcwxFeature, X1800KbpsMethod>
 #define B_32_IP_FW6_5 NeoPixelBus<NeoGrbcwxFeature, X8800KbpsMethod> // parallel I2S
-//WS2805 RGBWC
+//WS2805 RGBCCT
 #define B_32_RN_2805_5 NeoPixelBus<NeoGrbwwFeature, NeoEsp32RmtMethod(Ws2805)>
 #define B_32_I2_2805_5 NeoPixelBus<NeoGrbwwFeature, X1Ws2805Method>
 #define B_32_IP_2805_5 NeoPixelBus<NeoGrbwwFeature, X8Ws2805Method> // parallel I2S
@@ -297,7 +297,7 @@
 #define B_32_RN_TM1914_3 NeoPixelBus<NeoGrbTm1914Feature, NeoEsp32RmtMethod(Tm1914)>
 #define B_32_I2_TM1914_3 NeoPixelBus<NeoGrbTm1914Feature, X1Tm1914Method>
 #define B_32_IP_TM1914_3 NeoPixelBus<NeoGrbTm1914Feature, X8Tm1914Method> // parallel I2S
-//Sm16825 (RGBWC)
+//Sm16825 (RGBCCT)
 #define B_32_RN_SM16825_5 NeoPixelBus<NeoRgbcwSm16825eFeature, NeoEsp32RmtMethod(Ws2812x)>
 #define B_32_I2_SM16825_5 NeoPixelBus<NeoRgbcwSm16825eFeature, X1Ws2812xMethod>
 #define B_32_IP_SM16825_5 NeoPixelBus<NeoRgbcwSm16825eFeature, X8Ws2812xMethod> // parallel I2S

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -319,7 +319,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define TYPE_DIGITAL_MIN         16            // first usable digital type
 #define TYPE_WS2812_1CH          18            //white-only chips (1 channel per IC) (unused)
 #define TYPE_WS2812_1CH_X3       19            //white-only chips (3 channels per IC)
-#define TYPE_WS2812_2CH_X3       20            //CCT chips (1st IC controls WW + CW of 1st zone and CW of 2nd zone, 2nd IC controls WW of 2nd zone and WW + CW of 3rd zone)
+//#define TYPE_WS2812_2CH_X3       20            // use FW1906
 #define TYPE_WS2812_WWA          21            //amber + warm + cold white
 #define TYPE_WS2812_RGB          22
 #define TYPE_GS8608              23            //same driver as WS2812, but will require signal 2x per second (else displays test pattern)


### PR DESCRIPTION
this is a suggestion to rename "CW" into "CCT"

@intermittech what do you think? Open for discussion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LED type display names returned by the LED types JSON API to more accurately reflect supported color-channel layouts, with clearer RGBCCT/RGBW wording for relevant bus types.
  * Revised inline channel labels and descriptive text for several supported LED bus formats so the displayed names align consistently with actual capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->