### PR TITLE
Encapsulate ntp.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/ntp.cpp
+++ b/wled00/ntp.cpp
@@ -8,6 +8,12 @@
 static void sendNTPPacket();
 static bool checkNTPResponse();
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static byte lastTimerMinute = 0;
+static unsigned long ntpPacketSentTime = NTP_NEVER;
+static IPAddress ntpServerIP;
+
 
 // WARNING: may cause errors in sunset calculations on ESP8266, see #3400
 // building with `-D WLED_USE_REAL_MATH` will prevent those errors at the expense of flash and RAM

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -706,7 +706,7 @@ WLED_GLOBAL bool hueStoreAllowed _INIT(false), hueNewKey _INIT(false);
 WLED_GLOBAL unsigned long countdownTime _INIT(1514764800L);
 WLED_GLOBAL bool countdownOverTriggered _INIT(true);
 
-WLED_GLOBAL byte lastTimerMinute  _INIT(0);
+// lastTimerMinute is private to ntp.cpp - see there.
 WLED_GLOBAL std::vector<Timer> timers;
 WLED_GLOBAL bool doAdvancePlaylist _INIT(false);
 
@@ -755,8 +755,7 @@ WLED_GLOBAL DNSServer dnsServer;
 WLED_GLOBAL bool ntpConnected _INIT(false);
 WLED_GLOBAL time_t localTime _INIT(0);
 WLED_GLOBAL unsigned long ntpLastSyncTime _INIT(NTP_NEVER);
-WLED_GLOBAL unsigned long ntpPacketSentTime _INIT(NTP_NEVER);
-WLED_GLOBAL IPAddress ntpServerIP;
+// ntpPacketSentTime/ntpServerIP are private to ntp.cpp - see there.
 WLED_GLOBAL uint16_t ntpLocalPort _INIT(2390);
 WLED_GLOBAL uint16_t rolloverMillis _INIT(0);
 WLED_GLOBAL float longitude _INIT(WLED_LON);


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5780 for earlier ones). 3 more turned out to be private to `ntp.cpp`: `lastTimerMinute`, `ntpPacketSentTime`, `ntpServerIP`.

Converted all 3 to file-local `static`, same types and initial values as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,323 bytes flash, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that none of the 3 converted variables are referenced outside `ntp.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of network time synchronization state.
  * No user-facing behavior or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
