### PR TITLE
Adding support for Waveshare ESP32-S3-RGB-Matrix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -658,8 +658,6 @@ upload_port = COM1:
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
-  -D NO_FAST_FUNCTIONS
-  -D NO_CIE1931
   -D WAVESHARE_S3_PINOUT
 ;  -D WLED_USE_SD_SPI
 ;  -D SD_PRINT_HOME_DIR

--- a/platformio.ini
+++ b/platformio.ini
@@ -649,20 +649,6 @@ board_build.partitions = tools/WLED_ESP32_32MB.csv
 board_upload.flash_size = 32MB
 board_upload.maximum_size = 33554432
 
-[env:waveshare_esp32s3_32MB_hub75]
-extends = env:esp32S3_wroom2_32MB
-monitor_filters = esp32_exception_decoder
-build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
-  -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2_32MB\" ;; need to un-set the relese name before setting a new one
-build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
-  -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
-  -D WAVESHARE_S3_PINOUT
-;  -D WLED_USE_SD_SPI
-;  -D SD_PRINT_HOME_DIR
-;  -D WLED_DEBUG
-lib_deps = ${esp32s3.lib_deps}
-  ${hub75.lib_deps}
-
 [env:esp32s3_4M_qspi]
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
 extends = esp32s3
@@ -792,6 +778,21 @@ build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} 
 lib_deps = ${esp32s3.lib_deps}
            ${hub75.lib_deps}
 ;; board_build.partitions = tools/partitions-8MB_spiffs-tinyuf2.csv ;; supports adafruit UF2 bootloader
+
+[env:waveshare_esp32s3_32MB_hub75]
+;; Waveshare ESP32-S3-RGB-Matrix (memory_type: opi_opi); see https://docs.waveshare.com/ESP32-S3-RGB-Matrix
+extends = env:esp32S3_wroom2_32MB
+monitor_filters = esp32_exception_decoder
+build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
+  -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2_32MB\" ;; need to un-set the relese name before setting a new one
+build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
+  -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
+  -D WAVESHARE_S3_PINOUT
+;  -D WLED_USE_SD_SPI
+;  -D SD_PRINT_HOME_DIR
+;  -D WLED_DEBUG
+lib_deps = ${esp32s3.lib_deps}
+  ${hub75.lib_deps}
 
 [env:esp32s3dev_16MB_opi_hub75]
 ;; MOONHUB HUB75 adapter board (lilygo T7-S3 with 16MB flash and octal PSRAM)

--- a/platformio.ini
+++ b/platformio.ini
@@ -649,6 +649,35 @@ board_build.partitions = tools/WLED_ESP32_32MB.csv
 board_upload.flash_size = 32MB
 board_upload.maximum_size = 33554432
 
+[env:waveshare_esp32s3_32MB_hub75]
+extends = env:esp32S3_wroom2_32MB
+board_build.partitions = ${esp32.extreme_partitions}
+board_build.f_flash = 80000000L
+board_upload.flash_size = 32MB
+monitor_filters = esp32_exception_decoder
+upload_speed = 115200
+upload_port = COM12
+build_unflags = ${common.build_unflags}
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshave_Matrix\"
+  -D WLED_ENABLE_HUB75MATRIX
+  -D NO_GFX
+  -D NO_FAST_FUNCTIONS
+  -D NO_CIE1931
+  -D S3_LCD_DIV_NUM=20
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DBOARD_HAS_PSRAM
+  -DLOLIN_WIFI_FIX ; seems to work much better with this
+  -D WLED_WATCHDOG_TIMEOUT=0
+  -D WAVESHARE_S3_PINOUT
+;  -D WLED_USE_SD_SPI
+;  -D SD_PRINT_HOME_DIR
+;  -D WLED_DEBUG
+  -D USERMOD_AUDIOREACTIVE
+  -D SR_DMTYPE=0 -D I2S_SDPIN=-1 -D I2S_CKPIN=-1 -D I2S_WSPIN=-1 -D MCLK_PIN=-1  ;; Disable to prevent pin clash
+lib_deps = ${esp32s3.lib_deps}
+  ${esp32.AR_lib_deps}
+  ${hub75.lib_deps}
+
 [env:esp32s3_4M_qspi]
 ;; ESP32-S3, with 4MB FLASH and <= 4MB PSRAM (memory_type: qio_qspi)
 extends = esp32s3

--- a/platformio.ini
+++ b/platformio.ini
@@ -651,31 +651,20 @@ board_upload.maximum_size = 33554432
 
 [env:waveshare_esp32s3_32MB_hub75]
 extends = env:esp32S3_wroom2_32MB
-board_build.partitions = ${esp32.extreme_partitions}
 board_build.f_flash = 80000000L
-board_upload.flash_size = 32MB
 monitor_filters = esp32_exception_decoder
 upload_speed = 115200
 upload_port = COM1:
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
-  -D WLED_ENABLE_HUB75MATRIX
-  -D NO_GFX
+build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
+  -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
   -D NO_FAST_FUNCTIONS
   -D NO_CIE1931
-  -D S3_LCD_DIV_NUM=20
-  -DARDUINO_USB_CDC_ON_BOOT=1
-  -DBOARD_HAS_PSRAM
-  -DLOLIN_WIFI_FIX ; seems to work much better with this
-  -D WLED_WATCHDOG_TIMEOUT=0
   -D WAVESHARE_S3_PINOUT
 ;  -D WLED_USE_SD_SPI
 ;  -D SD_PRINT_HOME_DIR
 ;  -D WLED_DEBUG
-  -D USERMOD_AUDIOREACTIVE
-  -D SR_DMTYPE=0 -D I2S_SDPIN=-1 -D I2S_CKPIN=-1 -D I2S_WSPIN=-1 -D MCLK_PIN=-1  ;; Disable to prevent pin clash
 lib_deps = ${esp32s3.lib_deps}
-  ${esp32.AR_lib_deps}
   ${hub75.lib_deps}
 
 [env:esp32s3_4M_qspi]

--- a/platformio.ini
+++ b/platformio.ini
@@ -652,8 +652,10 @@ board_upload.maximum_size = 33554432
 [env:waveshare_esp32s3_32MB_hub75]
 extends = env:esp32S3_wroom2_32MB
 monitor_filters = esp32_exception_decoder
+build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
+  -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2_32MB\" ;; need to un-set the relese name before setting a new one
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
-  -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
+  -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT
 ;  -D WLED_USE_SD_SPI
 ;  -D SD_PRINT_HOME_DIR

--- a/platformio.ini
+++ b/platformio.ini
@@ -651,10 +651,7 @@ board_upload.maximum_size = 33554432
 
 [env:waveshare_esp32s3_32MB_hub75]
 extends = env:esp32S3_wroom2_32MB
-board_build.f_flash = 80000000L
 monitor_filters = esp32_exception_decoder
-upload_speed = 115200
-upload_port = COM1:
 build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"

--- a/platformio.ini
+++ b/platformio.ini
@@ -652,7 +652,6 @@ board_upload.maximum_size = 33554432
 [env:waveshare_esp32s3_32MB_hub75]
 extends = env:esp32S3_wroom2_32MB
 monitor_filters = esp32_exception_decoder
-build_unflags = ${common.build_unflags}
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
   -D WAVESHARE_S3_PINOUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -656,9 +656,9 @@ board_build.f_flash = 80000000L
 board_upload.flash_size = 32MB
 monitor_filters = esp32_exception_decoder
 upload_speed = 115200
-upload_port = COM12
+upload_port = COM1:
 build_unflags = ${common.build_unflags}
-build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshave_Matrix\"
+build_flags = ${common.build_flags} ${esp32s3.build_flags} -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_Matrix\"
   -D WLED_ENABLE_HUB75MATRIX
   -D NO_GFX
   -D NO_FAST_FUNCTIONS

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -881,6 +881,12 @@ BusHub75Matrix::BusHub75Matrix(const BusConfig &bc) : Bus(bc.type, bc.start, bc.
   // HUB75_I2S_CFG::i2s_pins _pins={R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN, A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN};
   mxconfig.gpio = { 1, 5, 6, 7, 13, 9, 16, 48, 47, 21, 38, 8, 4, 18 };
 
+#elif defined(WAVESHARE_S3_PINOUT)
+  DEBUGBUS_PRINTLN("MatrixPanel_I2S_DMA - Waveshare S3 with PSRAM, Waveshare pinout");
+
+  // HUB75_I2S_CFG::i2s_pins _pins={R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN, A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN};
+  mxconfig.gpio = {4, 5, 6, 7, 15, 16, 18, 8, 3, 42, 9, 40, 2, 41};
+  
 #else
   DEBUGBUS_PRINTLN("MatrixPanel_I2S_DMA - S3 with PSRAM");
   // HUB75_I2S_CFG::i2s_pins _pins={R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN, A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN};


### PR DESCRIPTION
Adding basic support for Waveshare ESP32-S3-RGB-Matrix
https://www.waveshare.com/esp32-s3-rgb-matrix.htm
https://docs.waveshare.com/ESP32-S3-RGB-Matrix

Matrix Panel is working. Microphone(s), SD card, and SHTC3 still need work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for Waveshare ESP32‑S3 (32MB) boards driving HUB75 LED matrices.
  * New build/profile enabling PSRAM and HUB75 matrix support with a Waveshare-specific pinout to prevent hardware conflicts.
  * Dedicated release name for this board and improved startup/serial diagnostics for clearer troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wled/WLED/pull/5657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->