### PR TITLE
Fix ledmap parser reading past end of map array

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -2173,6 +2173,7 @@ bool WS2812FX::deserializeMap(unsigned n) {
         int index = atoi(number);
         if (index < 0 || index > 65535) index = 0xFFFF; // prevent integer wrap around
         customMappingTable[customMappingSize++] = index;
+        if (end != nullptr) break; // array closing ']' was in this chunk; stop before atoi() coerces trailing JSON keys into bogus entries
         if (customMappingSize >= getLengthTotal()) break;
       } else break; // there was nothing to read, stop
     }


### PR DESCRIPTION
## Summary

`WS2812FX::deserializeMap()` (`wled00/FX_fcn.cpp:2160-2178`) reads the `map` array one comma-delimited token at a time, breaking out only when `customMappingSize >= getLengthTotal()`. When `getLengthTotal()` exceeds the actual `map[]` entry count (e.g. a trailing PWM/OnOff bus placed after a 2D matrix), and the JSON has `"map"` before `"width"/"height"`, the loop continues past the array's closing `]` and reads the next JSON key. `atoi("\"width\":23")` returns 0, which gets stored at `customMappingTable[matrixSize]`. The trailing strip's segment writes are then silently rerouted to physical pixel 0.

The existing `if (!foundDigit) break` handles the case where `]` appears alone in a chunk. This adds the symmetric case for when `]` follows the last valid digit in the same chunk — store the entry, then exit.

## How it works

```cpp
customMappingTable[customMappingSize++] = index;
if (end != nullptr) break;  // ← new line
if (customMappingSize >= getLengthTotal()) break;
```

`end` is already computed earlier as `strchr(number, ']')`. If non-null, the chunk we just processed contained the array terminator, so there are no more entries to read regardless of what `getLengthTotal()` is.

## Reproduction (pre-fix)

- ESP32-C3, WLED 16.0.0 (parser code is identical on `main` and `16_x`)
- Digital strip on one pin: 55 LEDs at start=0
- PWM White (TYPE_ANALOG_1CH) on a separate pin at start=529 (post-matrix trailing strip)
- `ledmap.json` defining a 23×23 matrix with the WLED-MM key order: `{"map":[...],"width":23,"height":23}`
- A 1D segment at `[529, 530)`

Writes to segment 1 are routed to physical pixel 0 of the digital bus instead of the PWM bus. Pin 9 receives no PWM updates.

## Why JSON key order matters

Commit 336e074b ("fix for 0byte size files, also made reading ledmaps more efficient", Nov 2025) changed WLED's UI to generate `"width"`/`"height"` before `"map"`. That implicitly dodges this bug because when the parser reads past the array, it hits the closing `}` — `strchr` finds `]`-or-nothing patterns it already handles via the no-digit-found path. The original PR framed the change as a load-time optimization; it also turns out to be a quiet workaround. WLED-MM and pre-`336e074b` ledmaps still trigger the bug.

## Testing

- Compiled clean on `esp32c3dev` and `esp32dev` (`pio run -e esp32c3dev`, `pio run -e esp32dev`).
- `npm test` passes.
- Tested on actual hardware (ESP32-C3 / Seeed Xiao, SK6812 RGBW matrix + PWM White via MOSFET):
  - With current `main`, broken-order ledmap, trailing PWM bus → PWM dead, matrix pixel 0 driven by segment 1. ✗
  - With this patch, same ledmap, same buses → PWM driven by segment 1, matrix pixel 0 untouched. ✓
- No behavior change for ledmaps where `"width"`/`"height"` come first (the `strchr(']')`-with-no-digit path still handles them).

## Risk

One line added, scoped to the trailing-strip + map-first JSON ordering case. The new break only fires on chunks that already contained the array terminator, so well-formed JSON with width/height first is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LED map parsing to correctly stop at the end of the mapping array, preventing misinterpretation of trailing JSON data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->