### PR TITLE
HUB75 hotfix: prevent double-applying gamma correction

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -730,6 +730,7 @@ board_build.partitions = ${esp32.extreme_partitions}  ; We're gonna need a bigge
 ;; Core HUB75 flags - common to every HUB75 build
 build_flags =
   -D WLED_ENABLE_HUB75MATRIX -D NO_GFX
+  -D NO_CIE1931 ;; disable driver-internal gamma correction
   -D WLED_DEBUG_BUS
   -D LED_TYPES=TYPE_HUB75MATRIX_HS
   ; -D WLED_DEBUG


### PR DESCRIPTION
disables the driver-internal CIE color correction.

partial solution for #5664

Tested on my HUB75 equipment, does what it should.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated HUB75 display settings to modify color rendering behavior on LED matrix displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->