### PR TITLE
Fix off-by-one bug in `drawCircle`

### DIFF
--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -500,7 +500,7 @@ void Segment::fillCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
   int radius2 = soft ? radius * radius : radius * radius + radius;  // (r+0.5)^2 = r*r + r + 0.25; use exact radius for "soft" circle to stay compatible with Wu’s algorithm
   for (int y = -radius; y <= radius; y++) {
     for (int x = -radius; x <= radius; x++) {
-      if (x * x + y * y < radius2 &&
+      if (x * x + y * y <= radius2 &&
           int(cx)+x >= 0 && int(cy)+y >= 0 &&
           int(cx)+x < vW && int(cy)+y < vH)
         setPixelColorXY(cx + x, cy + y, col);

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -478,13 +478,13 @@ void Segment::drawCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
         setPixelColorXY(cx + dx, cy + dy, col);
         setPixelColorXY(cx + dy, cy + dx, col);
     }
-      x++;
       if (d > 0) {
-        y--;
         d += 4 * (x - y) + 10;
+        y--;
       } else {
         d += 4 * x + 6;
       }
+      x++;
     }
   }
 }

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -497,9 +497,10 @@ void Segment::fillCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
   // draw soft bounding circle
   if (soft) drawCircle(cx, cy, radius, col, soft);
   // fill it
+  int radius2 = soft ? radius * radius : radius * radius + radius;  // (r+0.5)^2 = r*r + r + 0.25; use exact radius for "soft" circle to stay compatible with Wu’s algorithm
   for (int y = -radius; y <= radius; y++) {
     for (int x = -radius; x <= radius; x++) {
-      if (x * x + y * y <= radius * radius &&
+      if (x * x + y * y < radius2 &&
           int(cx)+x >= 0 && int(cy)+y >= 0 &&
           int(cx)+x < vW && int(cy)+y < vH)
         setPixelColorXY(cx + x, cy + y, col);

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -500,7 +500,7 @@ void Segment::fillCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
   int radius2 = soft ? radius * radius : radius * radius + radius;  // (r+0.5)^2 = r*r + r + 0.25; use exact radius for "soft" circle to stay compatible with Wu’s algorithm
   for (int y = -radius; y <= radius; y++) {
     for (int x = -radius; x <= radius; x++) {
-      if (x * x + y * y <= radius2 &&
+      if (x * x + y * y < radius2 &&
           int(cx)+x >= 0 && int(cy)+y >= 0 &&
           int(cx)+x < vW && int(cy)+y < vH)
         setPixelColorXY(cx + x, cy + y, col);


### PR DESCRIPTION
Bresenham's algorithm (used in the non-soft version of `drawCircle`) calculates the next decision variable based on the *current* x- and y-values. `drawCircle` incorrectly adjusts x and y *before* calculating the next decision variable, making the arc slightly flatter than it should be.

I wrote a python script to compare the implementations, with the python library `Pillow` used as a reference:

<img width="2826" height="868" alt="circles_outline" src="https://github.com/user-attachments/assets/d27dc529-4892-4e3f-ad63-2625c1da8aeb" />

As you can see, this change makes WLED agree with Pillow. Everything from `r=7` and up looks rounder after this change. The lower radii are more a matter of taste (and which ones I prefer depend on the size of each pixel).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy and consistency of circle rendering in 2D visual effects.
  * Refined circle boundaries for more precise soft- and hard-edged shapes.
  * Prevented pixels exactly on the circle boundary from being filled, producing cleaner edges and more predictable visual results.
  * Improved circle outline calculations for smoother, more symmetrical rendering across different sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->