### PR TITLE
Add RTL8201-based wESP32 rev7 Ethernet option

### DIFF
--- a/wled00/const.h
+++ b/wled00/const.h
@@ -395,7 +395,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define BTN_TYPE_TOUCH_SWITCH     9
 
 //Ethernet board types
-#define WLED_NUM_ETH_TYPES        16
+#define WLED_NUM_ETH_TYPES        17
 
 
 #define WLED_ETH_NONE              0
@@ -414,6 +414,7 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define WLED_ETH_GLEDOPTO         13
 #define WLED_ETH_QUINLED_V4_UNOQUAD  14
 #define WLED_ETH_QUINLED_V4_OCTA     15
+#define WLED_ETH_WESP32_RTL8201      16
 
 
 //Hue error codes

--- a/wled00/data/settings_wifi.htm
+++ b/wled00/data/settings_wifi.htm
@@ -242,7 +242,8 @@ Static subnet mask:<br>
 			<option value="15">QuinLED v4 Octa</option>
 			<option value="10">Serg74-ETH32</option>
 			<option value="5">TwilightLord-ESP32</option>
-			<option value="3">WESP32</option>
+			<option value="3">WESP32 (Rev ≤6)</option>
+			<option value="16">WESP32 (Rev 7+)</option>
 			<option value="1">WT32-ETH01</option>
 			<option value="13">Gledopto</option>
 		</select><br><br>

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -45,7 +45,7 @@ const ethernet_settings ethernetBoards[] = {
     ETH_CLOCK_GPIO17_OUT  // eth_clk_mode
   },
 
-   // WESP32
+   // WESP32 rev 6 and earlier
   {
     0,			              // eth_address,
     -1,			              // eth_power,
@@ -173,6 +173,16 @@ const ethernet_settings ethernetBoards[] = {
     23,                  // eth_mdc
     18,                  // eth_mdio
     ETH_PHY_LAN8720,     // eth_type
+    ETH_CLOCK_GPIO0_IN   // eth_clk_mode
+  },
+
+ // WLED_ETH_WESP32_RTL8201 (16) - WESP32 rev 7 and later
+  {
+    0,                   // eth_address
+    -1,                  // eth_power
+    16,                  // eth_mdc
+    17,                  // eth_mdio
+    ETH_PHY_RTL8201,     // eth_type
     ETH_CLOCK_GPIO0_IN   // eth_clk_mode
   },
 };


### PR DESCRIPTION
Add a separate Ethernet board type for wESP32 rev7 and later boards, which use the RTL8201 PHY instead of the LAN8720 used by earlier revisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WESP32 Rev 7 with RTL8201 Ethernet PHY.
  * Ethernet Type selector now distinguishes WESP32 (Rev ≤6) vs WESP32 (Rev 7+).
  * Improved Ethernet compatibility and initialization for WESP32 Rev 7 devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->