### PR TITLE
fix-solid-color-sync

### DIFF
--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -355,7 +355,7 @@ static void parseNotifyPacket(const uint8_t *udpIn) {
   }
 
   // simple effect sync, applies to all selected segments
-  if ((applyEffects || receiveNotificationPalette) && (version < 11 || !receiveSegmentOptions)) {
+  if ((applyEffects || receiveNotificationPalette || receiveNotificationColor || !someSel) && (version < 11 || !receiveSegmentOptions)) {
     for (size_t i = 0; i < strip.getSegmentsNum(); i++) {
       Segment& seg = strip.getSegment(i);
       if (!seg.isActive() || !seg.isSelected()) continue;
@@ -365,9 +365,16 @@ static void parseNotifyPacket(const uint8_t *udpIn) {
         if (version > 2) seg.intensity = udpIn[16];
       }
       if (version > 4 && receiveNotificationPalette) seg.setPalette(udpIn[19]);
+      if (receiveNotificationColor || !someSel) {
+        // apply colors to all selected segments, not just the main segment (e.g. so Solid effect syncs everywhere)
+        seg.setColor(0, RGBW32(udpIn[3], udpIn[4], udpIn[5], (version > 0) ? udpIn[10] : 0));
+        if (version > 1) seg.setColor(1, RGBW32(udpIn[12], udpIn[13], udpIn[14], udpIn[15]));
+        if (version > 6) seg.setColor(2, RGBW32(udpIn[20], udpIn[21], udpIn[22], udpIn[23]));
+      }
     }
     stateChanged = true;
   }
+
 
   if (applyEffects && version > 5) {
     uint32_t t = (udpIn[25] << 24) | (udpIn[26] << 16) | (udpIn[27] << 8) | (udpIn[28]);


### PR DESCRIPTION
What
In the UDP notifier receive path (parseNotifyPacket, wled00/udp.cpp), incoming colors were applied only to the main segment, while effect/speed/intensity/palette were applied to all selected segments. So color changes never reached non-main selected segments on receiving instances. Most visible with the Solid effect, where colors[0] is the entire output.

Why / how
Adds color application to the existing per-selected-segment sync loop, mirroring how palette is already handled and reusing the same version-gating as the main-segment color block.

Notes
The original main-segment color block is kept (covers an unselected main segment + CCT). Segment::setColor() early-returns when the value is unchanged, so no double transition.
Only runs when "Segment options" sync is off; the receiveSegmentOptions path already handles per-segment color.
No platformio.ini changes. Built and tested on hardware (ESP32-Ethernet) — Solid color now syncs across all selected segments on all instances.

Fixes #5705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync behavior so incoming color updates are applied more reliably.
  * Ensured selected active segments receive the updated RGBW and related color values, including version-dependent white/CCT handling.
  * Expanded the simple effect sync path so it also responds to color changes when no selection filtering is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->