### PR TITLE
Add WS live stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ Originally created by [Aircoookie](https://github.com/Aircoookie), now maintaine
 - [Adalight / TPM2](https://kno.wled.ge/interfaces/serial/) (PC ambilight via serial)
 - [Infrared remote control](https://kno.wled.ge/interfaces/infrared/) (24-key RGB, receiver required)
 - Timers and schedules (NTP time sync, full timezone and DST support)
+- **WebSocket** realtime sync for other incompatible broadcast sources (browser-based applications such as [WSync LED](https://github.com/Antonin1106/WSync-LED)).
 
 ### Developer-Friendly
 - **Usermod system** — extend WLED with community or custom modules without modifying core code

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -13,12 +13,39 @@ constexpr uint8_t BINARY_PROTOCOL_GENERIC = 0xFF; // generic / auto detect NOT I
 constexpr uint8_t BINARY_PROTOCOL_E131    = P_E131; // = 0, untested!
 constexpr uint8_t BINARY_PROTOCOL_ARTNET  = P_ARTNET; // = 1, untested!
 constexpr uint8_t BINARY_PROTOCOL_DDP     = P_DDP; // = 2
+constexpr uint8_t BINARY_PROTOCOL_RAW_RGB = 0x10; // WS reception
 
 static uint16_t wsLiveClientId = 0;
 static unsigned long wsLastLiveTime = 0;
 //static uint8_t* wsFrameBuffer = nullptr;
 
 #define WS_LIVE_INTERVAL 40
+
+void handleRawRGB(const uint8_t *data, size_t packetLength)
+{
+  realtimeLock(
+      realtimeTimeoutMs,
+      REALTIME_MODE_GENERIC);
+
+  if (realtimeOverride)
+    return;
+
+  // Number of leds
+  const uint16_t ledCount = min(strip.getLengthTotal(), (uint16_t)(packetLength / 3)); // R, G, B so /3
+
+  // Set all leds to the color received
+  for (uint16_t i = 0, o = 0; i < ledCount; i++, o += 3)
+  {
+    setRealtimePixel(
+        i,
+        data[o],
+        data[o + 1],
+        data[o + 2],
+        0);
+  }
+
+  e131NewData = true;
+}
 
 void wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len)
 {
@@ -94,7 +121,11 @@ void wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
             break;
           case BINARY_PROTOCOL_DDP:
             handleE131Packet((e131_packet_t*)&data[offset], client->remoteIP(), P_DDP, len - offset);
-        }
+          case BINARY_PROTOCOL_RAW_RGB:
+            realtimeIP = client->remoteIP();
+            handleRawRGB(&data[offset], len - offset);
+            break;
+          }
       }
     } else {
       DEBUG_PRINTF_P(PSTR("WS multipart message: final %u index %u len %u total %u\n"), info->final, info->index, len, (uint32_t)info->len);


### PR DESCRIPTION
# Add new WebSocket Live Stream interface 
> This new feature provides low-latency LED streaming over WebSocket for environments where native real-time protocols such as DDP, E1.31, Art-Net, or DMX are unavailable or cannot be used (browser-based applications).

## How it work ?
The implementation reuses the existing WebSocket infrastructure to minimize changes and avoid duplicating logic.

1. Streaming data is received through the existing `wsEvent()` handler in [`ws.cpp`](https://github.com/Antonin1106/WLED/blob/main/wled00/ws.cpp).
2. A new function, `handleRawRGB()`, is called from a new `switch` case inside `wsEvent()`.
3. `handleRawRGB()` processes the incoming frame and updates the LED strip by calling `setRealtimePixel()`.


## Binary Protocol

Streaming uses a compact binary packet.

Each frame begins with a single command byte (`0x10`) followed by the RGB values of every LED, such as : `0x10 R G B R G B R G B ...`.
Each LED therefore occupies three bytes (1 per colors). 
For N LEDs, the packet size is `1 + (N × 3) bytes`.

### Example
For three LEDs (first red, second green, third blue), the transmitted bytes are `10 FF 00 00 00 FF 00 00 00 FF`.

> [!NOTE]
> RGBW is not currently supported.
>
> For RGBW LED strips, the white channel is automatically set to `0`.
> Sending RGBW data over this protocol will result in undefined behavior.

## Testing

- Verified to work as expected.
- Tested on an `esp32dev` board with a WS2812B LED strip.

> You can try it with this browser-based application : [WSync LED](https://github.com/Antonin1106/WSync-LED).

> [!NOTE]
> If this PR is accepted, we'll submit a follow-up PR to `wled-docs` documenting the protocol and its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WebSocket realtime synchronization for incompatible broadcast sources.
  - Added support for receiving raw RGB data over WebSocket to directly control LED colors.
  - Documented browser-based WebSocket integration as an example use case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->