### PR TITLE
Minimal C3 bitbanging fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -130,7 +130,7 @@ upload_speed = 115200
 lib_compat_mode = strict
 lib_deps =
     IRremoteESP8266 @ 2.8.2
-    https://github.com/Makuna/NeoPixelBus.git#a0919d1c10696614625978dd6fb750a1317a14ce
+    https://github.com/willmmiles/NeoPixelBus.git#71112f0627e1db397f1770881a4cffc6c067a420
     https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.2
     marvinroger/AsyncMqttClient @ 0.9.0
   # for I2C interface

--- a/wled00/bus_wrapper.h
+++ b/wled00/bus_wrapper.h
@@ -248,6 +248,15 @@
 #if !defined(WLED_USE_SHARED_RMT)  && !defined(__riscv)
 #include <NeoEsp32RmtHIMethod.h>
 #define NeoEsp32RmtMethod(x) NeoEsp32RmtHIN ## x ## Method
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+// We're going to cheat and use bitbanging
+// Wrapper type strips the 'channel' argument
+template<typename T> class NPBMethodStripChannelWrapper : public T {
+public:
+    NPBMethodStripChannelWrapper(uint8_t pin, uint16_t pixelCount, size_t elementSize, size_t settingsSize, NeoBusChannel channel) : T(pin, pixelCount, elementSize, settingsSize) {
+    };
+};
+#define NeoEsp32RmtMethod(x) NPBMethodStripChannelWrapper<NeoEsp32BitBang ## x ## Method>
 #else
 #define NeoEsp32RmtMethod(x) NeoEsp32RmtN ## x ## Method
 #endif


### PR DESCRIPTION
This is the simplest, lamest solution to C3 glitches: replace it with the bitbanging driver.  I am presenting this here as a draft for reference if we decide we need an immediate solution, no matter the performance cost.  This is not a good solution by any means - merely a working one on my test system.

Sadly it turned out that NPB's bitbanging driver also wasn't completely stable on RISCV systems, I am guessing due to cache issues returning from ISR handling.   Lowering the latch time estimates and prefetching the pixel outputs on to the stack seemed to help on my test system.  (Probably I should've added a "ISR return fudge factor" instead of permuting the timings directly; that could be done if there's interest in pursing this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added dedicated support for ESP32-C3 boards with improved addressable LED driver compatibility, ensuring proper control and reliability on this microcontroller variant.

* **Chores**
  * Updated NeoPixel library dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->