### PR TITLE
Encapsulate wled_server.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -776,8 +776,7 @@ WLED_GLOBAL byte currentPreset _INIT(0);
 
 WLED_GLOBAL byte errorFlag _INIT(0);
 
-WLED_GLOBAL String messageHead, messageSub;
-WLED_GLOBAL byte optionType;
+// messageHead/messageSub/optionType are private to wled_server.cpp - see there.
 
 WLED_GLOBAL bool configNeedsWrite  _INIT(false);        // flag to initiate saving of config
 WLED_GLOBAL bool doReboot          _INIT(false);        // flag to initiate reboot from async handlers
@@ -797,7 +796,7 @@ WLED_GLOBAL AsyncWebSocket ws _INIT_N((("/ws")));
 #ifndef WLED_DISABLE_HUESYNC
 WLED_GLOBAL AsyncClient     *hueClient _INIT(NULL);
 #endif
-WLED_GLOBAL AsyncWebHandler *editHandler _INIT(nullptr);
+// editHandler is private to wled_server.cpp - see there.
 
 // udp interface objects
 WLED_GLOBAL WiFiUDP notifierUdp, rgbUdp, notifier2Udp;

--- a/wled00/wled_server.cpp
+++ b/wled00/wled_server.cpp
@@ -23,6 +23,12 @@
 // forward declarations
 static void createEditHandler();
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static AsyncWebHandler *editHandler = nullptr;
+static String messageHead, messageSub;
+static byte optionType;
+
 
 // define flash strings once (saves flash memory)
 static const char s_redirecting[] PROGMEM = "Redirecting...";


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777, #5778, #5779 for earlier ones). 4 more turned out to be private to `wled_server.cpp`: `editHandler`, `messageHead`, `messageSub`, `optionType`. (`messageHead` was declared on the same source line as `messageSub` but turned out to be just as single-file — verified separately before removing both.)

Converted all 4 to file-local `static`, same types and initial values as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,323 bytes flash, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that none of the 4 converted variables are referenced outside `wled_server.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Encapsulated internal web-server state to limit its visibility within the application.
  * No user-facing behavior or runtime functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
