### PR TITLE
Fix whole-segment blackout frame at the start of on/off transitions with non-fade blending styles

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1642,7 +1642,9 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
         // workaround for On/Off transition
         // (bri != briT) && !bri => from On to Off
         // (bri != briT) &&  bri => from Off to On
-        if ((briOld == 0 || bri == 0) && ((!clipped && (bri != briT) && !bri) || (clipped && (bri != briT) && bri))) c_a = BLACK;
+        // note: only blank pixels once the segment transition has actually started; bri changes before
+        // startTransition() is called (stateUpdated()) and a frame rendered in that window would blank the whole segment
+        if (topSegment.isInTransition() && (briOld == 0 || bri == 0) && ((!clipped && (bri != briT) && !bri) || (clipped && (bri != briT) && bri))) c_a = BLACK;
       }
       // map it into frame buffer
       x = c;  // restore coordiates if we were PUSHing
@@ -1714,7 +1716,9 @@ void WS2812FX::blendSegment(const Segment &topSegment) const {
         // workaround for On/Off transition
         // (bri != briT) && !bri => from On to Off
         // (bri != briT) &&  bri => from Off to On
-        if ((briOld == 0 || bri == 0) && ((!clipped && (bri != briT) && !bri) || (clipped && (bri != briT) && bri))) c_a = BLACK;
+        // note: only blank pixels once the segment transition has actually started; bri changes before
+        // startTransition() is called (stateUpdated()) and a frame rendered in that window would blank the whole segment
+        if (topSegment.isInTransition() && (briOld == 0 || bri == 0) && ((!clipped && (bri != briT) && !bri) || (clipped && (bri != briT) && bri))) c_a = BLACK;
       }
       // map into frame buffer
       i = k; // restore index if we were PUSHing


### PR DESCRIPTION
## Symptom

With a transition time set and any blending style other than *Fade*, toggling power **off** causes a visible flick: the whole segment goes black for a single frame, jumps back to full brightness, and only then the transition animation plays. Toggling **on** has the same defect, but it is invisible in practice (the LEDs are still dark at that moment).

Reproducible on v16.0.1 and current `main` (ESP32, 313× WS2814, styles tested: Inside-out, Outside-in; transition 1.5–5 s). Not reproducible with *Fade*.

## Root cause

A race between the request context and the render loop.

`stateUpdated()` (led.cpp) sets `bri = 0` first and only calls `strip.setTransitionMode(true)` further down - after `notify()` / `sendSysInfoUDP()`, which can take several milliseconds of WiFi I/O. On ESP32 the render loop runs on a different task, so a frame can be serviced inside that window.

In that window the on/off workaround in `blendSegment()`:
```cpp
if ((briOld == 0 || bri == 0) && ((!clipped && (bri != briT) && !bri) || (clipped && (bri != briT) && bri))) c_a = BLACK;
```
already sees `bri != briT` (power change pending), but no segment transition exists yet, so `isPixelClipped()` returns `false` for every pixel. As a result the `!clipped && !bri` arm blanks every pixel of the segment for that frame. One frame later the transition has started and the animation begins from full brightness - hence the flick.

## Fix

Gate the blackout workaround on the segment transition actually having started (`topSegment.isInTransition()`), in both the 1D and 2D paths. Outside the race window the condition is unchanged: in steady state `bri == briT` (and `isPixelClipped()` needs an active transition anyway), and at the end of the transition `applyFinalBri()` makes `bri == briT`, so behavior there is identical.

## Testing

- ESP32 (esp32dev), 313× WS2814, single segment, transition 1.5–5 s.
- Before: dark flash right after turning off (Inside-out / Outside-in / Swipe).
- After: transition starts cleanly from the current frame; on/off, interrupted transitions and Fade behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LED transition handling so pixels are no longer briefly blanked before a segment transition actually starts.
  * Applied the fix consistently across both matrix and standard blending paths, resulting in smoother on/off brightness changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->