### PR TITLE
Make twinkle FX look more like it was in the past

### DIFF
--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2345,7 +2345,7 @@ void mode_colortwinkle() {
           unsigned index = i >> 3;
           unsigned  bitNum = i & 0x07;
           bitWrite(SEGENV.data[index], bitNum, true);
-          SEGMENT.setPixelColor(i, ColorFromPalette(SEGPALETTE, hw_random8(), 64, NOBLEND));
+          SEGMENT.setPixelColor(i, ColorFromPalette(SEGPALETTE, hw_random8(), gamma8inv(64), NOBLEND));  // note on gamma8inv: inverting results in non-linear brightness fade as originally designed
           break; //only spawn 1 new pixel per frame per 50 LEDs
         }
       }
@@ -2616,7 +2616,7 @@ static CRGBW twinklefox_one_twinkle(uint32_t ms, uint8_t salt, bool cat)
   unsigned hue = slowcycle8 - salt;
   CRGBW c;
   if (bright > 0) {
-    c = ColorFromPalette(SEGPALETTE, hue, bright, NOBLEND);
+    c = ColorFromPalette(SEGPALETTE, hue, gamma8inv(bright), NOBLEND); // note on gamma8inv: inverting results in non-linear brightness fade as originally designed
     if (!SEGMENT.check1) {
       // This code takes a pixel, and if its in the 'fading down'
       // part of the cycle, it adjusts the color a little bit like the

--- a/wled00/FX.cpp
+++ b/wled00/FX.cpp
@@ -2651,19 +2651,18 @@ static void twinklefox_base(bool cat)
   if (SEGMENT.speed > 100) SEGENV.aux0 = 3 + ((255 - SEGMENT.speed) >> 3);
   else SEGENV.aux0 = 22 + ((100 - SEGMENT.speed) >> 1);
 
-  // Set up the background color, "bg".
+  // Set up the background color, "bg". Note: using gamma invert for brightness as the FX was written without any gamma correction, it will dim down too much now
   CRGBW bg = SEGCOLOR(1);
-  unsigned bglight = bg.getAverageLight();
+  unsigned bglight = bg.getRGBaverage();
   if (bglight > 64) {
-    bg = color_fade(bg, 16, true); // very bright, so scale to 1/16th
+    bg = color_fade(bg, gamma8inv(16), true); // very bright, so scale to 1/16th
   } else if (bglight > 16) {
-    bg = color_fade(bg, 64, true); // not that bright, so scale to 1/4th
+    bg = color_fade(bg, gamma8inv(64), true); // not that bright, so scale to 1/4
   } else {
-    bg = color_fade(bg, 86, true); // dim, scale to 1/3rd.
+    bg = color_fade(bg, gamma8inv(86), true); // dim, scale to 1/3rd
   }
-  bg = gamma32inv(bg); // need to invert gamma as the FX was written without any gamma correction and it will dim down too much otherwise
 
-  unsigned backgroundBrightness = bg.getAverageLight();
+  bglight = bg.getRGBaverage(); // update after scaling
 
   for (unsigned i = 0; i < SEGLEN; i++) {
 
@@ -2680,8 +2679,8 @@ static void twinklefox_base(bool cat)
     // on the "brightness = f( time )" idea.
     CRGBW c = twinklefox_one_twinkle(myclock30, myunique8, cat);
 
-    unsigned cbright = c.getAverageLight();
-    int deltabright = cbright - backgroundBrightness;
+    unsigned cbright = c.getRGBaverage();
+    int deltabright = cbright - bglight;
     if (deltabright >= 32 || (bg==0)) {
       // If the new pixel is significantly brighter than the background color,
       // use the new color.

--- a/wled00/colors.h
+++ b/wled00/colors.h
@@ -198,6 +198,11 @@ struct CRGBW {
   uint8_t getAverageLight() const {
     return (r + g + b + w) >> 2;
   }
+
+  // get the average of the R, G, B values
+  uint8_t getRGBaverage() const {
+    return ((r + g + b) * 21846) >> 16; // x*21846>>16 is equal to "divide by 3"
+  }
 };
 
 inline CHSV32::CHSV32(const CRGBW& rgb) {


### PR DESCRIPTION
fixes #5622 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved brightness handling in the TwinkleFOX effect for more consistent and accurate twinkle intensity.
  * Adjusted how new twinkle pixels initialize brightness for more even visuals.
  * Switched color averaging to use RGB-only averaging, improving overall color rendering and background comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->