### PR TITLE
Encapsulate util.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/util.cpp
+++ b/wled00/util.cpp
@@ -262,6 +262,13 @@ size_t utf8_strlen(const char *s)
   return len;
 }
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+#if defined(ARDUINO_ARCH_ESP32)
+static SemaphoreHandle_t jsonBufferLockMutex = xSemaphoreCreateRecursiveMutex();
+#endif
+static volatile uint8_t jsonBufferLock = 0;
+
 //threading/network callback details: https://github.com/wled-dev/WLED/pull/2336#discussion_r762276994
 bool requestJSONBufferLock(uint8_t moduleID)
 {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -854,9 +854,7 @@ WLED_GLOBAL int8_t spi_sclk  _INIT(SPISCLKPIN);
 #endif
 
 // global ArduinoJson buffer
-#if defined(ARDUINO_ARCH_ESP32)
-WLED_GLOBAL SemaphoreHandle_t jsonBufferLockMutex _INIT(xSemaphoreCreateRecursiveMutex());
-#endif
+// jsonBufferLockMutex/jsonBufferLock are private to util.cpp - see there.
 #ifdef BOARD_HAS_PSRAM
 // if board has PSRAM, use it for JSON document (allocated in setup())
 WLED_GLOBAL JsonDocument *pDoc _INIT(nullptr);
@@ -864,7 +862,6 @@ WLED_GLOBAL JsonDocument *pDoc _INIT(nullptr);
 WLED_GLOBAL StaticJsonDocument<JSON_BUFFER_SIZE> gDoc;
 WLED_GLOBAL JsonDocument *pDoc _INIT(&gDoc);
 #endif
-WLED_GLOBAL volatile uint8_t jsonBufferLock _INIT(0);
 
 // enable additional debug output
 #if defined(WLED_DEBUG_HOST)


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5782 for earlier ones). 2 more turned out to be private to `util.cpp`: `jsonBufferLock`, `jsonBufferLockMutex`.

Converted both to file-local `static`, preserving the `#if defined(ARDUINO_ARCH_ESP32)` guard around `jsonBufferLockMutex` (it's a FreeRTOS semaphore, ESP32-only).

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev` — 1,320,319 bytes flash, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that neither converted variable is referenced outside `util.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of JSON buffer locking on ESP32.
  * No user-facing behavior or functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->