### PR TITLE
Encapsulate ir.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/ir.cpp
+++ b/wled00/ir.cpp
@@ -10,6 +10,10 @@
 
 static IRrecv* irrecv;
 static decode_results results;
+
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static byte whiteLast = 128; // white channel before turned off. Used for toggle function
 static unsigned long irCheckedTime = 0;
 static uint32_t lastValidCode = 0;
 static byte lastRepeatableAction = ACTION_NONE;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -618,7 +618,7 @@ WLED_GLOBAL byte bri                 _INIT(briS);          // global brightness 
 WLED_GLOBAL byte briOld              _INIT(0);             // global brightness while in transition loop (previous iteration)
 WLED_GLOBAL byte briT                _INIT(0);             // global brightness during transition
 WLED_GLOBAL byte briLast             _INIT(128);           // brightness before turned off. Used for toggle function
-WLED_GLOBAL byte whiteLast           _INIT(128);           // white channel before turned off. Used for toggle function in ir.cpp
+// whiteLast is private to ir.cpp - see there.
 
 // button
 struct Button {


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5784 for earlier ones). `whiteLast` turned out to be private to `ir.cpp`.

Converted it to file-local `static`, same type and initial value as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that `whiteLast` is not referenced outside `ir.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified ownership of an internal brightness state.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->