### PR TITLE
waveshare_esp32s3_32MB_hub75 - audio support

### DIFF
--- a/.github/platformio_release.ini.template
+++ b/.github/platformio_release.ini.template
@@ -43,3 +43,4 @@ default_envs = nodemcuv2
                adafruit_matrixportal_esp32s3
                esp32s3dev_16MB_opi_hub75 ;; MoonHub
                esp32s3dev_4MB_qspi_hub75 ;; HD-WF2
+               waveshare_esp32s3_32MB_hub75

--- a/platformio.ini
+++ b/platformio.ini
@@ -797,11 +797,18 @@ extends = env:esp32S3_wroom2_32MB
 monitor_filters = esp32_exception_decoder
 build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2_32MB\" ;; need to un-set the relese name before setting a new one
-build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags} ${hub75.i2s_disable_flags}
+custom_usermods = 
+	Internal_Temperature 
+	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#171c0bbc2bc47e2c11ae203dd00beed82865df2b ;; broadcast
+build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT
-;  -D WLED_USE_SD_SPI
-;  -D SD_PRINT_HOME_DIR
+  -D BTNPIN=0
+  -D I2CSDAPIN=47 -D I2CSCLPIN=48
+  -D SR_DMTYPE=9 -D I2S_SDPIN=39 -D I2S_CKPIN=43 -D I2S_WSPIN=38 -D MCLK_PIN=12 ; Waveshare ES8311 Codec pins
+  -D UM_SD_SELECT=14 -D UM_SD_CLOCK=1 -D UM_SD_POCI=17 -D UM_SD_PICO=44 ; Waveshare SD Card pins ** Requires updated sd_card from this PR https://github.com/wled/WLED/pull/5679 **
+  -D WLED_USE_SD_SPI
+  -D SD_PRINT_HOME_DIR
 ;  -D WLED_DEBUG
 lib_deps = ${esp32s3.lib_deps}
   ${hub75.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -799,7 +799,7 @@ build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_WROOM-2_32MB\" ;; need to un-set the relese name before setting a new one
 custom_usermods = 
 	Internal_Temperature 
-	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#171c0bbc2bc47e2c11ae203dd00beed82865df2b ;; broadcast
+	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#8d988e985901e00a0a92e119aaa8e3249f817754 ;; SR_DMTYPE 254 fix
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT


### PR DESCRIPTION
Fresh PR with just the waveshare changes, unlike https://github.com/wled/WLED/pull/5660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added official release support for the **Waveshare ESP32-S3 (32MB) HUB75** hardware, including **Audio Reactive** capabilities and **SD card** support.

* **Chores**
  * Updated the release automation/build matrix to include an additional Waveshare environment so tagged releases are published for this hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->