### PR TITLE
Add SHTC3_v2 usermod to platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1165,6 +1165,7 @@ build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
 custom_usermods = 
 	Internal_Temperature 
 	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#8d988e985901e00a0a92e119aaa8e3249f817754 ;; SR_DMTYPE 254 fix
+	SHTC3_v2 = https://github.com/lost-hope/SHTC3_v2.git
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -1165,7 +1165,7 @@ build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
 custom_usermods = 
 	Internal_Temperature 
 	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#8d988e985901e00a0a92e119aaa8e3249f817754 ;; SR_DMTYPE 254 fix
-	SHTC3_v2 = https://github.com/lost-hope/SHTC3_v2/commit/b8a648e7b71ac1bb6efca1bacdf6577aeb17b09c
+	SHTC3_v2 = https://github.com/lost-hope/SHTC3_v2/commit/1f6e3fc7d6135b704aa41fadf09a36cbf6712834
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -1165,7 +1165,7 @@ build_unflags = ${env:esp32S3_wroom2_32MB.build_unflags}
 custom_usermods = 
 	Internal_Temperature 
 	audioreactive = https://github.com/MoonModules/WLED-AudioReactive-Usermod#8d988e985901e00a0a92e119aaa8e3249f817754 ;; SR_DMTYPE 254 fix
-	SHTC3_v2 = https://github.com/lost-hope/SHTC3_v2.git
+	SHTC3_v2 = https://github.com/lost-hope/SHTC3_v2/commit/b8a648e7b71ac1bb6efca1bacdf6577aeb17b09c
 build_flags = ${common.build_flags} ${esp32s3.build_flags} ${hub75.build_flags} ${hub75.s3_build_flags}
   -D WLED_RELEASE_NAME=\"ESP32-S3_Waveshare_HUB75\"
   -D WAVESHARE_S3_PINOUT


### PR DESCRIPTION
Add SHTC3_v2 usermod for temperature sensing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SHTC3 v2 temperature and humidity sensors to the Waveshare ESP32-S3 Hub75 build.
  * Enables temperature and humidity readings from compatible SHTC3 v2 devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->