### PR TITLE
fix: prevent uint8 underflow in AP client disconnect handler

### DIFF
--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -421,7 +421,8 @@ void WiFiEvent(WiFiEvent_t event)
   switch (event) {
     case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED:
       // AP client disconnected
-      if (apClients > 0 && --apClients == 0 && isWiFiConfigured()) forceReconnect = true; // no clients reconnect WiFi if available
+      if (apClients > 0) apClients--;
+      if (apClients == 0 && isWiFiConfigured()) forceReconnect = true; // no clients reconnect WiFi if available
       DEBUG_PRINTF_P(PSTR("WiFi-E: AP Client Disconnected (%d) @ %lus.\n"), (int)apClients, millis()/1000);
       break;
     case ARDUINO_EVENT_WIFI_AP_STACONNECTED:

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -421,7 +421,7 @@ void WiFiEvent(WiFiEvent_t event)
   switch (event) {
     case ARDUINO_EVENT_WIFI_AP_STADISCONNECTED:
       // AP client disconnected
-      if (--apClients == 0 && isWiFiConfigured()) forceReconnect = true; // no clients reconnect WiFi if awailable
+      if (apClients > 0 && --apClients == 0 && isWiFiConfigured()) forceReconnect = true; // no clients reconnect WiFi if available
       DEBUG_PRINTF_P(PSTR("WiFi-E: AP Client Disconnected (%d) @ %lus.\n"), (int)apClients, millis()/1000);
       break;
     case ARDUINO_EVENT_WIFI_AP_STACONNECTED:


### PR DESCRIPTION
## Summary
- Add bounds check before decrementing `apClients` to prevent uint8 wraparound from 0 to 255
- Also fix typo: awailable → available
## Problem
The WiFi event handler can fire `AP_STADISCONNECTED` without a prior connect event (e.g., during driver init or race conditions). This causes `apClients` to underflow from 0 to 255.
**Before:**
```cpp
if (--apClients == 0 && isWiFiConfigured()) forceReconnect = true;
```
After:
```cpp
if (apClients > 0 && --apClients == 0 && isWiFiConfigured()) forceReconnect = true;
```

Impact
Minimal — one-line fix with no side effects. Prevents potential undefined behavior in edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Fixed an issue where the access point client count could drop below zero after a client disconnected.
  - Wi‑Fi reconnect behavior when the last access point client disconnects remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->