### PR TITLE
make relay post-switching delay a config parameter

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -379,7 +379,7 @@ void handleOnOff(bool forceOff)
       if (rlyPin>=0) {
         // note: pinMode is set in first call to handleOnOff(true) in beginStrip()
         digitalWrite(rlyPin, rlyMde); // set to on state
-        delay(RELAY_DELAY); // let power stabilize before sending LED data (#346 #812 #3581 #3955)
+        delay(relayDelay); // let power stabilize before sending LED data (#346 #812 #3581 #3955)
       }
       offMode = false;
     }

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -461,6 +461,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   JsonObject relay = hw[F("relay")];
 
   rlyOpenDrain  = relay[F("odrain")] | rlyOpenDrain;
+  CJSON(relayDelay, relay[F("del")]);
   int hw_relay_pin = relay["pin"] | -2;
   if (hw_relay_pin > -2) {
     PinManager::deallocatePin(rlyPin, PinOwner::Relay);
@@ -1049,6 +1050,7 @@ void serializeConfig(JsonObject root) {
   hw_relay["pin"] = rlyPin;
   hw_relay["rev"] = !rlyMde;
   hw_relay[F("odrain")] = rlyOpenDrain;
+  hw_relay[F("del")] = relayDelay;
 
   hw[F("baud")] = serialBaud;
 

--- a/wled00/const.h
+++ b/wled00/const.h
@@ -129,7 +129,9 @@ static_assert(WLED_MAX_BUSSES <= 32, "WLED_MAX_BUSSES exceeds hard limit");
   #endif
 #endif
 
-#define RELAY_DELAY 50 // delay in ms between switching on relay and sending data to LEDs
+#ifndef RELAY_DELAY
+#define RELAY_DELAY 50 // default delay in ms between switching on relay and sending data to LEDs
+#endif
 
 #if defined(ESP8266) || defined(CONFIG_IDF_TARGET_ESP32S2)
 #define WLED_MAX_COLOR_ORDER_MAPPINGS 5

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -811,6 +811,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 						d.getElementsByName("RL")[0].value   = rl.pin;
 						d.getElementsByName("RM")[0].checked = rl.rev;
 						d.getElementsByName("RO")[0].checked = rl.odrain;
+						d.getElementsByName("RLD")[0].value  = rl.delay;
 					}
 					let li = c.light;
 					if (li) {
@@ -1115,7 +1116,8 @@ Swap: <select id="xw${s}" name="XW${s}">
 	<div class="sec">
 		<h3>Relay</h3>
 		Relay GPIO: <input type="number" min="-1" max="48" name="RL" onchange="UI()" class="xs"><span style="cursor: pointer;" onclick="off('RL')">&nbsp;&#x2715;</span><br>
-		Invert <input type="checkbox" name="RM"> Open drain <input type="checkbox" name="RO"><br><br>
+		Invert <input type="checkbox" name="RM"> Open drain <input type="checkbox" name="RO"><br>
+		Delay: <input type="number" min="0" max="65535" name="RLD" class="xl"> ms<br><br>
 	</div>
 	<h2>General settings</h2>
 	<div class="sec">

--- a/wled00/data/settings_leds.htm
+++ b/wled00/data/settings_leds.htm
@@ -811,7 +811,7 @@ Swap: <select id="xw${s}" name="XW${s}">
 						d.getElementsByName("RL")[0].value   = rl.pin;
 						d.getElementsByName("RM")[0].checked = rl.rev;
 						d.getElementsByName("RO")[0].checked = rl.odrain;
-						d.getElementsByName("RLD")[0].value  = rl.delay;
+						d.getElementsByName("RLD")[0].value  = rl.del;
 					}
 					let li = c.light;
 					if (li) {

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -308,6 +308,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     }
     rlyMde = (bool)request->hasArg(F("RM"));
     rlyOpenDrain = (bool)request->hasArg(F("RO"));
+    relayDelay = request->arg(F("RLD")).toInt();
 
     disablePullUp = (bool)request->hasArg(F("IP"));
     touchThreshold = request->arg(F("TT")).toInt();

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -308,6 +308,7 @@ WLED_GLOBAL bool rlyOpenDrain _INIT(false);
 #else
 WLED_GLOBAL bool rlyOpenDrain _INIT(RLYODRAIN);
 #endif
+WLED_GLOBAL uint16_t relayDelay _INIT(RELAY_DELAY); // delay in ms between switching on relay and sending data to LEDs
 #ifndef IRPIN
   #define IRPIN -1
 #endif

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -450,6 +450,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormValue(settingsScript,PSTR("RL"),rlyPin);
     printSetFormCheckbox(settingsScript,PSTR("RM"),rlyMde);
     printSetFormCheckbox(settingsScript,PSTR("RO"),rlyOpenDrain);
+    printSetFormValue(settingsScript,PSTR("RLD"),relayDelay);
     int i = 0;
     for (const auto &button : buttons) {
       settingsScript.printf_P(PSTR("addBtn(%d,%d,%d);"), i++, button.pin, button.type);


### PR DESCRIPTION
Can be set in relay configuration, stored in cfg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable relay activation delay in the LED settings.
  * The relay delay (in milliseconds) can be adjusted via the Relay controls and is persisted in configuration.
  * Settings import/export now include the relay delay value.

* **Bug Fixes**
  * Relay activation timing now uses the configured relay delay consistently instead of a fixed default value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->