### PR TITLE
Encapsulate rolloverMillis with a read-only accessor

### DIFF
--- a/usermods/quinled-an-penta/quinled-an-penta.cpp
+++ b/usermods/quinled-an-penta/quinled-an-penta.cpp
@@ -354,7 +354,7 @@ class QuinLEDAnPentaUsermod : public Usermod
 
             // Always draw these two on the bottom
             char charUptime[charPerRow+1];
-            sprintf(charUptime, "Uptime: %ds", int(millis()/1000 + rolloverMillis*4294967)); // From json.cpp
+            sprintf(charUptime, "Uptime: %ds", int(millis()/1000 + getRolloverMillis()*4294967)); // From json.cpp
             oledDisplay->drawStr(0, 53, charUptime);
 
             char charWledVersion[charPerRow+1];

--- a/wled00/fcn_declare.h
+++ b/wled00/fcn_declare.h
@@ -294,6 +294,9 @@ bool isAsterisksOnly(const char* str, byte maxLen);
 void handleSettingsSet(AsyncWebServerRequest *request, byte subPage);
 bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply=true);
 
+//wled.cpp
+uint16_t getRolloverMillis();
+
 //udp.cpp
 void notify(byte callMode, bool followUp=false);
 uint8_t realtimeBroadcast(uint8_t type, IPAddress client, uint16_t length, const uint8_t* buffer, uint8_t bri=255, bool isRGBW=false);

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -886,7 +886,7 @@ void serializeInfo(JsonObject root)
   // Total PSRAM size in MB, round up to correct for allocator overhead
   root[F("psrSz")] = (ESP.getPsramSize() + (1024U * 1024U - 1)) / (1024U * 1024U); 
   #endif
-  root[F("uptime")] = millis()/1000 + rolloverMillis*4294967;
+  root[F("uptime")] = millis()/1000 + getRolloverMillis()*4294967;
 
   char time[32];
   getTimeString(time);

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -25,6 +25,13 @@
 #endif
 extern "C" void usePWMFixedNMI();
 
+// millis()-rollover counter (millis() wraps every ~50 days) - previously
+// WLED_GLOBAL. json.cpp and usermods only ever read it for uptime reporting,
+// so it gets a by-value getter rather than a mutable reference: an accidental
+// write from outside this file is now a build error instead of a silent bug.
+static uint16_t rolloverMillis = 0;
+uint16_t getRolloverMillis() { return rolloverMillis; }
+
 /*
  * Main WLED class implementation. Mostly initialization and connection logic
  */

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -758,7 +758,7 @@ WLED_GLOBAL unsigned long ntpLastSyncTime _INIT(NTP_NEVER);
 WLED_GLOBAL unsigned long ntpPacketSentTime _INIT(NTP_NEVER);
 WLED_GLOBAL IPAddress ntpServerIP;
 WLED_GLOBAL uint16_t ntpLocalPort _INIT(2390);
-WLED_GLOBAL uint16_t rolloverMillis _INIT(0);
+// rolloverMillis is private to wled.cpp - use getRolloverMillis() instead.
 WLED_GLOBAL float longitude _INIT(WLED_LON);
 WLED_GLOBAL float latitude _INIT(WLED_LAT);
 WLED_GLOBAL time_t sunrise _INIT(0);


### PR DESCRIPTION
## Summary

Part of an ongoing pass on `WLED_GLOBAL` declarations (see #5777-#5789, #5774/#12 for earlier ones). `rolloverMillis` (a `millis()`-rollover counter, incremented in `wled.cpp`'s main loop) is read-only from `json.cpp` and one usermod.

Moved it to file-local `static` in `wled.cpp` and exposed a by-value getter, `getRolloverMillis()`, rather than a mutable reference — same reasoning as #5789: since nothing outside `wled.cpp` writes it, the by-value getter makes an accidental external write a build error instead of a silent bug.

Also fixed the one external consumer this surfaced: `usermods/quinled-an-penta` read `rolloverMillis` directly for its own uptime string (same idiom as `json.cpp` — its own comment says "From json.cpp"). Updated to use the new accessor.

No behavior change — purely a storage/access-pattern change.

## Test plan

- [x] `esp32dev`: builds and links cleanly via `pio run -e esp32dev`.
- [x] `usermods` env (builds all 59 usermods, including the fixed `quinled-an-penta`): builds and links cleanly via `pio run -e usermods`.
- [x] Repo-wide grep confirms no remaining raw references to `rolloverMillis` outside `wled.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)