### PR TITLE
align with WLEDMM extended error codes, small improvement for brownout detection

### DIFF
--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -2071,6 +2071,13 @@ class AudioReactive : public Usermod {
       bool configComplete = !top.isNull();
       bool oldEnabled = enabled;
       bool oldAddPalettes = addPalettes;
+    #ifdef ARDUINO_ARCH_ESP32
+      auto oldDMType = dmType;
+      auto oldI2SsdPin = i2ssdPin;
+      auto oldI2swsPin = i2swsPin;
+      auto oldI2SckPin = i2sckPin;
+      auto oldI2SmclkPin = mclkPin;
+    #endif
 
       configComplete &= getJsonValue(top[FPSTR(_enabled)], enabled);
       configComplete &= getJsonValue(top[FPSTR(_addPalettes)], addPalettes);
@@ -2112,6 +2119,15 @@ class AudioReactive : public Usermod {
         // add/remove custom/audioreactive palettes
         if ((oldAddPalettes && !addPalettes) || (oldAddPalettes && !enabled)) removeAudioPalettes();
         if ((addPalettes && !oldAddPalettes && enabled) || (addPalettes && !oldEnabled && enabled)) createAudioPalettes();
+	    #ifdef ARDUINO_ARCH_ESP32
+        // notify user when a reboot is necessary
+          if ((audioSource != nullptr) && (oldDMType != dmType)) errorFlag = ERR_REBOOT_NEEDED;  // changing mic type requires reboot
+          if (   (audioSource != nullptr) && (enabled==true)
+              && ((oldI2SsdPin != i2ssdPin) || (oldI2swsPin != i2swsPin) || (oldI2SckPin != i2sckPin)) ) errorFlag = ERR_REBOOT_NEEDED;  // changing mic pins requires reboot
+          if ((audioSource != nullptr) && (oldI2SmclkPin != mclkPin)) errorFlag = ERR_REBOOT_NEEDED;  // changing MCLK pin requires reboot
+          if ((oldDMType != dmType) && (oldDMType == 0)) errorFlag = ERR_POWEROFF_NEEDED;  // changing from analog mic requires power cycle
+          if ((oldDMType != dmType) && (dmType == 0)) errorFlag = ERR_POWEROFF_NEEDED;  // changing to analog mic requires power cycle
+        #endif
       } // else setup() will create palettes
       return configComplete;
     }

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1134,9 +1134,8 @@ void BusHub75Matrix::cleanup() {
   if (display != nullptr) delete display;
   display = nullptr;
   virtualDisp = nullptr; // note: when not using "NO_GFX" this causes a memory leak
-  #if defined(CONFIG_IDF_TARGET_ESP32S3)  // runtime reconfiguration is not working on -S3
+  #else  // runtime reconfiguration is not working on -S3, request reboot from user instead
     errorFlag = ERR_REBOOT_NEEDED;
-  #endif
   #endif
   if (_ledBuffer != nullptr) d_free(_ledBuffer); _ledBuffer = nullptr;
   if (_ledsDirty != nullptr) d_free(_ledsDirty); _ledsDirty = nullptr;

--- a/wled00/bus_manager.cpp
+++ b/wled00/bus_manager.cpp
@@ -1134,6 +1134,9 @@ void BusHub75Matrix::cleanup() {
   if (display != nullptr) delete display;
   display = nullptr;
   virtualDisp = nullptr; // note: when not using "NO_GFX" this causes a memory leak
+  #if defined(CONFIG_IDF_TARGET_ESP32S3)  // runtime reconfiguration is not working on -S3
+    errorFlag = ERR_REBOOT_NEEDED;
+  #endif
   #endif
   if (_ledBuffer != nullptr) d_free(_ledBuffer); _ledBuffer = nullptr;
   if (_ledsDirty != nullptr) d_free(_ledsDirty); _ledsDirty = nullptr;

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -481,6 +481,8 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define ERR_SYS_BROWNOUT  91  // reboot after brownout alert
 #define ERR_PERSISTENT_THRESHOLD 100 // (WLEDMM compatibility) errors below this value are non-persistent; persistent errors stay in the UI until restart
 // ERR_PERSISTENT_THRESHOLD is a threshold value only - never assign directly to errorFlag
+// Reserved threshold for WLEDMM-compatible persistent error handling.
+// Current runtime behavior still clears errorFlag after serialization.
 #define ERR_REBOOT_NEEDED 100 // reboot needed after changing hardware setting
 #define ERR_POWEROFF_NEEDED 101 // power-cycle needed after changing hardware setting
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -472,8 +472,17 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define ERR_OVERTEMP    30  // An attached temperature sensor has measured above threshold temperature (not implemented)
 #define ERR_OVERCURRENT 31  // An attached current sensor has measured a current above the threshold (not implemented)
 #define ERR_UNDERVOLT   32  // An attached voltmeter has measured a voltage below the threshold (not implemented)
-#define ERR_REBOOT_NEEDED 98 // reboot needed after changing hardware setting
-#define ERR_POWEROFF_NEEDED 99 // power-cycle needed after changing hardware setting
+//#define ERR_LOW_MEM     33  // WLEDMM: low memory (RAM)
+//#define ERR_LOW_SEG_MEM 34  // WLEDMM: low memory (segment data RAM)
+//#define ERR_LOW_WS_MEM  35  // WLEDMM: low memory (ws)
+//#define ERR_LOW_AJAX_MEM  36 // WLEDMM: low memory (oappend)
+//#define ERR_LOW_BUF     37  // WLEDMM: low memory (LED buffer from allocLEDs)
+#define ERR_SYS_REBOOT    90  // reboot after error, trying to roll back
+#define ERR_SYS_BROWNOUT  91  // reboot after brownout alert
+#define ERR_PERSISTENT_THRESHOLD 100 // (WLEDMM compatibility) errors below this value are non-persistent; persistent errors stay in the UI until restart
+// ERR_PERSISTENT_THRESHOLD is a threshold value only - never assign directly to errorFlag
+#define ERR_REBOOT_NEEDED 100 // reboot needed after changing hardware setting
+#define ERR_POWEROFF_NEEDED 101 // power-cycle needed after changing hardware setting
 
 // JSON buffer lock owners
 #define JSON_LOCK_UNKNOWN        255

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -472,18 +472,16 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
 #define ERR_OVERTEMP    30  // An attached temperature sensor has measured above threshold temperature (not implemented)
 #define ERR_OVERCURRENT 31  // An attached current sensor has measured a current above the threshold (not implemented)
 #define ERR_UNDERVOLT   32  // An attached voltmeter has measured a voltage below the threshold (not implemented)
-//#define ERR_LOW_MEM     33  // WLEDMM: low memory (RAM)
-//#define ERR_LOW_SEG_MEM 34  // WLEDMM: low memory (segment data RAM)
-//#define ERR_LOW_WS_MEM  35  // WLEDMM: low memory (ws)
-//#define ERR_LOW_AJAX_MEM  36 // WLEDMM: low memory (oappend)
-//#define ERR_LOW_BUF     37  // WLEDMM: low memory (LED buffer from allocLEDs)
-#define ERR_SYS_REBOOT    90  // reboot after error, trying to roll back
-#define ERR_SYS_BROWNOUT  91  // reboot after brownout alert
-#define ERR_PERSISTENT_THRESHOLD 100 // (WLEDMM compatibility) errors below this value are non-persistent; persistent errors stay in the UI until restart
+#define ERR_LOW_MEM     33  // low memory (RAM)
+#define ERR_LOW_SEG_MEM 34  // low memory (effect data RAM)
+#define ERR_LOW_WS_MEM  35  // low memory (ws)
+//#define ERR_LOW_AJAX_MEM 36 // (not used any more) low memory (oappend)
+#define ERR_LOW_BUF     37  // low memory (LED pixels buffer)
+#define ERR_SYS_REBOOT      90  // reboot after error, trying to roll back
+#define ERR_SYS_BROWNOUT    91  // reboot after brownout alert
+#define ERR_PERSISTENT_THRESHOLD 100 // ToDO: errors below this value are non-persistent; persistent errors stay in the UI until restart
 // ERR_PERSISTENT_THRESHOLD is a threshold value only - never assign directly to errorFlag
-// Reserved threshold for WLEDMM-compatible persistent error handling.
-// Current runtime behavior still clears errorFlag after serialization.
-#define ERR_REBOOT_NEEDED 100 // reboot needed after changing hardware setting
+#define ERR_REBOOT_NEEDED   100 // reboot needed after changing hardware setting
 #define ERR_POWEROFF_NEEDED 101 // power-cycle needed after changing hardware setting
 
 // JSON buffer lock owners

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1596,7 +1596,7 @@ function readState(s,command=false)
 				errstr = "Please switch your device off and back on.";
 		  break;
 		}
-		showToast('Error ' + s.error + ": " + errstr, true);
+		showToast((s.error<100) ? 'Error ': 'Note ' + s.error + ": " + errstr, true);  // show "please restart" as a note, all others as errors
 	}
 
 	selectedPal = i.pal;

--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -1567,6 +1567,34 @@ function readState(s,command=false)
 			case 19:
 				errstr = "A filesystem error has occured.";
 				break;
+// error code from WLEDMM - not supported yet
+//			case 33:
+//				errstr = "Low Memory (generic RAM).";
+//		  break;
+//			case 34:
+//				errstr = "Low Memory (effect data).";
+//		  break;
+//			case 35:
+//				errstr = "Low Memory (WS data).";
+//		  break;
+//			case 36:
+//				errstr = "Low Memory (oappend buffer).";
+//		  break;
+//			case 37:
+//				errstr = "no memory for LEDs buffer.";
+//		  break;
+			case 90:
+				errstr = "Unexpected Restart.";
+		  break;
+			case 91:
+				errstr = "Brownout Restart.";
+		  break;
+			case 100:
+				errstr = "Please reboot WLED to activate changed settings.";
+		  break;
+			case 101:
+				errstr = "Please switch your device off and back on.";
+		  break;
 		}
 		showToast('Error ' + s.error + ": " + errstr, true);
 	}

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -998,6 +998,11 @@ RTC_NOINIT_ATTR static uint32_t bl_crashcounter;
 RTC_NOINIT_ATTR static uint32_t bl_actiontracker;
 
 static inline ResetReason rebootReason() {
+  // check RTC restart reason first - brownout is not reliably reported by esp_reset_reason()
+  if (rtc_get_reset_reason(0) == RTCWDT_BROWN_OUT_RESET) return ResetReason::Brownout; // core0 brownout
+  #if SOC_CPU_CORES_NUM > 1
+  if (rtc_get_reset_reason(1) == RTCWDT_BROWN_OUT_RESET) return ResetReason::Brownout; // core1 brownout
+  #endif
   esp_reset_reason_t reason = esp_reset_reason();
   if (reason == ESP_RST_BROWNOUT) return ResetReason::Brownout;
   if (reason == ESP_RST_SW) return ResetReason::Software;
@@ -1032,6 +1037,7 @@ static bool detectBootLoop() {
     case ResetReason::Crash:
     {
       DEBUG_PRINTLN(F("crash detected!"));
+      errorFlag = ERR_SYS_REBOOT;
       uint32_t rebootinterval = rtctime - bl_last_boottime;
       if (rebootinterval < BOOTLOOP_INTERVAL_MILLIS) {
         bl_crashcounter++;
@@ -1052,6 +1058,7 @@ static bool detectBootLoop() {
     case ResetReason::Brownout:
       // crash due to brownout can't be detected unless using flash memory to store bootloop variables
       DEBUG_PRINTLN(F("brownout detected"));
+      errorFlag = ERR_SYS_BROWNOUT;
       //restoreConfig(); // TODO: blindly restoring config if brownout detected is a bad idea, need a better way (if at all)
       break;
   }

--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -8,6 +8,7 @@
 #else
 #include <Update.h>
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+  #include "rom/rtc.h"      // for rtc_get_reset_reason()
   #include "esp32/rtc.h"    // for bootloop detection
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(3, 3, 0)
   #include "soc/rtc.h"


### PR DESCRIPTION
Backport and alignment of error codes between upstream WLED and WLED-MM
Fixes some inconsistencies introduced with 56b3345f6f6ffad93fc55cb8a7e566b54cba1773, and improves brownout detection by first checking RTC restart reason.

* Align ERR_REBOOT_NEEDED and ERR_POWEROFF_NEEDED with WLEDMM (prepare for AR out-of-tree)
* use new error codes in AR and in HUB75 driver
* add new error codes to WebUI
* improved brownout detection on ESP32

open ends:
* "persistent errors stay in the UI until restart" is not implemented in this PR - will come as a follow-on for 17.0.0-dev only
* brownouts that cause a reboot loop will still not show in the WebUI, same about crash restart loops.

This change is low-risk and fixes a few inconsistencies introduced in a previous commit. I'd say its good for 16.0.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Audio-reactive microphone and I2S configuration changes now retain existing settings and reliably require a reboot or power-cycle when relevant hardware settings are altered.
  * Improved system reboot/bootloop reporting distinguishes brownout resets from reboots.
  * On ESP32-S3, display cleanup now correctly initiates a reboot when needed.

* **New Features**
  * Added new system error/brownout and reboot-related toast messages, and refreshed error-code handling and “low memory” messaging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->