### PR TITLE
Fix KIT-VE Ethernet: PHY address should be 1, not 0

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -87,7 +87,7 @@ const ethernet_settings ethernetBoards[] = {
 
   // ESP32-ETHERNET-KIT-VE
   {
-    0,                    // eth_address,
+    1,                    // eth_address,
     5,                    // eth_power,
     23,                   // eth_mdc,
     18,                   // eth_mdio,


### PR DESCRIPTION
## Summary

The ESP32-ETHERNET-KIT-VE entry in `ethernetBoards[]` has `eth_address` set to `0`, but the IP101GRI PHY on the Espressif ESP32-Ethernet-Kit V1.x actually responds at address `1`. With address 0, `ETH.begin()` returns false immediately and silently — the precompiled arduino-esp32 v2.0.18 libraries have the IDF log level baked at info, so `phy_802_3 power up timeout` errors from the lower driver layers never reach the serial console. Users see "link LED on, no DHCP, no errors anywhere" and have generally concluded WLED simply doesn't work on this board.

This one-character change makes Ethernet work on the KIT-VE.

## Verification

Tested on an ESP32-Ethernet-Kit V1.2 (A-board v1.2 + B-board v1.0) using a custom build of `main` at commit 186aafa with this fix applied. 

**Before**: `/json/info` contained no `eth` block, device only reachable on WiFi. Serial debug log shows `initE: Attempting ETH config: 7` → pin allocations → immediate `initE: ETH.begin() failed` with no further diagnostic output.

**After**: device obtains a DHCP lease on the Ethernet interface using a separate MAC (WiFi MAC + 3), is reachable on both interfaces simultaneously, and `/json/info` shows the Ethernet IP.

## References

The correct PHY address for the IP101 on the KIT-VE is well documented:

- [arduino-esp32#3554](https://github.com/espressif/arduino-esp32/issues/3554) — the PR that originally added IP101 support to arduino-esp32 explicitly notes: *"The phy address for the IP101 on the ethernet kit is 1."*
- Espressif's ESP-IDF Ethernet basic example for the KIT-VE configures `CONFIG_EXAMPLE_ETH_PHY_ADDR=1`
- [esp32.com forum discussion](https://www.esp32.com/viewtopic.php?t=39492) — custom board referencing the KIT-VE pinout, same `PHY Address: 1`

## Closes

This is the root cause of long-standing reports of "Ethernet doesn't work on KIT-VE" going back years:

- #2591 (board request / Ethernet not working, open since March 2022)
- [WLED Discourse: "How to get Ethernet Working with ESP32-Ethernet Kit by Espressif"](https://wled.discourse.group/t/how-to-get-ethernet-working-with-esp32-ethernet-kit-by-espressif/9445)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Ethernet connectivity configuration for ESP32-ETHERNET-KIT-VE board to ensure proper operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->