### PR TITLE
Encapsulate set.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -4,6 +4,11 @@
  * Receives client input
  */
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static byte presetCycMin = 1;
+static byte presetCycMax = 5;
+
 //called upon POST settings form submit
 void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
 {

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -718,8 +718,7 @@ WLED_GLOBAL byte improvError _INIT(0);
 WLED_GLOBAL int16_t currentPlaylist _INIT(-1);
 //still used for "PL=~" HTTP API command
 WLED_GLOBAL byte presetCycCurr _INIT(0);
-WLED_GLOBAL byte presetCycMin _INIT(1);
-WLED_GLOBAL byte presetCycMax _INIT(5);
+// presetCycMin/presetCycMax are private to set.cpp - see there.
 
 // realtime
 WLED_GLOBAL byte realtimeMode _INIT(REALTIME_MODE_INACTIVE);


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5783 for earlier ones). 2 more turned out to be private to `set.cpp`: `presetCycMin`, `presetCycMax`.

Converted both to file-local `static`, same types and initial values as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that neither converted variable is referenced outside `set.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of preset-cycle limits without changing user-visible behavior.
  * Reduced exposure of implementation details while preserving existing preset-cycle functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->