### PR TITLE
ADS1115 v2: skip ADC loop during strip updates, bump deps and improve docs

### DIFF
--- a/usermods/ADS1115_v2/ADS1115_v2.cpp
+++ b/usermods/ADS1115_v2/ADS1115_v2.cpp
@@ -28,18 +28,19 @@ class ADS1115Usermod : public Usermod {
     }
 
     void loop() {
-      if (isEnabled && millis() - lastTime > loopInterval) {
-        lastTime = millis();
+      if (!isEnabled || strip.isUpdating() || millis() - lastTime <= loopInterval)
+        return;
 
-        // If we don't have new data, skip this iteration.
-        if (!ads.conversionComplete()) {
-          return;
-        }
+      lastTime = millis();
 
-        updateResult();
-        moveToNextChannel();
-        startReading();
+      // If we don't have new data, skip this iteration.
+      if (!ads.conversionComplete()) {
+        return;
       }
+
+      updateResult();
+      moveToNextChannel();
+      startReading();
     }
 
     void addToJsonInfo(JsonObject& root)
@@ -69,6 +70,8 @@ class ADS1115Usermod : public Usermod {
     {
       JsonObject top = root.createNestedObject(F("ADC ADS1115"));
       
+      top[F("Loop Interval")] = loopInterval;
+
       for (uint8_t i = 0; i < channelsCount; i++) {
         ChannelSettings* settingsPtr = &(channelSettings[i]);
         JsonObject channel = top.createNestedObject(settingsPtr->settingName);
@@ -79,8 +82,6 @@ class ADS1115Usermod : public Usermod {
         channel[F("Offset")] = settingsPtr->offset;
         channel[F("Decimals")] = settingsPtr->decimals;
       }
-
-      top[F("Loop Interval")] = loopInterval;
     }
 
     bool readFromConfig(JsonObject& root)

--- a/usermods/ADS1115_v2/library.json
+++ b/usermods/ADS1115_v2/library.json
@@ -2,7 +2,7 @@
   "name": "ADS1115_v2",
   "build": { "libArchive": false },
   "dependencies": {
-    "Adafruit BusIO": "https://github.com/adafruit/Adafruit_BusIO#1.13.2",
-    "Adafruit ADS1X15": "https://github.com/adafruit/Adafruit_ADS1X15#2.4.0"
+    "Adafruit BusIO": "https://github.com/adafruit/Adafruit_BusIO#1.17.4",
+    "Adafruit ADS1X15": "https://github.com/adafruit/Adafruit_ADS1X15#2.6.2"
   }
 }

--- a/usermods/ADS1115_v2/readme.md
+++ b/usermods/ADS1115_v2/readme.md
@@ -1,10 +1,29 @@
-# ADS1115 16-Bit ADC with four inputs
+# ADS1115 Usermod
 
-This usermod will read from an ADS1115 ADC. The voltages are displayed in the Info section of the web UI.
+Reads values from an ADS1115 16-bit ADC and exposes them in the `Info` tab.
 
-Configuration is performed via the Usermod menu. There are no parameters to set in code!
+## Features
+- Reads values from an ADS1115 over I2C.
+- Supports 8 ADS1115 input modes:
+	- 4 single-ended inputs (`AIN0` to `AIN3`)
+	- 4 differential pairs (`AIN0-AIN1`, `AIN0-AIN3`, `AIN1-AIN3`, `AIN2-AIN3`)
+- Per-channel configuration in the Usermod settings:
+	- Enable/disable
+	- Display name
+	- Units
+	- Multiplier and offset
+	- Decimal precision
+- Configurable measurement loop interval.
+- Publishes configured channel values to the `Info` tab.
 
-## Installation 
+## Compatibility
+- Requires an ADS1115 module connected via I2C.
+- Works on targets with I2C support.
+- Default ADC gain is `1x` (input range `+/-4.096V`).
 
-Add 'ADS1115' to `custom_usermods` in your platformio environment.
+## Installation
+- Add `ADS1115` to `custom_usermods` in your `platformio.ini` (or `platformio_override.ini`).
+
+## Author
+- Dima Zhemkov [@dima-zhemkov](https://github.com/dima-zhemkov)
 


### PR DESCRIPTION
This PR refactors the ADS1115 usermod loop to avoid running ADC processing while LED output is actively updating.

What changed
- Added an early-return guard with `strip.isUpdating` in the ADS1115 loop.
- Kept loop logic explicit and sequential: conversion check, result update, channel switch, next read start.
- Updated Adafruit dependency versions in the usermod library metadata.
- Reworked ADS1115 README for clearer features, compatibility, and installation notes.

Why
- Prevent interference with time-sensitive LED bus updates.
- Align ADS1115 scheduling behavior with existing WLED core/usermod patterns.
- Improve maintainability and contributor/user clarity.

Validation:
- Builds successfully for all default environments.
- Runtime-tested on esp32dev and esp32s3dev_8MB_opi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ADS1115 v2 Usermod Update

* **Bug Fixes**
  * Fixed configuration output to prevent duplicate Loop Interval field

* **Documentation**
  * Rewrote ADS1115 v2 documentation with comprehensive feature list, installation instructions, and compatibility requirements

* **Chores**
  * Updated Adafruit BusIO library to v1.17.4
  * Updated Adafruit ADS1X15 library to v2.6.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->