### PR TITLE
fix: prevent setInterval memory leak in setEffectParameters()

### DIFF
--- a/wled00/data/index.js
+++ b/wled00/data/index.js
@@ -27,6 +27,7 @@ var lastinfo = {};
 var isM = false, mw = 0, mh=0;
 var bsOpts = null; // blending style options snapshot, used for dynamic filtering based on matrix mode (iOS compatibility)
 var ws, wsRpt=0;
+var _selFxInterval = null; // interval ID for selected effect position update
 var cfg = {
 	theme:{base:"dark", bg:{url:"", rnd: false, rndGrayscale: false, rndBlur: false}, alpha:{bg:0.6,tab:0.8}, color:{bg:""}},
 	comp :{colors:{picker: true, rgb: false, quick: true, hex: false},
@@ -1673,7 +1674,8 @@ function setEffectParameters(idx)
 	}
 
 	setSelectedEffectPosition();
-	setInterval(setSelectedEffectPosition,750);
+	if (_selFxInterval) clearInterval(_selFxInterval);
+	_selFxInterval = setInterval(setSelectedEffectPosition,750);
 	// set html color items on/off
 	var cslLabel = '';
 	var sep = '';


### PR DESCRIPTION
The setInterval() call was inside setEffectParameters() which runs frequently. Each call created a new interval without clearing the previous one, causing a memory leak.

Now the interval ID is stored in _selFxInterval and cleared before creating a new interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effect selection updates by preventing overlapping timers.
  * Ensured the selected effect position refreshes reliably at regular intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->