### PR TITLE
Don't restrict pins from non pin dropdowns in UM settings

### DIFF
--- a/wled00/data/settings_um.htm
+++ b/wled00/data/settings_um.htm
@@ -161,6 +161,7 @@
 	}
 	function UI(e) {
 		// update changed select options across all usermods
+		if (!e.classList.contains("pin")) return; // not a pin select, ignore. fix for #5759
 		let oldV = parseInt(e.dataset.val);
 		e.dataset.val = e.value;
 		let txt = e.name.split(":")[e.name.split(":").length-2];


### PR DESCRIPTION
Fix for #5759

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented non-pin controls from unintentionally changing pin selection options in the usermod settings interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->