### PR TITLE
Update to IDF 5.5.4

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -423,9 +423,8 @@ monitor_filters = esp32_exception_decoder
 
 [esp32c5]
 ;; generic definitions for all ESP32-C5 boards
-;; NOTE: ESP32-C5 requires pioarduino platform (Tasmota framework doesn't include C5 Arduino libs yet)
-platform = ${esp32_idf_V5.platform_pioarduino}
-platform_packages = ${esp32_idf_V5.platform_packages_pioarduino}
+platform = ${esp32_idf_V5.platform}
+platform_packages = ${esp32_idf_V5.platform_packages}
 
 custom_usermods = ;; ${common.default_usermods} ;; ToDO: audiorective compiles, but not tested on C5 yet
 build_unflags = ${esp32_idf_V5.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -319,9 +319,14 @@ lib_deps =
 lib_ignore = 
 
 [esp32_idf_V5]
-;; Platform 2026.05.50 Tasmota Arduino Core 3.3.8.260506 based on IDF 5.5.4.260407
+;; (default) Platform 2026.05.50 Tasmota Arduino Core 3.3.8.260506 based on IDF 5.5.4.260407
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2026.05.50/platform-espressif32.zip
 platform_packages =
+
+;; (optional) pioardunio platform - needs 300kB extra flash - Arduino Core v3.3.7 based on ESP-IDF v5.5.2.260206
+platform_pioarduino = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform_packages_pioarduino =
+
 build_unflags = ${common.build_unflags}
   -Wno-volatile ;; avoid warning on .c files: "-Wno-volatile only applies to c++ files"
 build_flags = -g
@@ -419,8 +424,9 @@ monitor_filters = esp32_exception_decoder
 [esp32c5]
 ;; generic definitions for all ESP32-C5 boards
 ;; NOTE: ESP32-C5 requires pioarduino platform (Tasmota framework doesn't include C5 Arduino libs yet)
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
-platform_packages =
+platform = ${esp32_idf_V5.platform_pioarduino}
+platform_packages = ${esp32_idf_V5.platform_packages_pioarduino}
+
 custom_usermods = ;; ${common.default_usermods} ;; ToDO: audiorective compiles, but not tested on C5 yet
 build_unflags = ${esp32_idf_V5.build_unflags}
   -D WLED_ENABLE_DMX_INPUT  ;; esp_dmx library doesn't support C5 UART registers yet

--- a/platformio.ini
+++ b/platformio.ini
@@ -319,8 +319,8 @@ lib_deps =
 lib_ignore = 
 
 [esp32_idf_V5]
-;; build environment for ESP32 using ESP-IDF 5.3.4 / arduino-esp32 v3.1.10
-platform = https://github.com/tasmota/platform-espressif32/releases/download/2026.02.30/platform-espressif32.zip
+;; Platform 2026.05.50 Tasmota Arduino Core 3.3.8.260506 based on IDF 5.5.4.260407
+platform = https://github.com/tasmota/platform-espressif32/releases/download/2026.05.50/platform-espressif32.zip
 platform_packages =
 build_unflags = ${common.build_unflags}
   -Wno-volatile ;; avoid warning on .c files: "-Wno-volatile only applies to c++ files"
@@ -331,6 +331,7 @@ build_flags = -g
   ; -DESP32=ESP32 ;; disabled to avoid compiler warning: "ESP32" redefined
   ${esp32_all_variants.build_flags}
   -D WLED_USE_SHARED_RMT     ;; ToDO: check if NeoESP32RmtHI is still needed with V5 (see discussion in PR#4838)
+  -D__unreachable=__builtin_unreachable ;; picolibc (new toolchain-xtensa-esp-elf) dropped __unreachable(), but esp_dmx still calls it
   ;;-D WLED_DISABLE_INFRARED ;; ToDO: needs more testing with V5
   ;;-D WLED_DISABLE_MQTT     ;; ToDO: needs more testing with V5
   -D WLED_ENABLE_DMX_INPUT

--- a/platformio.ini
+++ b/platformio.ini
@@ -323,8 +323,8 @@ lib_ignore =
 platform = https://github.com/tasmota/platform-espressif32/releases/download/2026.05.50/platform-espressif32.zip
 platform_packages =
 
-;; (optional) pioardunio platform - needs 300kB extra flash - Arduino Core v3.3.7 based on ESP-IDF v5.5.2.260206
-platform_pioarduino = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+;; (optional) pioarduino platform - needs 300kB extra flash - Arduino Core v3.3.9 based on ESP-IDF v5.5.4
+platform_pioarduino = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
 platform_packages_pioarduino =
 
 build_unflags = ${common.build_unflags}

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-platformio>=6.1.17
+platformio>=6.1.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ marshmallow==3.26.1
     # via platformio
 packaging==25.0
     # via marshmallow
-platformio==6.1.18
+platformio==6.1.19
     # via -r requirements.in
 pyelftools==0.32
     # via platformio

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -669,12 +669,6 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   JsonObject if_ntp = interfaces[F("ntp")];
   CJSON(ntpEnabled, if_ntp["en"]);
-#ifdef CONFIG_IDF_TARGET_ESP32C5 // ToDO: esp32-c5 crashes on NTP requests, see https://github.com/wled/WLED/pull/5048/changes#r3003182550
-  if (ntpEnabled) { DEBUG_PRINTLN("NTP disabled on -C5, as it leads to crashes"); }
-                                 // assert failed: udp_new_ip_type /IDF/components/lwip/lwip/src/core/udp.c:1278 (Required to lock TCPIP core functionality!)
-  ntpEnabled = false;            // --> disable NTP support, until the crash is resolved
-  #warning "enabling NTP lead to crashes on -C5. NTP disabled"
-#endif
   getStringFromJson(ntpServerName, if_ntp[F("host")], 33); // "1.wled.pool.ntp.org"
   CJSON(currentTimezone, if_ntp[F("tz")]);
   CJSON(utcOffsetSecs, if_ntp[F("offset")]);

--- a/wled00/mbedtls_sha1_shim.cpp
+++ b/wled00/mbedtls_sha1_shim.cpp
@@ -1,8 +1,9 @@
 #include "wled.h"
 #ifdef ESP32
-// ESP32-C5 on pioarduino uses IDF 5.5+ which has SHA1 built-in, skip shim
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
 #include "mbedtls/sha1.h"
+// Some ESP-IDF builds/platforms compile mbedtls without SHA1 support (MBEDTLS_SHA1_C undefined),
+// while others (e.g. ESP32-C5 on pioarduino) have it built-in. Only provide the shim when missing.
+#if !defined(MBEDTLS_SHA1_C)
 #include "SHA1Builder.h"
 
 // Wrapper functions to map mbedtls SHA1 calls to Arduino SHA1Builder

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -548,11 +548,6 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
   if (subPage == SUBPAGE_TIME)
   {
     ntpEnabled = request->hasArg(F("NT"));
-#ifdef CONFIG_IDF_TARGET_ESP32C5 // ToDO: esp32-c5 crashes on NTP requests: assert failed: udp_new_ip_type udp.c:1278 (Required to lock TCPIP core functionality!)
-    if (ntpEnabled) { DEBUG_PRINTLN("NTP disabled on -C5, as it leads to crashes"); }
-    ntpEnabled = false;
-    #warning "enabling NTP lead to crashes on -C5. NTP disabled"
-#endif
     strlcpy(ntpServerName, request->arg(F("NS")).c_str(), 33);
     useAMPM = !request->hasArg(F("CF"));
     currentTimezone = request->arg(F("TZ")).toInt();

--- a/wled00/src/dependencies/time/TimeLib.h
+++ b/wled00/src/dependencies/time/TimeLib.h
@@ -17,7 +17,7 @@
 #endif
 
 
-#if !defined(__time_t_defined) // avoid conflict with newlib or other posix libc
+#if !defined(__time_t_defined) && !defined(_TIME_T_DECLARED) // avoid conflict with newlib, picolibc, or other posix libc
 typedef unsigned long time_t;
 #endif
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -413,7 +413,12 @@ void WLED::setup()
   #else
     DEBUG_PRINTLN(F("arduino-esp32 v1.0.x\n"));  // we can't say in more detail.
   #endif
-  DEBUG_PRINTF_P(PSTR("\nCPU:   %s rev.%d, %d core(s), %d MHz.\n"), ESP.getChipModel(), (int)ESP.getChipRevision(), ESP.getChipCores(), ESP.getCpuFreqMHz());
+  #if ESP_IDF_VERSION_MAJOR > 4
+    // chip revision uses a new format in V5
+    DEBUG_PRINTF_P(PSTR("\nCPU:   %s v%d.%d, %d core(s), %d MHz.\n"), ESP.getChipModel(), (int)ESP.getChipRevision() / 100, (int)ESP.getChipRevision()% 100 , ESP.getChipCores(), ESP.getCpuFreqMHz());
+  #else
+    DEBUG_PRINTF_P(PSTR("\nCPU:   %s rev.%d, %d core(s), %d MHz.\n"), ESP.getChipModel(), (int)ESP.getChipRevision(), ESP.getChipCores(), ESP.getCpuFreqMHz());
+  #endif
   DEBUG_PRINTF_P(PSTR("FLASH: %d MB, Mode %d "), (ESP.getFlashChipSize()/1024)/1024, (int)ESP.getFlashChipMode());
   #ifdef WLED_DEBUG
   switch (ESP.getFlashChipMode()) {


### PR DESCRIPTION
Not tested with hardware yet, but this gets the build to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the latest ESP32 software platform and toolchain.
  * Updated support for newer Arduino Core and ESP-IDF releases.
  * Improved ESP32-C5 compatibility with the shared platform configuration.
  * Restored normal NTP configuration behavior on ESP32-C5 devices.
  * Prevented build conflicts involving SHA1 support and time-related type definitions.
  * Improved ESP32 CPU revision reporting on newer firmware platforms.
  * Updated the minimum supported PlatformIO version for more reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->