### PR TITLE
improve bootup behaviour for boot presets

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -598,7 +598,7 @@ class Segment {
       DEBUGFX_PRINTF_P(PSTR("-- Creating segment: %p [%d,%d:%d,%d]\n"), this, (int)start, (int)stop, (int)startY, (int)stopY);
       uint32_t bootTimeDelay = 5000;
       #ifdef WLED_BOOTUPDELAY
-      bootTimeDelay += WLED_BOOTUPDELAY
+      bootTimeDelay += WLED_BOOTUPDELAY;
       #endif
       if (millis() < bootTimeDelay)
         colors[0] = BLACK; // at bootup create black segments so boot-up fade-in does not fade to orange

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -42,7 +42,7 @@
 #define DEFAULT_MODE       (uint8_t)0
 #define DEFAULT_SPEED      (uint8_t)128
 #define DEFAULT_INTENSITY  (uint8_t)128
-#define DEFAULT_COLOR      (uint32_t)0xFFAA00
+#define DEFAULT_COLOR      (uint32_t)0xFFA000
 #define DEFAULT_C1         (uint8_t)128
 #define DEFAULT_C2         (uint8_t)128
 #define DEFAULT_C3         (uint8_t)16
@@ -562,7 +562,7 @@ class Segment {
   public:
 
     Segment(uint16_t sStart=0, uint16_t sStop=30, uint16_t sStartY = 0, uint16_t sStopY = 1)
-    : colors{DEFAULT_COLOR,BLACK,BLACK}
+    : colors{DEFAULT_COLOR,BLACK,BLACK} // create "warm orange" segment by default
     , start(sStart)
     , stop(sStop > sStart ? sStop : sStart+1) // minimum length is 1
     , startY(sStartY)
@@ -596,6 +596,12 @@ class Segment {
     , _t(nullptr)
     {
       DEBUGFX_PRINTF_P(PSTR("-- Creating segment: %p [%d,%d:%d,%d]\n"), this, (int)start, (int)stop, (int)startY, (int)stopY);
+      uint32_t bootTimeDelay = 5000;
+      #ifdef WLED_BOOTUPDELAY
+      bootTimeDelay += WLED_BOOTUPDELAY
+      #endif
+      if (millis() < bootTimeDelay)
+        colors[0] = BLACK; // at bootup create black segments so boot-up fade-in does not fade to orange
       // allocate render buffer (always entire segment), prefer PSRAM if DRAM is running low. Note: impact on FPS with PSRAM buffer is low (<2% with QSPI PSRAM)
       pixels = static_cast<uint32_t*>(allocate_buffer(length() * sizeof(uint32_t), BFRALLOC_PREFER_PSRAM | BFRALLOC_NOBYTEACCESS | BFRALLOC_CLEAR));
       if (!pixels) {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -562,7 +562,7 @@ class Segment {
   public:
 
     Segment(uint16_t sStart=0, uint16_t sStop=30, uint16_t sStartY = 0, uint16_t sStopY = 1)
-    : colors{DEFAULT_COLOR,BLACK,BLACK} // create "warm orange" segment by default
+    : colors{BLACK,BLACK,BLACK} // set colors to black, will be updated to orange if segment is created as "auto segment" or from UI
     , start(sStart)
     , stop(sStop > sStart ? sStop : sStart+1) // minimum length is 1
     , startY(sStartY)
@@ -596,12 +596,6 @@ class Segment {
     , _t(nullptr)
     {
       DEBUGFX_PRINTF_P(PSTR("-- Creating segment: %p [%d,%d:%d,%d]\n"), this, (int)start, (int)stop, (int)startY, (int)stopY);
-      uint32_t bootupTime = 2000; // 2s should be more than enough to init bootup-segments to black
-      #ifdef WLED_BOOTUPDELAY
-      bootupTime += WLED_BOOTUPDELAY;
-      #endif
-      if (millis() < bootupTime)
-        colors[0] = BLACK; // at bootup create black segments so boot-up fade-in does not turn to orange for presets
       // allocate render buffer (always entire segment), prefer PSRAM if DRAM is running low. Note: impact on FPS with PSRAM buffer is low (<2% with QSPI PSRAM)
       pixels = static_cast<uint32_t*>(allocate_buffer(length() * sizeof(uint32_t), BFRALLOC_PREFER_PSRAM | BFRALLOC_NOBYTEACCESS | BFRALLOC_CLEAR));
       if (!pixels) {

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -596,12 +596,12 @@ class Segment {
     , _t(nullptr)
     {
       DEBUGFX_PRINTF_P(PSTR("-- Creating segment: %p [%d,%d:%d,%d]\n"), this, (int)start, (int)stop, (int)startY, (int)stopY);
-      uint32_t bootTimeDelay = 5000;
+      uint32_t bootupTime = 2000; // 2s should be more than enough to init bootup-segments to black
       #ifdef WLED_BOOTUPDELAY
-      bootTimeDelay += WLED_BOOTUPDELAY;
+      bootupTime += WLED_BOOTUPDELAY;
       #endif
-      if (millis() < bootTimeDelay)
-        colors[0] = BLACK; // at bootup create black segments so boot-up fade-in does not fade to orange
+      if (millis() < bootupTime)
+        colors[0] = BLACK; // at bootup create black segments so boot-up fade-in does not turn to orange for presets
       // allocate render buffer (always entire segment), prefer PSRAM if DRAM is running low. Note: impact on FPS with PSRAM buffer is low (<2% with QSPI PSRAM)
       pixels = static_cast<uint32_t*>(allocate_buffer(length() * sizeof(uint32_t), BFRALLOC_PREFER_PSRAM | BFRALLOC_NOBYTEACCESS | BFRALLOC_CLEAR));
       if (!pixels) {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1991,6 +1991,9 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
     for (size_t i = 1; i < s; i++) {
       _segments.emplace_back(segStarts[i], segStops[i]);
     }
+    for (size_t i = 0; i < s; i++) {
+      _segments[i].colors[0] = DEFAULT_COLOR; // set color to default orange on all segments
+    }
     DEBUGFX_PRINTF_P(PSTR("%d auto segments created.\n"), _segments.size());
 
   } else {

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1991,7 +1991,7 @@ void WS2812FX::makeAutoSegments(bool forceReset) {
     for (size_t i = 1; i < s; i++) {
       _segments.emplace_back(segStarts[i], segStops[i]);
     }
-    for (size_t i = 0; i < s; i++) {
+    for (size_t i = 0; i < _segments.size(); i++) {
       _segments[i].colors[0] = DEFAULT_COLOR; // set color to default orange on all segments
     }
     DEBUGFX_PRINTF_P(PSTR("%d auto segments created.\n"), _segments.size());

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -1126,7 +1126,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 	<div class="sec">
 		<h3>Power up</h3>
 		Turn LEDs on after power up/reset: <input type="checkbox" name="BO"><br>
-		with brightness: <input name="CA" type="number" class="m" min="1" max="255" required> (1-255)<br>
+		Bootup brightness: <input name="CA" type="number" class="m" min="1" max="255" required> (1-255)<br>
 		<i>(disable if using boot preset to turn LEDs on)</i><br><br>
 		Apply preset <input name="BP" type="number" class="m" min="0" max="250" required> at boot (0 = none)<br><br>
 	</div>

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -1126,8 +1126,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 	<div class="sec">
 		<h3>Power up</h3>
 		Turn LEDs on after power up/reset: <input type="checkbox" name="BO"><br>
-		Bootup brightness: <input name="CA" type="number" class="m" min="1" max="255" required> (1-255)<br>
-		<i>(disable if using boot preset to turn LEDs on)</i><br><br>
+		Bootup brightness: <input name="CA" type="number" class="m" min="1" max="255" required> (1-255)<br><br>
 		Apply preset <input name="BP" type="number" class="m" min="0" max="250" required> at boot (0 = none)<br><br>
 	</div>
 	<div class="sec">

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -85,6 +85,9 @@ static bool deserializeSegment(JsonObject elem, byte it, byte presetId = 0)
 
   //DEBUG_PRINTLN(F("-- JSON deserialize segment."));
   Segment& seg = strip.getSegment(id);
+  if (newSeg && presetId == 0) {
+    seg.colors[0] = DEFAULT_COLOR; // set color of newly created segment to warm orange as an indicator to the user
+  }
   // we do not want to make segment copy as it may use a lot of RAM (effect data and pixel buffer)
   // so we will create a copy of segment options and compare it with original segment when done processing
   SegmentCopy prev = {

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -617,26 +617,36 @@ void WLED::beginStrip()
   offMode = false;   // init to on state to allow proper relay init
   handleOnOff(true); // init relay and force off
   if (rlyPin < 0) strip.show(); // ensure LEDs are off if no relay is used
+  // note on how bootup behaviour:
+  // if turnOnAtBoot is false, strip is set to black. It will fade in to startup brightness and orange when turned on
+  // if a bootup preset is set, it will fade to that preset if it has on:true set (to default brightness) or to that preset's brightness if set
+  // if turnOnAtBoot is true the LEDs will fade in to orange and default brightness
+  // if a booup preset is set, it will start at the default brightness except if "fade" transition is used, then it will still fade from black
+  // there is no way to have LEDs off at boot and upon turn-on have them immediatel jump to a target brightness but users can use a playlist to do that
+
   bri = 0; // start off black by default (on a fresh install this is overruled by briS as turnOnAtBoot is true)
   if (turnOnAtBoot) {
-    bri = briS ? briS : 128; // load startup brightness (set in UI), fall back to mid if set to 0 to make sure LEDs turn on
-    // set color to warm welcoming orange (aka DEFAULT_COLOR)
-    colPri[0] = 255;
-    colPri[1] = 160;
-    colPri[2] = colPri[3] = 0;
+    bri = briS; // load startup brightness (set in UI), 0 is not allowed in UI
   }
+  else briLast = briS; // go to startup brightness (set in UI) when turning on (can be overruled by a preset)
 
   if (bootPreset > 0) {
     colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
     applyPreset(bootPreset, CALL_MODE_INIT);
-    // set all segments black (no transition), their default creation color is orange (which is needed for creating new segments in the UI)
+    // note: if turn on at boot is disabled, preset will fade in from black, even if swipe is used
+    // if fade is used, it will always fade from black.
     for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
       Segment &seg = strip.getSegment(i);
       if (seg.isActive()) seg.colors[0] = BLACK;
     }
   }
-  else
+  else {
+    // set color to warm welcoming orange (aka DEFAULT_COLOR) if no preset loaded (will fade to this color once turned on)
+    colPri[0] = 255;
+    colPri[1] = 160;
+    colPri[2] = colPri[3] = 0;
     strip.setTransition(transitionDelayDefault);  // restore default transition time (was set to 0 above)
+  }
 
   colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition, if still zero, brightness is set immediately
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -637,9 +637,10 @@ void WLED::beginStrip()
   }
   else {
     // set color to warm welcoming orange (aka DEFAULT_COLOR) if no preset loaded (will fade to this color once turned on)
-    colPri[0] = 255;
-    colPri[1] = 160;
-    colPri[2] = colPri[3] = 0;
+    colPri[0] = R(DEFAULT_COLOR);
+    colPri[1] = G(DEFAULT_COLOR);
+    colPri[2] = B(DEFAULT_COLOR);
+    colPri[3] = W(DEFAULT_COLOR);
   }
 
   strip.setTransition(transitionDelayDefault);  // restore default transition time

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -616,31 +616,30 @@ void WLED::beginStrip()
   // init offMode and relay
   offMode = false;   // init to on state to allow proper relay init
   handleOnOff(true); // init relay and force off
-
+  if (rlyPin < 0) strip.show(); // ensure LEDs are off if no relay is used
+  bri = 0; // start off black by default (on a fresh install this is overruled by briS as turnOnAtBoot is true)
   if (turnOnAtBoot) {
-    if (briS > 0) bri = briS;
-    else if (bri == 0) bri = 128;
-  } else {
-    // fix for #3196
-    if (bootPreset > 0) {
-      // set all segments black (no transition)
-      for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
-        Segment &seg = strip.getSegment(i);
-        if (seg.isActive()) seg.colors[0] = BLACK;
-      }
-      colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
-    }
-    briLast = briS; bri = 0;
-    strip.fill(BLACK);
-    if (rlyPin < 0)
-      strip.show(); // ensure LEDs are off if no relay is used
-  }
-  colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition
-  if (bootPreset > 0) {
-    applyPreset(bootPreset, CALL_MODE_INIT);
+    bri = briS ? briS : 128; // load startup brightness (set in UI), fall back to mid if set to 0 to make sure LEDs turn on
+    // set color to warm welcoming orange (aka DEFAULT_COLOR)
+    colPri[0] = 255;
+    colPri[1] = 160;
+    colPri[2] = colPri[3] = 0;
   }
 
-  strip.setTransition(transitionDelayDefault);  // restore transitions
+  if (bootPreset > 0) {
+    colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
+    applyPreset(bootPreset, CALL_MODE_INIT);
+    // set all segments black (no transition), their default creation color is orange (which is needed for creating new segments in the UI)
+    for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
+      Segment &seg = strip.getSegment(i);
+      if (seg.isActive()) seg.colors[0] = BLACK;
+    }
+  }
+  else
+    strip.setTransition(transitionDelayDefault);  // restore default transition time (was set to 0 above)
+
+  colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition, if still zero, brightness is set immediately
+
 }
 
 void WLED::initAP(bool resetAP)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -617,11 +617,11 @@ void WLED::beginStrip()
   offMode = false;   // init to on state to allow proper relay init
   handleOnOff(true); // init relay and force off
   if (rlyPin < 0) strip.show(); // ensure LEDs are off if no relay is used
-  // note on how bootup behaviour:
-  // if turnOnAtBoot is false, strip is set to black. It will fade in to startup brightness and orange when turned on
-  // if a bootup preset is set, it will fade to that preset if it has on:true set (to default brightness) or to that preset's brightness if set
-  // if turnOnAtBoot is true the LEDs will fade in to orange and default brightness
-  // if a bootup preset is set, it will start at the default brightness except if "fade" transition is used, then it will still fade from black
+  // note on how bootup behaviour works:
+  // if turnOnAtBoot is false: strip is set to black. It will fade in to startup brightness and orange when turned on
+  //   if a bootup preset is set, it will fade to that preset if it has "on:true" set (to default brightness) or to that preset's brightness if set
+  // if turnOnAtBoot is true: the LEDs will fade in to orange and default brightness
+  //   if a bootup preset is set, it will start at the default brightness except if "fade" transition is used, then it will still fade from black
   // there is no way to have LEDs off at boot and upon turn-on have them immediatel jump to a target brightness but users can use a playlist to do that
 
   bri = 0; // start off black by default (on a fresh install this is overruled by briS as turnOnAtBoot is true)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -621,7 +621,7 @@ void WLED::beginStrip()
   // if turnOnAtBoot is false, strip is set to black. It will fade in to startup brightness and orange when turned on
   // if a bootup preset is set, it will fade to that preset if it has on:true set (to default brightness) or to that preset's brightness if set
   // if turnOnAtBoot is true the LEDs will fade in to orange and default brightness
-  // if a booup preset is set, it will start at the default brightness except if "fade" transition is used, then it will still fade from black
+  // if a bootup preset is set, it will start at the default brightness except if "fade" transition is used, then it will still fade from black
   // there is no way to have LEDs off at boot and upon turn-on have them immediatel jump to a target brightness but users can use a playlist to do that
 
   bri = 0; // start off black by default (on a fresh install this is overruled by briS as turnOnAtBoot is true)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -617,7 +617,8 @@ void WLED::beginStrip()
   offMode = false;   // init to on state to allow proper relay init
   handleOnOff(true); // init relay and force off
   if (rlyPin < 0) strip.show(); // ensure LEDs are off if no relay is used
-  // note on how bootup behaviour works:
+
+  // Note on how bootup behaviour works:
   // if turnOnAtBoot is false: strip is set to black. It will fade in to startup brightness and orange when turned on
   //   if a bootup preset is set, it will fade to that preset if it has "on:true" set (to default brightness) or to that preset's brightness if set
   // if turnOnAtBoot is true: the LEDs will fade in to orange and default brightness
@@ -638,11 +639,10 @@ void WLED::beginStrip()
     colPri[0] = 255;
     colPri[1] = 160;
     colPri[2] = colPri[3] = 0;
-    strip.setTransition(transitionDelayDefault);  // restore default transition time (was set to 0 above)
   }
 
-  colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition, if still zero, brightness is set immediately
-
+  colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition, brightness is set immediately
+  strip.setTransition(transitionDelayDefault);  // restore default transition time
 }
 
 void WLED::initAP(bool resetAP)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -630,6 +630,7 @@ void WLED::beginStrip()
     bri = briS; // load startup brightness (set in UI), 0 is not allowed in UI
   }
   else briLast = briS; // go to startup brightness (set in UI) when turning on (can be overruled by a preset)
+  colorUpdated(CALL_MODE_INIT); // set bootup brightness immediately, do not send notification (brightness is also set for preset if used, useful for swipe etc.)
 
   if (bootPreset > 0) {
     applyPreset(bootPreset, CALL_MODE_INIT);
@@ -641,8 +642,8 @@ void WLED::beginStrip()
     colPri[2] = colPri[3] = 0;
   }
 
-  colorUpdated(CALL_MODE_INIT); // will not send notification but will initiate transition, brightness is set immediately
   strip.setTransition(transitionDelayDefault);  // restore default transition time
+  colorUpdated(CALL_MODE_INIT); // apply color & initiate transition, do not send notification
 }
 
 void WLED::initAP(bool resetAP)

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -631,14 +631,7 @@ void WLED::beginStrip()
   else briLast = briS; // go to startup brightness (set in UI) when turning on (can be overruled by a preset)
 
   if (bootPreset > 0) {
-    colPri[0] = colPri[1] = colPri[2] = colPri[3] = 0;  // needed for colorUpdated()
     applyPreset(bootPreset, CALL_MODE_INIT);
-    // note: if turn on at boot is disabled, preset will fade in from black, even if swipe is used
-    // if fade is used, it will always fade from black.
-    for (unsigned i = 0; i < strip.getSegmentsNum(); i++) {
-      Segment &seg = strip.getSegment(i);
-      if (seg.isActive()) seg.colors[0] = BLACK;
-    }
   }
   else {
     // set color to warm welcoming orange (aka DEFAULT_COLOR) if no preset loaded (will fade to this color once turned on)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -413,8 +413,8 @@ WLED_GLOBAL bool gammaCorrectCol    _INIT(true);  // use gamma correction on col
 WLED_GLOBAL bool gammaCorrectBri    _INIT(false); // use gamma correction on brightness
 WLED_GLOBAL float gammaCorrectVal   _INIT(2.2f);  // gamma correction value
 
-WLED_GLOBAL byte colPri[] _INIT_N(({ 255, 160, 0, 0 }));  // current RGB(W) primary color. colPri[] should be updated if you want to change the color.
-WLED_GLOBAL byte colSec[] _INIT_N(({ 0, 0, 0, 0 }));      // current RGB(W) secondary color
+WLED_GLOBAL byte colPri[] _INIT_N(({ 0, 0, 0, 0 }));   // current RGB(W) primary color. colPri[] should be updated if you want to change the color.
+WLED_GLOBAL byte colSec[] _INIT_N(({ 0, 0, 0, 0 }));   // current RGB(W) secondary color
 
 WLED_GLOBAL byte nightlightTargetBri _INIT(0);      // brightness after nightlight is over
 WLED_GLOBAL byte nightlightDelayMins _INIT(60);


### PR DESCRIPTION
changes made:

- full refactor of the bootup behaviour regarding "bootup preset" and "turn on at boot" here is how it works now:
  - if turn on at boot is set, LEDs turn on unconditionally to the set default brightness
  - if no prest is applied, it still fades from black at the set default transition time instead of instantly turning on (same as it was in 0.14)
  - if a preset is applied it fades to that preset on all segments, starting off black
  - if any transition mode other than fade is set, LEDs start off at "default brightness" instead of fading from black if "turn on at boot" is set (not acutally sure why on "fade" transition it starts off black but it works)

- Segments created by a bootup presets no longer use the DEFAULT_COLOR but start out black: segments created within the first 5s after bootup default to black
- DEFAULT_COLOR used for new segments is now the same as the bootup color (AA which is 170 changed to A0 which is 160)

TLDR; 
no matter if "turn on at boot" is now set or not, boot up presets are applied correctly. If "turn on at boot" is set, LEDs always turn on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot behavior so LEDs reliably begin from black, including when no relay is configured.
  * Streamlined startup brightness and boot preset initialization for more consistent first-frame behavior.
* **UI/UX**
  * Updated the bootup brightness field label to “Bootup brightness”.
* **Behavior / Visual Defaults**
  * Adjusted the default warm orange shade and ensured newly created auto segments and certain default segments start with the expected primary color.
* **Style**
  * Changed the initial stored primary color state to start from black.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->