### PR TITLE
Fix for ESP32C3 Glitching on Long Strips

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -178,7 +178,10 @@ void WLED::loop()
     // calling getContiguousFreeHeap() during led update causes glitches on C3
     // this can (probably) be removed once RMT driver for C3 is fixed
     unsigned t0 = millis();
-    while (strip.isUpdating() && (millis() - t0 < 15)) delay(1);    // be nice, but not too nice. Waits up to 15ms
+    // Most strips run at 800kHz, each LED needs 24 bits = 30µs per LED
+    // Add 30% margin and convert to ms, minimum 15ms
+    uint32_t waitMs = max(15u, (unsigned)(strip.getLengthTotal() * 30 / 1000 * 1.3));
+    while (strip.isUpdating() && (millis() - t0 < waitMs)) delay(1);    // be nice, but not too nice
     #endif
     uint32_t heap = getContiguousFreeHeap(); // ESP32 family needs ~10k of contiguous free heap for UI to work properly
     #endif

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -40,7 +40,7 @@ void WLED::reset()
 
 void WLED::loop()
 {
-  static uint16_t      heapTime = 0;   // timestamp for heap check
+  static uint16_t      heapTime = millis();   // timestamp for heap check
   static uint8_t       heapDanger = 0; // counter for consecutive low-heap readings
 #ifdef WLED_DEBUG
   static unsigned long lastRun = 0;
@@ -177,42 +177,43 @@ void WLED::loop()
     #ifdef CONFIG_IDF_TARGET_ESP32C3
     // calling getContiguousFreeHeap() during led update causes glitches on C3
     // this can (probably) be removed once RMT driver for C3 is fixed
-    unsigned t0 = millis();
-    // Most strips run at 800kHz, each LED needs 24 bits = 30µs per LED
-    // Add 30% margin and convert to ms, minimum 15ms
-    uint32_t waitMs = max(15u, (unsigned)(strip.getLengthTotal() * 30 / 1000 * 1.3));
-    while (strip.isUpdating() && (millis() - t0 < waitMs)) delay(1);    // be nice, but not too nice
+    // If strip updating, defer heap check until future
+    if (strip.isUpdating()) {
+      heapTime = millis() - 4999;
+    } else
     #endif
-    uint32_t heap = getContiguousFreeHeap(); // ESP32 family needs ~10k of contiguous free heap for UI to work properly
-    #endif
-    if (heap < MIN_HEAP_SIZE - 1024) heapDanger+=5; // allow 1k of "wiggle room" for things that do not respect min heap limits
-    else heapDanger = 0;
-    switch (heapDanger) {
-      case 15: // 15 consecutive seconds
-        DEBUG_PRINTLN(F("Heap low, purging segments"));
-        strip.purgeSegments();
-        strip.setTransition(0); // disable transitions
-        for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
-          strip.getSegments()[i].setMode(FX_MODE_STATIC); // set static mode to free effect memory
-        }
-        errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: segment reset
-        break;
-      case 30: // 30 consecutive seconds
-        DEBUG_PRINTLN(F("Heap low, reset segments"));
-        strip.resetSegments(); // remove all but one segments from memory
-        errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: segment reset
-        break;
-      case 45: // 45 consecutive seconds
-        DEBUG_PRINTF_P(PSTR("Heap panic! Reset strip, reset connection\n"));
-        strip.~WS2812FX();      // deallocate strip and all its memory
-        new(&strip) WS2812FX(); // re-create strip object, respecting current memory limits
-        if (!Update.isRunning()) forceReconnect = true; // in case wifi is broken, make sure UI comes back, set disableForceReconnect = true to avert
-        errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: strip reset
-        break;
-      default:
-        break;
+    {
+      uint32_t heap = getContiguousFreeHeap(); // ESP32 family needs ~10k of contiguous free heap for UI to work properly
+      #endif
+      if (heap < MIN_HEAP_SIZE - 1024) heapDanger+=5; // allow 1k of "wiggle room" for things that do not respect min heap limits
+      else heapDanger = 0;
+      switch (heapDanger) {
+        case 15: // 15 consecutive seconds
+          DEBUG_PRINTLN(F("Heap low, purging segments"));
+          strip.purgeSegments();
+          strip.setTransition(0); // disable transitions
+          for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
+            strip.getSegments()[i].setMode(FX_MODE_STATIC); // set static mode to free effect memory
+          }
+          errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: segment reset
+          break;
+        case 30: // 30 consecutive seconds
+          DEBUG_PRINTLN(F("Heap low, reset segments"));
+          strip.resetSegments(); // remove all but one segments from memory
+          errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: segment reset
+          break;
+        case 45: // 45 consecutive seconds
+          DEBUG_PRINTF_P(PSTR("Heap panic! Reset strip, reset connection\n"));
+          strip.~WS2812FX();      // deallocate strip and all its memory
+          new(&strip) WS2812FX(); // re-create strip object, respecting current memory limits
+          if (!Update.isRunning()) forceReconnect = true; // in case wifi is broken, make sure UI comes back, set disableForceReconnect = true to avert
+          errorFlag = ERR_NORAM; // alert UI  TODO: make this a distinct error: strip reset
+          break;
+        default:
+          break;
+      }
+      heapTime = (uint16_t)millis();
     }
-    heapTime = (uint16_t)millis();
   }
 
   //LED settings have been saved, re-init busses

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -40,7 +40,7 @@ void WLED::reset()
 
 void WLED::loop()
 {
-  static uint16_t      heapTime = millis();   // timestamp for heap check
+  static uint16_t      heapTime = 0;   // timestamp for heap check
   static uint8_t       heapDanger = 0; // counter for consecutive low-heap readings
 #ifdef WLED_DEBUG
   static unsigned long lastRun = 0;


### PR DESCRIPTION
### Hardware
- Seeed XIAO ESP32-C3
- 833x WS2815 ECO LEDs

### Fix
Made wait time before calling getContiguousFreeHeap() on ESP32C3 to be a function of the number of LEDs to avoid interrupting RMT transmissions, which corrupts end of frame during animations every 5 seconds. At 800kHz with 24 bits per LED, a full frame takes N × 30µs. For strips longer than ~500 LEDs the fixed 15ms wait is insufficient, causing getContiguousFreeHeap() to interrupt an in-progress RMT transmission and corrupt the last portion of the frame (visible as a white flash every 5 seconds). This PR replaces the hardcoded value with a calculation based on actual strip length with a safety margin, floored at the original 15ms so short strips are unaffected.

### Ongoing Issue
When running the effect given in "Wavesins API Command," my solution stopped the glitching. And in all other effects I tested, the issue is fixed. However, when running the effect given in "Stream API Command," the issue is still persisting. Additionally, the glitching occurs not just in the last quarter of the frame as it did with the other effects, but instead on the whole frame. And instead of glitching every 5 seconds, it's glitching every 6 seconds. Even when I raised the margin in the waitMS calculation, the glitch still occurred the exact same way on the Stream effect.


**Wavesins API Command**
`{"on":true,"bri":255,"transition":0,"bs":0,"mainseg":0,"seg":[{"id":0,"start":0,"stop":832,"grp":1,"spc":0,"of":0,"on":true,"frz":false,"bri":255,"cct":127,"set":0,"lc":1,"n":"","col":[[115,0,255],[255,4,0],[0,0,0]],"fx":184,"sx":15,"ix":245,"pal":18,"c1":124,"c2":34,"c3":1,"sel":true,"rev":false,"mi":false,"o1":false,"o2":false,"o3":false,"si":0,"m12":0,"bm":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0}]}`

**Stream API Command**
`{"on":true,"bri":255,"transition":0,"bs":0,"mainseg":0,"seg":[{"id":0,"start":0,"stop":832,"grp":1,"spc":0,"of":0,"on":true,"frz":false,"bri":255,"cct":127,"set":0,"lc":1,"n":"","col":[[115,0,255],[255,4,0],[0,0,0]],"fx":39,"sx":255,"ix":39,"pal":48,"c1":128,"c2":128,"c3":16,"sel":true,"rev":false,"mi":false,"o1":false,"o2":false,"o3":false,"si":0,"m12":0,"bm":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0},{"stop":0}]}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness on ESP32C3 devices by optimizing memory health monitoring to prevent blocking during LED strip updates. The system defers heap checks when the strip is actively updating and resumes normal monitoring intervals when complete. All memory safety checks remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->