### PR TITLE
Encapsulate colors.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/colors.cpp
+++ b/wled00/colors.cpp
@@ -144,6 +144,10 @@ uint32_t ColorFromPalette(const CRGBPalette16& pal, unsigned index, uint8_t brig
   return RGBW32(red1,green1,blue1,0);
 }
 
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static byte lastRandomIndex = 0; // used to save last random color so the new one is not the same
+
 void setRandomColor(byte* rgb)
 {
   lastRandomIndex = get_random_wheel_index(lastRandomIndex);

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -585,7 +585,7 @@ WLED_GLOBAL bool interfacesInited _INIT(false);
 WLED_GLOBAL bool wasConnected _INIT(false);
 
 // color
-WLED_GLOBAL byte lastRandomIndex _INIT(0);        // used to save last random color so the new one is not the same
+// lastRandomIndex is private to colors.cpp - see there.
 WLED_GLOBAL std::vector<CRGBPalette16> customPalettes;  // custom palettes (file-based, IDs grow downwards starting at 200)
 WLED_GLOBAL std::vector<UsermodPalette> usermodPalettes; // usermod-registered palettes (IDs 255, 254, 253...)
 WLED_GLOBAL uint8_t paletteBlend _INIT(0);        // determines blending and wrapping of palette: 0: blend, wrap if moving (SEGMENT.speed>0); 1: blend, always wrap; 2: blend, never wrap; 3: don't blend or wrap


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5786 for earlier ones). `lastRandomIndex` turned out to be private to `colors.cpp`.

Converted it to file-local `static`, same type and initial value as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that `lastRandomIndex` is not referenced outside `colors.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)