### PR TITLE
Prevent arduino core from assigning default MISO pin

### DIFF
--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -358,6 +358,7 @@ class PolyBus {
     #ifdef ESP8266
     dotStar_strip->Begin();
     #else
+    if (miso == -1) miso = 127; // note: in arduino core, -1 meaans "default" not "none", passing 127 as the MISO pin is a workaround to prevent SPI.begin() assign the default pin, see #5670
     if (sck == -1 && mosi == -1) dotStar_strip->Begin();
     else                         dotStar_strip->Begin(sck, miso, mosi, ss);
     #endif

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -358,7 +358,7 @@ class PolyBus {
     #ifdef ESP8266
     dotStar_strip->Begin();
     #else
-    if (miso == -1) miso = 127; // note: in arduino core, -1 meaans "default" not "none", passing 127 as the MISO pin is a workaround to prevent SPI.begin() assign the default pin, see #5670
+    if (miso == -1) miso = 127; // note: in arduino core, -1 means "default" not "none", passing 127 as the MISO pin is a workaround to prevent SPI.begin() assign the default pin, see #5670
     if (sck == -1 && mosi == -1) dotStar_strip->Begin();
     else                         dotStar_strip->Begin(sck, miso, mosi, ss);
     #endif


### PR DESCRIPTION
Adds invalid dummy pin if miso is undefined to prevent default fallback

fixes #5670

copy of comment from [#5670](https://github.com/wled/WLED/issues/5670#issuecomment-4638253129):

>I have found a fix that works around this arduino core quirk, to not say bug. In beginDotStar() adding this line fixes it:
if (miso == -1) miso = 127;
For reference:
in IDF passing a "-1" as a pin means unused
in arduino core a "-1" as apin means "use default"
the solution is to pass an invalid pin to the arduino function, it will then try to assign it, the underlaying IDF API rejects the pin, arduino core does not even check if it fails and just move on.
The default assignment by arduino may actually have some other side-effects when using clocked LEDs in combination with default MISO pins, all ESP32 flavours are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on non-ESP8266 boards where DotStar LED initialization could pick an incorrect default SPI pin, causing erratic or non-working LED output. This update ensures the SPI setup respects caller intent and prevents unintended pin reassignment during DotStar startup, improving LED reliability on affected platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->