### PR TITLE
  Fix: prevent LED flash on cold boot when a boot preset is configured

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -507,6 +507,7 @@ void WLED::setup()
     handlePresets();  // handle boot preset
     handlePlaylist(); // handle playlist if preset queued one
     handlePresets();  // handle presets again to give a chance for anything queued by the boot preset or playlist
+    strip.setTransition(transitionDelayDefault); // restore transitions now that the boot preset applied instantly (no boot flash)
   }
   
   if (strcmp(multiWiFi[0].clientSSID, DEFAULT_CLIENT_SSID) == 0 && !configBackupExists())
@@ -617,19 +618,28 @@ void WLED::beginStrip()
   offMode = false;   // init to on state to allow proper relay init
   handleOnOff(true); // init relay and force off
 
-  if (turnOnAtBoot) {
+  // fix for #3196 and the boot flash: if a boot preset is configured, fully blank the strip and
+  // push a black frame before applying it. The boot preset is applied with a transition, which
+  // crossfades FROM the current (restored) segment buffer; without a black starting frame that
+  // restored state flashes at the restored brightness for the first fraction of a second.
+  // This must run for turnOnAtBoot too. Brightness 0 alone (the boot brightness still feeds the
+  // crossfade's source) and blanking colors[0] alone (palette/FX states still render) are each
+  // insufficient on their own, which is why earlier attempts still flashed.
+  if (bootPreset > 0) {
+    // set all segments black (no transition)
+    for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
+      Segment &seg = strip.getSegment(i);
+      if (seg.isActive()) seg.colors[0] = BLACK;
+    }
+    colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
+    briLast = briS; bri = 0;       // stay dark; the boot preset sets its own brightness when it applies
+    strip.fill(BLACK);
+    if (rlyPin < 0)
+      strip.show();                // push a black frame so the boot preset's transition starts from black
+  } else if (turnOnAtBoot) {
     if (briS > 0) bri = briS;
     else if (bri == 0) bri = 128;
   } else {
-    // fix for #3196
-    if (bootPreset > 0) {
-      // set all segments black (no transition)
-      for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
-        Segment &seg = strip.getSegment(i);
-        if (seg.isActive()) seg.colors[0] = BLACK;
-      }
-      colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
-    }
     briLast = briS; bri = 0;
     strip.fill(BLACK);
     if (rlyPin < 0)
@@ -638,6 +648,11 @@ void WLED::beginStrip()
   colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition
   if (bootPreset > 0) {
     applyPreset(bootPreset, CALL_MODE_INIT);
+    // keep transitions disabled until the boot preset has actually been applied (in setup(), after
+    // beginStrip() returns) so it applies instantly with NO crossfade from the restored state -
+    // a crossfade is what makes the restored state flash on cold boot. Transitions are restored
+    // in setup() right after the boot preset/playlist is handled.
+    return;
   }
 
   strip.setTransition(transitionDelayDefault);  // restore transitions


### PR DESCRIPTION
# Description 
When WLED is powered by a "dumb" switch that cuts power to the whole circuit (PSU + ESP together), the LEDs briefly flash their previously-restored state at full/restored brightness during boot, before the configured boot preset (e.g. a playlist) takes over. This PR removes that flash.

# Root Cause
The boot preset is queued in WLED::beginStrip() and applied later in setup() with a transition. That transition crossfades from the current (restored) segment buffer. On cold boot the segment buffer still holds the restored colors at the restored brightness, so the crossfade's source frame is bright — that's what flashes for the first fraction of a second.

# Testing performed

  - ✅  Compiles.
  - ✅  Tested on actual hardware (ESP32 + WS2812B, single-switch PSU+ESP setup, FCOB SPI CCT WS2811 IC LED Strip) with a boot playlist. Normal cold boot (power off ≥3 s, then on) is now clean — no flash.
  - ⚠️ Known limitation: a rapid off/on within <2 s can still show a brief flash. This is a hardware effect, not firmware — the PSU's bulk capacitors keep the WS2812s powered through the dip, so the
  strip holds its last latched frame until the ESP reboots and sends a black frame. Waiting a few seconds (or adding a bleeder resistor across the 5 V rail) avoids it. Firmware sends black as early as
  it can (after config load + finalizeInit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot preset initialization to properly manage LED transitions during startup. When a boot preset is applied, the LED strip now initializes to a clean black state with transitions appropriately disabled, then re-enables transitions after the preset is fully applied. This ensures smoother and more predictable LED behavior during device startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->