### PR TITLE
fix(watchdog): use esp_task_wdt_config_t struct API for IDF 5.x

### DIFF
--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -361,7 +361,21 @@ void WLED::loop()
 #if WLED_WATCHDOG_TIMEOUT > 0
 void WLED::enableWatchdog() {
   #ifdef ARDUINO_ARCH_ESP32
+  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+  // IDF v5: esp_task_wdt_init() takes a config struct, not (timeout, panic)
+  esp_task_wdt_config_t wdt_cfg = {
+    .timeout_ms = WLED_WATCHDOG_TIMEOUT * 1000,
+    .idle_core_mask = 0,       // don't subscribe idle tasks — only our loop task
+    .trigger_panic = true,
+  };
+  esp_err_t watchdog = esp_task_wdt_init(&wdt_cfg);
+  if (watchdog == ESP_ERR_INVALID_STATE) {
+    // TWDT already initialized (by IDF startup), reconfigure it
+    watchdog = esp_task_wdt_reconfigure(&wdt_cfg);
+  }
+  #else
   esp_err_t watchdog = esp_task_wdt_init(WLED_WATCHDOG_TIMEOUT, true);
+  #endif
   DEBUG_PRINT(F("Watchdog enabled: "));
   if (watchdog == ESP_OK) {
     DEBUG_PRINTLN(F("OK"));

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -362,10 +362,9 @@ void WLED::loop()
 void WLED::enableWatchdog() {
   #ifdef ARDUINO_ARCH_ESP32
   #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-  // IDF v5: esp_task_wdt_init() takes a config struct, not (timeout, panic)
   esp_task_wdt_config_t wdt_cfg = {
     .timeout_ms = WLED_WATCHDOG_TIMEOUT * 1000,
-    .idle_core_mask = 0,       // don't subscribe idle tasks — only our loop task
+    .idle_core_mask = 0,       // only watch our loop task, not idle tasks
     .trigger_panic = true,
   };
   esp_err_t watchdog = esp_task_wdt_init(&wdt_cfg);


### PR DESCRIPTION
esp_task_wdt_init(timeout, panic) was removed in ESP-IDF 5.x. The new API takes an esp_task_wdt_config_t struct. Without this fix, the watchdog silently fails to initialise on IDF 5.x builds — the device will not reset on a hung loop task.

Fix: #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0) branch using esp_task_wdt_config_t, with fallback to the old two-argument API for IDF 4.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchdog compatibility and reliability on newer platform versions.
  * Added safer watchdog behavior, including configurable timeout and panic handling.
  * Ensured already active watchdogs are correctly updated when needed.
  * Preserved support for older platform versions.
  * Reduced unnecessary monitoring while maintaining expected system protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->