### PR TITLE
perf(ws): skip serializeInfo() on broadcast updates to save heap

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -625,6 +625,7 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
   #endif
 
   CJSON(arlsForceMaxBri, if_live[F("maxbri")]);
+  CJSON(wsBroadcastStateOnly, if_live[F("wsbso")]);
   CJSON(arlsDisableGammaCorrection, if_live[F("no-gc")]); // false
   CJSON(arlsOffset, if_live[F("offset")]); // 0
 
@@ -1156,6 +1157,7 @@ void serializeConfig(JsonObject root) {
 
   if_live[F("timeout")] = realtimeTimeoutMs / 100;
   if_live[F("maxbri")] = arlsForceMaxBri;
+  if_live[F("wsbso")] = wsBroadcastStateOnly;
   if_live[F("no-gc")] = arlsDisableGammaCorrection;
   if_live[F("offset")] = arlsOffset;
 

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -727,6 +727,11 @@ WLED_GLOBAL uint8_t tpmPacketCount _INIT(0);
 WLED_GLOBAL uint16_t tpmPayloadFrameSize _INIT(0);
 WLED_GLOBAL bool useMainSegmentOnly _INIT(false);
 WLED_GLOBAL bool realtimeRespectLedMaps _INIT(true);                     // Respect LED maps when receiving realtime data
+#ifndef WLED_WS_BROADCAST_STATE_ONLY
+WLED_GLOBAL bool wsBroadcastStateOnly _INIT(false);  // if true, omit info block from WS broadcast -- saves 4-6KB heap per push
+#else
+WLED_GLOBAL bool wsBroadcastStateOnly _INIT(WLED_WS_BROADCAST_STATE_ONLY);
+#endif
 
 WLED_GLOBAL unsigned long lastInterfaceUpdate _INIT(0);
 WLED_GLOBAL byte interfaceUpdateCallMode _INIT(CALL_MODE_INIT);

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -146,8 +146,15 @@ void sendDataWs(AsyncWebSocketClient * client)
 
   JsonObject state = pDoc->createNestedObject("state");
   serializeState(state);
-  JsonObject info  = pDoc->createNestedObject("info");
-  serializeInfo(info);
+  // Only include info block for targeted client responses (client != nullptr),
+  // i.e. initial connect (wsEvent WS_EVT_CONNECT) and individual state replies.
+  // Info is ~4-6KB of mostly-static data (version, MAC, WiFi, FS stats).
+  // Broadcast updates (client == nullptr) send state-only (~3-4KB),
+  // saving critical heap on constrained devices (ESP32-PICO-D4 WiFi+PPP).
+  if (client) {
+    JsonObject info  = pDoc->createNestedObject("info");
+    serializeInfo(info);
+  }
 
   size_t len = measureJson(*pDoc);
   DEBUG_PRINTF_P(PSTR("JSON buffer size: %u for WS request (%u).\n"), pDoc->memoryUsage(), len);

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -146,12 +146,7 @@ void sendDataWs(AsyncWebSocketClient * client)
 
   JsonObject state = pDoc->createNestedObject("state");
   serializeState(state);
-  // Only include info block for targeted client responses (client != nullptr),
-  // i.e. initial connect (wsEvent WS_EVT_CONNECT) and individual state replies.
-  // Info is ~4-6KB of mostly-static data (version, MAC, WiFi, FS stats).
-  // Broadcast updates (client == nullptr) send state-only (~3-4KB),
-  // saving critical heap on constrained devices (ESP32-PICO-D4 WiFi+PPP).
-  if (client) {
+  if (client) { // broadcasts omit info block (~4KB mostly-static data)
     JsonObject info  = pDoc->createNestedObject("info");
     serializeInfo(info);
   }

--- a/wled00/ws.cpp
+++ b/wled00/ws.cpp
@@ -146,7 +146,7 @@ void sendDataWs(AsyncWebSocketClient * client)
 
   JsonObject state = pDoc->createNestedObject("state");
   serializeState(state);
-  if (client) { // broadcasts omit info block (~4KB mostly-static data)
+  if (client || !wsBroadcastStateOnly) {
     JsonObject info  = pDoc->createNestedObject("info");
     serializeInfo(info);
   }


### PR DESCRIPTION
WebSocket broadcast updates (client == nullptr) send state+info JSON to all connected clients. The info block is ~4-6KB of mostly-static data (version, MAC, WiFi, FS stats) that clients need on connect but not on every state change.

Previous version of this PR made the omission unconditional. Review confirmed the native apps do consume the broadcast info block, so this rework makes it opt-in via a persistent cfg flag.

Fix: add `wsBroadcastStateOnly` bool (default false, persisted under `if.live.wsbso` in /json/cfg). When true, broadcasts send state-only; targeted responses (client != nullptr) always get state+info regardless. Compile-time default via `-D WLED_WS_BROADCAST_STATE_ONLY=1` for constrained builds.

Enable: `POST /json/cfg {"if":{"live":{"wsbso":true}}}`

Tested on M5StickC (ESP32-PICO-D4) over PPP at 1.5Mbaud: default behaviour unchanged, opt-in omits info block from broadcasts, targeted connect always receives state+info, flag survives reboot.