### PR TITLE
Fix LED glitches on long strips for C3

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -943,7 +943,7 @@ class WS2812FX {
     uint16_t getLengthPhysical() const;
     uint16_t getLengthTotal() const; // will include virtual/nonexistent pixels in matrix
 
-    inline uint16_t getFps() const          { return (FPS_MULTIPLIER * _cumulativeFps) >> FPS_CALC_SHIFT; } // Returns the refresh rate of the LED strip (_cumulativeFps is stored in fixed point)
+    inline uint16_t getFps() const          { return (millis() - _lastShow > 2000) ? 0 : (FPS_MULTIPLIER * _cumulativeFps) >> FPS_CALC_SHIFT; } // Returns the refresh rate of the LED strip (_cumulativeFps is stored in fixed point)
     inline uint16_t getFrameTime() const    { return _frametime; }        // returns amount of time a frame should take (in ms)
     inline uint16_t getMinShowDelay() const { return MIN_FRAME_DELAY; }   // returns minimum amount of time strip.service() can be delayed (constant)
     inline uint16_t getLength() const       { return _length; }           // returns actual amount of LEDs on a strip (2D matrix may have less LEDs than W*H)

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -943,7 +943,7 @@ class WS2812FX {
     uint16_t getLengthPhysical() const;
     uint16_t getLengthTotal() const; // will include virtual/nonexistent pixels in matrix
 
-    inline uint16_t getFps() const          { return (millis() - _lastShow > 2000) ? 0 : (FPS_MULTIPLIER * _cumulativeFps) >> FPS_CALC_SHIFT; } // Returns the refresh rate of the LED strip (_cumulativeFps is stored in fixed point)
+    inline uint16_t getFps() const          { return (FPS_MULTIPLIER * _cumulativeFps) >> FPS_CALC_SHIFT; } // Returns the refresh rate of the LED strip (_cumulativeFps is stored in fixed point)
     inline uint16_t getFrameTime() const    { return _frametime; }        // returns amount of time a frame should take (in ms)
     inline uint16_t getMinShowDelay() const { return MIN_FRAME_DELAY; }   // returns minimum amount of time strip.service() can be delayed (constant)
     inline uint16_t getLength() const       { return _length; }           // returns actual amount of LEDs on a strip (2D matrix may have less LEDs than W*H)

--- a/wled00/image_loader.cpp
+++ b/wled00/image_loader.cpp
@@ -30,7 +30,7 @@ int fileReadCallback(void) {
 int fileReadBlockCallback(void * buffer, int numberOfBytes) {
   #ifdef CONFIG_IDF_TARGET_ESP32C3
   unsigned t0 = millis();
-  while (strip.isUpdating() && (millis() - t0 < 15)) yield(); // be nice, but not too nice. Waits up to 15ms to avoid glitches
+  while (strip.isUpdating() && (millis() - t0 < 150)) yield(); // be nice, but not too nice. Waits up to 150ms to avoid glitches
   #endif
   return file.read((uint8_t*)buffer, numberOfBytes);
 }

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -178,7 +178,7 @@ void WLED::loop()
     // calling getContiguousFreeHeap() during led update causes glitches on C3
     // this can (probably) be removed once RMT driver for C3 is fixed
     unsigned t0 = millis();
-    while (strip.isUpdating() && (millis() - t0 < 15)) delay(1);    // be nice, but not too nice. Waits up to 15ms
+    while (strip.isUpdating() && (millis() - t0 < 150)) delay(1);    // be nice, but not too nice. Waits up to 150ms
     #endif
     uint32_t heap = getContiguousFreeHeap(); // ESP32 family needs ~10k of contiguous free heap for UI to work properly
     #endif


### PR DESCRIPTION
increase wait time to 150ms which is enough for almost all realistic scenarios.

previous discussion see #5683 

The reason I chose not to defer to a follow-up loop and instead just wait is this: deferring is futile if target FPS is higher than actual FPS, which is very likely the case in the scenarios where such glitches appear. It just overcomplicates code for little to no gain.

The proper way to do it would be this:
- add a `runBlockingFunctions()` function that is executed in `strip.show()` just before `BusManager::show()` which needs to wait for the bus anyway.
- said function would wait for the strip to finish, then run stuff that can suspend interrupts

it would however convolute code by running "background stuff" in `show()` - very bad design. The alternative would be to have `strip.show()` not call `BusManager::show()` but instead setting a flag "_frameReady" then return to main(), `runBlockingFunctions()` from there and afterwards run `BusManager::show()` if the frame is ready and clear the flag. Pretty much overcomplicating it just to fix an edge case IMHO. Unless there are other things that would benefit from such an approach @willmmiles & @softhack007 your thoughts on this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during GIF animation playback and LED strip updates, particularly when the system is under heavy load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->