### PR TITLE
Setting for transition center

### DIFF
--- a/usermods/transition_center/library.json
+++ b/usermods/transition_center/library.json
@@ -1,0 +1,5 @@
+{
+  "name": "transition_center",
+  "build": { "libArchive": false },
+  "dependencies": {}
+}

--- a/usermods/transition_center/transition_center.cpp
+++ b/usermods/transition_center/transition_center.cpp
@@ -1,0 +1,40 @@
+#include "wled.h"
+
+/*
+ * Exposes `blendingCenterPct` (center of the Inside-out/Outside-in transition
+ * styles, 0-100% of segment width) as a usermod setting.
+ */
+class TransitionCenterUsermod : public Usermod {
+  private:
+    static const char _name[];
+
+  public:
+    void setup() override {}
+    void loop() override {}
+
+    void addToConfig(JsonObject& root) override {
+      JsonObject top = root.createNestedObject(FPSTR(_name));
+      top[F("center_pct")] = blendingCenterPct;
+    }
+
+    bool readFromConfig(JsonObject& root) override {
+      JsonObject top = root[FPSTR(_name)];
+      if (top.isNull()) return false;
+      int v = blendingCenterPct;
+      bool ok = getJsonValue(top[F("center_pct")], v, 50);
+      blendingCenterPct = constrain(v, 0, 100);
+      return ok;
+    }
+
+    void appendConfigData() override {
+      oappend(F("addInfo('")); oappend(String(FPSTR(_name)).c_str()); oappend(F(":center_pct"));
+      oappend(F("',1,'% of strip length; 50 = middle, 0 = start, 100 = end');"));
+    }
+
+    uint16_t getId() override { return USERMOD_ID_UNSPECIFIED; }
+};
+
+const char TransitionCenterUsermod::_name[] PROGMEM = "TransitionCenter";
+
+static TransitionCenterUsermod transition_center_um;
+REGISTER_USERMOD(transition_center_um);

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1517,6 +1517,11 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
   const unsigned progInv  = 0xFFFFU - progress;
   const unsigned dw = (blendingStyle==TRANSITION_OUTSIDE_IN ? progInv : progress) * width / 0xFFFFU + 1;
   const unsigned dh = (blendingStyle==TRANSITION_OUTSIDE_IN ? progInv : progress) * height / 0xFFFFU + 1;
+  // Inside-out/Outside-in fronts are scaled so both reach their ends at the same time
+  const int      cx  = width * constrain((int)blendingCenterPct, 0, 100) / 100;
+  const int      prC = (blendingStyle==TRANSITION_OUTSIDE_IN) ? (int)progInv : (int)progress;
+  const int      dwl = prC * cx / 0xFFFF + 1;
+  const int      dwr = prC * (width - cx) / 0xFFFF + 1;
   const unsigned orgBS = blendingStyle;
   if (width*height == 1) blendingStyle = TRANSITION_FADE; // disable style for single pixel segments (use fade instead)
   switch (blendingStyle) {
@@ -1534,10 +1539,10 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
       Segment::setClippingRect(width - dw, width, 0, height);
       break;
     case TRANSITION_OUTSIDE_IN:   // corners
-      Segment::setClippingRect((width + dw)/2, (width - dw)/2, (height + dh)/2, (height - dh)/2); // inverted!!
+      Segment::setClippingRect(min(width, cx + dwr), max(0, cx - dwl), (height + dh)/2, (height - dh)/2); // inverted!!
       break;
     case TRANSITION_INSIDE_OUT:  // outward
-      Segment::setClippingRect((width - dw)/2, (width + dw)/2, (height - dh)/2, (height + dh)/2);
+      Segment::setClippingRect(max(0, cx - dwl), min(width, cx + dwr), (height - dh)/2, (height + dh)/2);
       break;
     case TRANSITION_SWIPE_DOWN:  // top-to-bottom (2D)
     case TRANSITION_PUSH_DOWN:   // top-to-bottom (2D)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -605,6 +605,7 @@ WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wra
 
 // transitions
 WLED_GLOBAL uint8_t       blendingStyle            _INIT(0);      // effect blending/transitionig style
+WLED_GLOBAL uint8_t       blendingCenterPct        _INIT(50);     // center of Inside-out/Outside-in styles in % of segment width
 WLED_GLOBAL bool          transitionActive         _INIT(false);
 WLED_GLOBAL uint16_t      transitionDelay          _INIT(750);    // global transition duration
 WLED_GLOBAL uint16_t      transitionDelayDefault   _INIT(750);    // default transition time (stored in cfg.json)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable center point for inside-out and outside-in transitions.
  * Introduced a new usermod setting to save and restore this transition center value.

* **Bug Fixes**
  * Improved transition clipping so blending now stays centered around the chosen percentage.
  * Kept transition bounds safely within the display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->