### PR TITLE
Encapsulate button.cpp's own runtime state as static, not global

### DIFF
--- a/wled00/button.cpp
+++ b/wled00/button.cpp
@@ -13,6 +13,10 @@
 #define WLED_LONG_BRI_STEPS          16 // how much to increase/decrease the brightness with each long press repetition
 
 static const char _mqtt_topic_button[] PROGMEM = "%s/button/%d";  // optimize flash usage
+
+// Runtime state private to this file - previously WLED_GLOBAL, a leftover from
+// when all state lived in one big extern block regardless of who used it.
+static unsigned long lastOnTime = 0;
 static bool buttonBriDirection = false; // true: increase brightness, false: decrease brightness
 
 void shortPressAction(uint8_t b)

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -611,7 +611,7 @@ WLED_GLOBAL byte briNlT _INIT(0);                     // current nightlight brig
 WLED_GLOBAL byte colNlT[] _INIT_N(({ 0, 0, 0, 0 }));        // current nightlight color
 
 // brightness
-WLED_GLOBAL unsigned long lastOnTime _INIT(0);
+// lastOnTime is private to button.cpp - see there.
 WLED_GLOBAL bool offMode             _INIT(!turnOnAtBoot);
 WLED_GLOBAL byte briS                _INIT(128);           // default brightness
 WLED_GLOBAL byte bri                 _INIT(briS);          // global brightness (set)


### PR DESCRIPTION
## Summary

Part of an ongoing pass identifying `WLED_GLOBAL` declarations that are actually only referenced in one file (see #5777-#5787 for earlier ones). `lastOnTime` turned out to be private to `button.cpp` — this is the last one from the Tier-1 (single-file) list.

Converted it to file-local `static`, same type and initial value as before.

No behavior change — purely a storage-class change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`, no warnings.
- [x] Confirmed via repo-wide grep (`wled00/`, `usermods/`) that `lastOnTime` is not referenced outside `button.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)