### PR TITLE
Encapsulate e131.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -10,6 +10,11 @@ static void handleArtnetPollReply(IPAddress ipAddress);
 static void prepareArtnetPollReply(ArtPollReply *reply);
 static void sendArtnetPollReply(ArtPollReply *reply, IPAddress ipAddress, uint16_t portAddress);
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static E131Priority highPriority(3);                              // E1.31 highest priority tracking, init = timeout in seconds
+static byte e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT];       // to detect packet loss
+static uint16_t pollReplyCount = 0;                                // count number of replies for ArtPoll node report
 
 /*
  * E1.31 handler

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -466,14 +466,12 @@ WLED_GLOBAL bool arlsForceMaxBri _INIT(false);                    // enable to f
 WLED_GLOBAL uint16_t e131Universe _INIT(1);                       // settings for E1.31 (sACN) protocol (only DMX_MODE_MULTIPLE_* can span over consequtive universes)
 WLED_GLOBAL uint16_t e131Port _INIT(5568);                        // DMX in port. E1.31 default is 5568, Art-Net is 6454
 WLED_GLOBAL byte e131Priority _INIT(0);                           // E1.31 port priority (if != 0 priority handling is active)
-WLED_GLOBAL E131Priority highPriority _INIT(3);                   // E1.31 highest priority tracking, init = timeout in seconds
+// highPriority/e131LastSequenceNumber/pollReplyCount are private to e131.cpp - see there.
 WLED_GLOBAL byte DMXMode _INIT(DMX_MODE_MULTIPLE_RGB);            // DMX mode (s.a.)
 WLED_GLOBAL uint16_t DMXAddress _INIT(1);                         // DMX start address of fixture, a.k.a. first Channel [for E1.31 (sACN) protocol]
 WLED_GLOBAL uint16_t DMXSegmentSpacing _INIT(0);                  // Number of void/unused channels between each segments DMX channels
-WLED_GLOBAL byte e131LastSequenceNumber[E131_MAX_UNIVERSE_COUNT]; // to detect packet loss
 WLED_GLOBAL bool e131Multicast _INIT(false);                      // multicast or unicast
 WLED_GLOBAL bool e131SkipOutOfSequence _INIT(false);              // freeze instead of flickering
-WLED_GLOBAL uint16_t pollReplyCount _INIT(0);                     // count number of replies for ArtPoll node report
 
 // mqtt
 WLED_GLOBAL unsigned long lastMqttReconnectAttempt _INIT(0);  // used for other periodic tasks too


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5781 for earlier ones). 3 more turned out to be private to `e131.cpp`: `highPriority`, `e131LastSequenceNumber`, `pollReplyCount`.

Converted all 3 to file-local `static`, using direct constructor syntax for the `E131Priority` object — equivalent to what `WLED_GLOBAL E131Priority highPriority _INIT(3);` expanded to when `wled.cpp` was the definition translation unit.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,307 bytes flash, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that none of the 3 converted variables are referenced outside `e131.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of E1.31 and Art-Net runtime state.
  * No changes to user-facing features or configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
