### PR TITLE
fix white channel for "Rainbow" and other color_wheel() based effects

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1148,10 +1148,10 @@ void Segment::blur(uint8_t blur_amount, bool smear) const {
  */
 uint32_t Segment::color_wheel(uint8_t pos) const {
   if (palette) return color_from_palette(pos, false, true, 0); // color_wheel is a continuous (moving) wheel, so wrap end->start (restores pre-0.16 behaviour)
-  uint8_t w = W(getCurrentColor(0));
   CRGBW rgb;
   rgb = CHSV32(static_cast<uint16_t>(pos << 8), 255, 255);
-  return rgb.color32 | (w << 24); // add white channel
+  rgb.w = W(getCurrentColor(0)); // add white channel
+  return rgb.color32;
 }
 
 /*

--- a/wled00/src/dependencies/fastled_slim/fastled_slim.cpp
+++ b/wled00/src/dependencies/fastled_slim/fastled_slim.cpp
@@ -102,7 +102,7 @@ __attribute__((optimize("O2"))) void hsv2rgb_rainbow(uint16_t h, uint8_t s, uint
     rgbdata[0] = b;
     rgbdata[1] = g;
     rgbdata[2] = r;
-    rgbdata[3] = 0; // white
+    //rgbdata[3] = 0; // white
   } else {
     rgbdata[0] = r;
     rgbdata[1] = g;

--- a/wled00/src/dependencies/fastled_slim/fastled_slim.cpp
+++ b/wled00/src/dependencies/fastled_slim/fastled_slim.cpp
@@ -102,7 +102,7 @@ __attribute__((optimize("O2"))) void hsv2rgb_rainbow(uint16_t h, uint8_t s, uint
     rgbdata[0] = b;
     rgbdata[1] = g;
     rgbdata[2] = r;
-    //rgbdata[3] = 0; // white
+    rgbdata[3] = 0; // white
   } else {
     rgbdata[0] = r;
     rgbdata[1] = g;


### PR DESCRIPTION
This PR fixes an issue when using the "Rainbow" effect on RGBW LEDs:

- The `CRGBW` instance allocated on the stack in `Segment::color_wheel` is not initialized, so all its color values may (and will) contain garbage.
- The subsequent assignment from a `CHSV32` instance calls `hsv2rgb_rainbow`, which doesn't clear the white value either.
- So even if the white value of the primary color is zero, the "Rainbow" effect produces RGBW colors with a non-zero white value.
- The final OR'ing with the primary color's white value in `Segment::color_wheel` produces (at least to a human eye) unexpected results.

The issue has been introduced in WLED v16.0.0 by the FastLED replacement in #4615.

The important part of the fix is to properly clear the white value in `hsv2rgb_rainbow`, because HSV only maps to RGB (not W). The line is already there, and I don't know why it had been commented out in the first place.

The change in `Segment::color_wheel` is merely cosmetic. Setting the white value produces the same result as OR'ing it to a (now guaranteed) zero value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed white channel handling in color wheel calculations to properly derive from primary color values
  * Fixed white channel initialization in HSV to RGBW color space conversions to prevent uninitialized values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->