### PR TITLE
Encapsulate fsBytesUsed/fsBytesTotal with read-only accessors

### DIFF
--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -122,6 +122,8 @@ bool writeObjectToFile(const char* file, const char* key, const JsonDocument* co
 bool readObjectFromFileUsingId(const char* file, uint16_t id, JsonDocument* dest, const JsonDocument* filter = nullptr);
 bool readObjectFromFile(const char* file, const char* key, JsonDocument* dest, const JsonDocument* filter = nullptr);
 void updateFSInfo();
+size_t getFsBytesUsed();
+size_t getFsBytesTotal();
 void closeFile();
 inline bool writeObjectToFileUsingId(const String &file, uint16_t id, const JsonDocument* content) { return writeObjectToFileUsingId(file.c_str(), id, content); };
 inline bool writeObjectToFile(const String &file, const char* key, const JsonDocument* content) { return writeObjectToFile(file.c_str(), key, content); };

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -12,6 +12,16 @@
 
 #define FS_BUFSIZE 256
 
+// Filesystem usage stats, refreshed by updateFSInfo() - previously WLED_GLOBAL,
+// a leftover from when all state lived in one big extern block regardless of
+// who used it. json.cpp only ever reads these (status report), so it gets
+// by-value getters rather than a mutable reference - an accidental write from
+// outside this file is now a build error instead of a silent bug.
+static size_t fsBytesUsed = 0;
+static size_t fsBytesTotal = 0;
+size_t getFsBytesUsed()  { return fsBytesUsed;  }
+size_t getFsBytesTotal() { return fsBytesTotal; }
+
 /*
  * Structural requirements for files managed by writeObjectToFile() and readObjectFromFile() utilities:
  * 1. File must be a string representation of a valid JSON object

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -838,8 +838,8 @@ void serializeInfo(JsonObject root)
   wifi_info[F("ap")] = apActive;
 
   JsonObject fs_info = root.createNestedObject("fs");
-  fs_info["u"] = fsBytesUsed / 1000;
-  fs_info["t"] = fsBytesTotal / 1000;
+  fs_info["u"] = getFsBytesUsed() / 1000;
+  fs_info["t"] = getFsBytesTotal() / 1000;
   fs_info[F("pmt")] = presetsModifiedTime;
 
   root[F("ndc")] = nodeListEnabled ? (int)Nodes.size() : -1;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -766,8 +766,7 @@ WLED_GLOBAL time_t sunset _INIT(0);
 WLED_GLOBAL Toki toki _INIT(Toki());
 
 // General filesystem
-WLED_GLOBAL size_t fsBytesUsed _INIT(0);
-WLED_GLOBAL size_t fsBytesTotal _INIT(0);
+// fsBytesUsed/fsBytesTotal are private to file.cpp - use getFsBytesUsed()/getFsBytesTotal() instead.
 WLED_GLOBAL unsigned long presetsModifiedTime _INIT(0L);
 WLED_GLOBAL bool doCloseFile _INIT(false);
 


### PR DESCRIPTION
## Summary

Part of an ongoing pass on `WLED_GLOBAL` declarations (see #5777-#5788, #5774/#12 for earlier ones). `fsBytesUsed`/`fsBytesTotal` are written and read by `file.cpp` (via `updateFSInfo()`), and read-only from `json.cpp` (status report in `serializeInfo()`).

Since `json.cpp` never writes them, moved both to file-local `static` in `file.cpp` and exposed two by-value getters — `getFsBytesUsed()`/`getFsBytesTotal()` — instead of a mutable reference.

This is deliberately narrower in scope than earlier Tier-2 work: only applied where the external file (`json.cpp`) is genuinely read-only. Because the getters return by value, an accidental write from `json.cpp` (or any other file) is now a build error instead of a silent bug — a real, compiler-enforced improvement, not just a rename. Other Tier-2 candidates where the external file legitimately needs to *write* (e.g. `loadLedmap`, `dnsServer`) are being left as plain globals, since no accessor shape actually restricts a write in C++ without a real module/friend boundary — wrapping those would just relabel the same coupling.

No behavior change — purely a storage/access-pattern change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`.
- [x] `usermods` env (builds all 59 usermods): builds and links cleanly via `pio run -e usermods`.
- [x] Repo-wide grep confirms no remaining raw references to either identifier outside `file.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)