### PR TITLE
remove unmaintained WLED_SAVE_RAM

### DIFF
--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -504,9 +504,7 @@ class Segment {
       Segment      *_oldSegment;          // previous segment environment (may be nullptr if effect did not change)
       unsigned long _start;               // must accommodate millis()
       uint32_t      _colors[NUM_COLORS];  // current colors
-      #ifndef WLED_SAVE_RAM
       CRGBPalette16 _palT;                // temporary palette (slowly being morphed from old to new)
-      #endif
       uint16_t      _dur;                 // duration of transition in ms
       uint16_t      _progress;            // transition progress (0-65535); pre-calculated from _start & _dur in updateTransitionProgress()
       uint8_t       _prevPaletteBlends;   // number of previous palette blends (there are max 255 blends possible)
@@ -515,9 +513,7 @@ class Segment {
       : _oldSegment(nullptr)
       , _start(millis())
       , _colors{0,0,0}
-      #ifndef WLED_SAVE_RAM
       , _palT(CRGBPalette16())
-      #endif
       , _dur(dur)
       , _progress(0)
       , _prevPaletteBlends(0)

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -345,9 +345,7 @@ void Segment::startTransition(uint16_t dur, bool segmentCopy) {
     _t->_bri = on ? opacity : 0;
     _t->_cct = cct;
     _t->_palette = palette;
-    #ifndef WLED_SAVE_RAM
     loadPalette(_t->_palT, palette);
-    #endif
     for (int i=0; i<NUM_COLORS; i++) _t->_colors[i] = colors[i];
     if (segmentCopy) _t->_oldSegment = new(std::nothrow) Segment(*this); // store/copy current segment settings
     if (_t->_oldSegment) {
@@ -414,18 +412,10 @@ void Segment::beginDraw(uint16_t prog) {
     // blend palettes
     // there are about 255 blend passes of 48 "blends" to completely blend two palettes (in _dur time)
     // minimum blend time is 100ms maximum is 65535ms
-    #ifndef WLED_SAVE_RAM
     unsigned noOfBlends = ((255U * prog) / 0xFFFFU) - _t->_prevPaletteBlends;
     if (noOfBlends > 255) noOfBlends = 255; // safety check
     for (unsigned i = 0; i < noOfBlends; i++, _t->_prevPaletteBlends++) nblendPaletteTowardPalette(_t->_palT, Segment::_currentPalette, 48);
     Segment::_currentPalette = _t->_palT; // copy transitioning/temporary palette
-    #else
-    unsigned noOfBlends = ((255U * prog) / 0xFFFFU);
-    CRGBPalette16 tmpPalette;
-    loadPalette(tmpPalette, _t->_palette);
-    for (unsigned i = 0; i < noOfBlends; i++) nblendPaletteTowardPalette(tmpPalette, Segment::_currentPalette, 48);
-    Segment::_currentPalette = tmpPalette; // copy transitioning/temporary palette
-    #endif
   }
 }
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -350,38 +350,6 @@ WLED_GLOBAL std::vector<WiFiConfig> multiWiFi;
 WLED_GLOBAL IPAddress dnsAddress _INIT_N(((  8,   8,  8,  8)));   // Google's DNS
 WLED_GLOBAL char cmDNS[33]       _INIT(MDNS_NAME);                // mDNS address (*.local, replaced by wledXXXXXX if default is used)
 WLED_GLOBAL char apSSID[33]      _INIT("");                       // AP off by default (unless setup)
-#ifdef WLED_SAVE_RAM
-typedef class WiFiOptions {
-  public:
-    struct {
-      uint8_t selectedWiFi : 4; // max 16 SSIDs
-      uint8_t apChannel    : 4;
-      uint8_t apHide       : 3;
-      uint8_t apBehavior   : 3;
-      bool    noWifiSleep  : 1;
-      bool    force802_3g  : 1;
-    };
-    WiFiOptions(uint8_t s, uint8_t c, bool h, uint8_t b, bool sl, bool g) {
-      selectedWiFi = s;
-      apChannel = c;
-      apHide = h;
-      apBehavior = b;
-      noWifiSleep = sl;
-      force802_3g = g;
-    }
-} __attribute__ ((aligned(1), packed)) wifi_options_t;
-  #ifdef ARDUINO_ARCH_ESP32
-WLED_GLOBAL wifi_options_t wifiOpt _INIT_N(({0, 1, false, AP_BEHAVIOR_BOOT_NO_CONN, true, false}));
-  #else
-WLED_GLOBAL wifi_options_t wifiOpt _INIT_N(({0, 1, false, AP_BEHAVIOR_BOOT_NO_CONN, false, false}));
-  #endif
-#define selectedWiFi wifiOpt.selectedWiFi
-#define apChannel    wifiOpt.apChannel
-#define apHide       wifiOpt.apHide
-#define apBehavior   wifiOpt.apBehavior
-#define noWifiSleep  wifiOpt.noWifiSleep
-#define force802_3g  wifiOpt.force802_3g
-#else
 WLED_GLOBAL int8_t selectedWiFi  _INIT(0);
 WLED_GLOBAL byte apChannel       _INIT(6);                        // 2.4GHz WiFi AP channel (1-13)
 WLED_GLOBAL byte apHide          _INIT(0);                        // hidden AP SSID
@@ -392,7 +360,7 @@ WLED_GLOBAL bool noWifiSleep _INIT(true);                         // disabling m
 WLED_GLOBAL bool noWifiSleep _INIT(false);
   #endif
 WLED_GLOBAL bool force802_3g _INIT(false);
-#endif // WLED_SAVE_RAM
+
 #ifdef SOC_WIFI_SUPPORT_5G
 WLED_GLOBAL byte wifiBandMode _INIT((byte)WIFI_BAND_MODE_AUTO);  // default for dual-band chips (1=2.4G, 2=5G, 3=Auto)
 #endif
@@ -694,67 +662,6 @@ WLED_GLOBAL byte notificationSentCallMode _INIT(CALL_MODE_INIT);
 WLED_GLOBAL uint8_t notificationCount _INIT(0);
 WLED_GLOBAL uint8_t syncGroups    _INIT(0x01);                // sync send groups this instance syncs to (bit mapped)
 WLED_GLOBAL uint8_t receiveGroups _INIT(0x01);                // sync receive groups this instance belongs to (bit mapped)
-#ifdef WLED_SAVE_RAM
-// this will save us 8 bytes of RAM while increasing code by ~400 bytes
-typedef class Receive {
-  public:
-    union {
-      uint8_t   Options;
-      struct {
-        bool    Brightness     : 1;
-        bool    Color          : 1;
-        bool    Effects        : 1;
-        bool    SegmentOptions : 1;
-        bool    SegmentBounds  : 1;
-        bool    Direct         : 1;
-        bool    Palette        : 1;
-        uint8_t reserved       : 1;
-      };
-    };
-    Receive(int i) { Options = i; }
-    Receive(bool b, bool c, bool e, bool sO, bool sB, bool p)
-    : Brightness(b)
-    , Color(c)
-    , Effects(e)
-    , SegmentOptions(sO)
-    , SegmentBounds(sB)
-    , Palette(p)
-    {};
-} __attribute__ ((aligned(1), packed)) receive_notification_t;
-typedef class Send {
-  public:
-    union {
-      uint8_t Options;
-      struct {
-        bool Direct : 1;
-        bool Button : 1;
-        bool Alexa  : 1;
-        bool Hue    : 1;
-        uint8_t reserved : 4;
-      };
-    };
-  Send(int o) { Options = o; }
-  Send(bool d, bool b, bool a, bool h) {
-    Direct = d;
-    Button = b;
-    Alexa = a;
-    Hue = h;
-  }
-} __attribute__ ((aligned(1), packed)) send_notification_t;
-WLED_GLOBAL receive_notification_t receiveN _INIT(0b01100111);
-WLED_GLOBAL send_notification_t    notifyG  _INIT(0b00001111);
-#define receiveNotificationBrightness receiveN.Brightness
-#define receiveNotificationColor      receiveN.Color
-#define receiveNotificationEffects    receiveN.Effects
-#define receiveNotificationPalette    receiveN.Palette
-#define receiveSegmentOptions         receiveN.SegmentOptions
-#define receiveSegmentBounds          receiveN.SegmentBounds
-#define receiveDirect                 receiveN.Direct
-#define notifyDirect notifyG.Direct
-#define notifyButton notifyG.Button
-#define notifyAlexa  notifyG.Alexa
-#define notifyHue    notifyG.Hue
-#else
 WLED_GLOBAL bool receiveNotificationBrightness _INIT(true);       // apply brightness from incoming notifications
 WLED_GLOBAL bool receiveNotificationColor      _INIT(true);       // apply color
 WLED_GLOBAL bool receiveNotificationEffects    _INIT(true);       // apply effects setup
@@ -766,7 +673,6 @@ WLED_GLOBAL bool notifyDirect _INIT(true);                        // send notifi
 WLED_GLOBAL bool notifyButton _INIT(true);                        // send if updated by button or infrared remote
 WLED_GLOBAL bool notifyAlexa  _INIT(false);                       // send notification if updated via Alexa
 WLED_GLOBAL bool notifyHue    _INIT(false);                       // send notification if Hue light changes
-#endif
 
 // effects
 WLED_GLOBAL byte effectCurrent _INIT(0);
@@ -776,38 +682,6 @@ WLED_GLOBAL byte effectPalette _INIT(0);
 WLED_GLOBAL bool stateChanged _INIT(false);
 
 // network
-#ifdef WLED_SAVE_RAM
-// this will save us 2 bytes of RAM while increasing code by ~400 bytes
-typedef class Udp {
-  public:
-    uint16_t  Port;
-    uint16_t  Port2;
-    uint16_t  RgbPort;
-    struct {
-      uint8_t NumRetries : 5;
-      bool    Connected : 1;
-      bool    Connected2 : 1;
-      bool    RgbConnected : 1;
-    };
-    Udp(int p1, int p2, int p3, int r, bool c1, bool c2, bool c3) {
-      Port = p1;
-      Port2 = p2;
-      RgbPort = p3;
-      NumRetries = r;
-      Connected = c1;
-      Connected2 = c2;
-      RgbConnected = c3;
-    }
-} __attribute__ ((aligned(1), packed)) udp_port_t;
-WLED_GLOBAL udp_port_t udp _INIT_N(({21234, 65506, 19446, 0, false, false, false}));
-#define udpPort         udp.Port
-#define udpPort2        udp.Port2
-#define udpRgbPort      udp.RgbPort
-#define udpNumRetries   udp.NumRetries
-#define udpConnected    udp.Connected
-#define udp2Connected   udp.Connected2
-#define udpRgbConnected udp.RgbConnected
-#else
 WLED_GLOBAL uint16_t udpPort    _INIT(21324); // WLED notifier default port
 WLED_GLOBAL uint16_t udpPort2   _INIT(65506); // WLED notifier supplemental port
 WLED_GLOBAL uint16_t udpRgbPort _INIT(19446); // Hyperion port
@@ -815,7 +689,6 @@ WLED_GLOBAL uint8_t  udpNumRetries _INIT(0);  // Number of times a UDP sync mess
 WLED_GLOBAL bool     udpConnected _INIT(false);
 WLED_GLOBAL bool     udp2Connected _INIT(false);
 WLED_GLOBAL bool     udpRgbConnected _INIT(false);
-#endif
 
 // ui style
 WLED_GLOBAL bool showWelcomePage _INIT(false);


### PR DESCRIPTION
On 8266, compiling with WLED_SAVE_RAM increases flash program size by 1.2KB, while reducing static RAM by 20 bytes only. Plus it reduces the size of the Segment::Transition struct by 48 bytes (from 80 to 32), by avoiding a separate palette for blending.

On the other side, the WLED_SAVE_RAM special code is not maintained (corner case, needs a special build flag to activate), and its largely untested with the latest codebase.

I suggest removing this micro-optimization, for the sake of maintainability, and for reducing special cases alternate implementations.