### PR TITLE
Encapsulate led.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/led.cpp
+++ b/wled00/led.cpp
@@ -4,6 +4,14 @@
  * LED methods
  */
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static bool          transitionActive = false;
+static unsigned long transitionStartTime;
+static unsigned long lastNlUpdate;
+static byte           briNlT = 0;              // current nightlight brightness
+static byte           colNlT[] = { 0, 0, 0, 0 }; // current nightlight color
+
  // applies chosen setment properties to legacy values
 void setValuesFromSegment(uint8_t s) {
   const Segment& seg = strip.getSegment(s);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -592,10 +592,9 @@ WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wra
 
 // transitions
 WLED_GLOBAL uint8_t       blendingStyle            _INIT(0);      // effect blending/transitionig style
-WLED_GLOBAL bool          transitionActive         _INIT(false);
+// transitionActive/transitionStartTime are private to led.cpp - see there.
 WLED_GLOBAL uint16_t      transitionDelay          _INIT(750);    // global transition duration
 WLED_GLOBAL uint16_t      transitionDelayDefault   _INIT(750);    // default transition time (stored in cfg.json)
-WLED_GLOBAL unsigned long transitionStartTime;
 WLED_GLOBAL bool          jsonTransitionOnce       _INIT(false);  // flag to override transitionDelay (playlist, JSON API: "live" & "seg":{"i"} & "tt")
 WLED_GLOBAL uint8_t       randomPaletteChangeTime  _INIT(5);      // amount of time [s] between random palette changes (min: 1s, max: 255s)
 WLED_GLOBAL bool          useHarmonicRandomPalette _INIT(true);   // use *harmonic* random palette generation (nicer looking) or truly random
@@ -606,9 +605,7 @@ WLED_GLOBAL bool nightlightActiveOld _INIT(false);
 WLED_GLOBAL uint32_t nightlightDelayMs _INIT(10);
 WLED_GLOBAL byte nightlightDelayMinsDefault _INIT(nightlightDelayMins);
 WLED_GLOBAL unsigned long nightlightStartTime;
-WLED_GLOBAL unsigned long lastNlUpdate;
-WLED_GLOBAL byte briNlT _INIT(0);                     // current nightlight brightness
-WLED_GLOBAL byte colNlT[] _INIT_N(({ 0, 0, 0, 0 }));        // current nightlight color
+// lastNlUpdate/briNlT/colNlT are private to led.cpp - see there.
 
 // brightness
 WLED_GLOBAL unsigned long lastOnTime _INIT(0);


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777, #5778 for earlier ones). 5 more turned out to be private to `led.cpp`: `briNlT`, `colNlT`, `lastNlUpdate`, `transitionActive`, `transitionStartTime`.

Converted all 5 to file-local `static`, same types and initial values as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,323 bytes flash, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that none of the 5 converted variables are referenced outside `led.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of transition and nightlight runtime state.
  * No user-facing behavior or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
