### PR TITLE
use NPB version with fixed buffers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -130,7 +130,7 @@ upload_speed = 115200
 lib_compat_mode = strict
 lib_deps =
     IRremoteESP8266 @ 2.8.2
-    https://github.com/Makuna/NeoPixelBus.git#a0919d1c10696614625978dd6fb750a1317a14ce
+    https://github.com/Makuna/NeoPixelBus.git#1d7ff38f14d04a976f9c6e365c83a232bcba04fc
     https://github.com/Aircoookie/ESPAsyncWebServer.git#v2.4.2
     marvinroger/AsyncMqttClient @ 0.9.0
   # for I2C interface


### PR DESCRIPTION
Bumps up NPB by one commit which fixes unitialized buffers causing garbage output when using gap files that do not send data to all LEDs. 

thx @blazoncek for fixing it and pointing this out.

fixes #5378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NeoPixelBus library dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->