### PR TITLE
fix(audioreactive): skip i2s_set_clk() for PDM mode on IDF 5.x

### DIFF
--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -97,12 +97,14 @@
 #ifdef I2S_USE_RIGHT_CHANNEL
 #define I2S_MIC_CHANNEL I2S_CHANNEL_FMT_ONLY_RIGHT
 #define I2S_MIC_CHANNEL_TEXT "right channel only."
+#define I2S_PDM_MIC_CHANNEL I2S_CHANNEL_FMT_ALL_RIGHT
+#define I2S_PDM_MIC_CHANNEL_TEXT "right channel (ALL_RIGHT for PDM compat)."
 #else
 #define I2S_MIC_CHANNEL I2S_CHANNEL_FMT_ONLY_LEFT
 #define I2S_MIC_CHANNEL_TEXT "left channel only."
+#define I2S_PDM_MIC_CHANNEL I2S_CHANNEL_FMT_ALL_LEFT
+#define I2S_PDM_MIC_CHANNEL_TEXT "left channel (ALL_LEFT for PDM compat)."
 #endif
-#define I2S_PDM_MIC_CHANNEL I2S_MIC_CHANNEL
-#define I2S_PDM_MIC_CHANNEL_TEXT I2S_MIC_CHANNEL_TEXT
 
 #endif
 
@@ -294,11 +296,20 @@ class I2SSource : public AudioSource {
       }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
-      err = i2s_set_clk(I2S_NUM_0, _sampleRate, I2S_SAMPLE_RESOLUTION, I2S_CHANNEL_MONO);  // set bit clocks. Also takes care of MCLK routing if needed.
-      if (err != ESP_OK) {
-        DEBUGSR_PRINTF("AR: Failed to configure i2s clocks: %d\n", err);
-        i2s_driver_uninstall(I2S_NUM_0);  // uninstall already-installed driver
-        return;
+      // i2s_set_clk() recalculates clock dividers after driver install.
+      // On IDF 5.x, this KILLS PDM mode — produces all-zero samples.
+      // Confirmed: legacy-with-set_clk=silence, legacy-without=data.
+      // See: ESP-IDF #8850, #9635; WLED #4583.
+      // PDM clocks are fully configured by i2s_driver_install() — skip.
+      if (!(_config.mode & I2S_MODE_PDM)) {
+        err = i2s_set_clk(I2S_NUM_0, _sampleRate, I2S_SAMPLE_RESOLUTION, I2S_CHANNEL_MONO);
+        if (err != ESP_OK) {
+          DEBUGSR_PRINTF("AR: Failed to configure i2s clocks: %d\n", err);
+          i2s_driver_uninstall(I2S_NUM_0);
+          return;
+        }
+      } else {
+        DEBUGSR_PRINTLN(F("AR: PDM mode — skipping i2s_set_clk (IDF 5.x compat)."));
       }
 #endif
       _initialized = true;

--- a/usermods/audioreactive/audio_source.h
+++ b/usermods/audioreactive/audio_source.h
@@ -296,20 +296,13 @@ class I2SSource : public AudioSource {
       }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
-      // i2s_set_clk() recalculates clock dividers after driver install.
-      // On IDF 5.x, this KILLS PDM mode — produces all-zero samples.
-      // Confirmed: legacy-with-set_clk=silence, legacy-without=data.
-      // See: ESP-IDF #8850, #9635; WLED #4583.
-      // PDM clocks are fully configured by i2s_driver_install() — skip.
       if (!(_config.mode & I2S_MODE_PDM)) {
-        err = i2s_set_clk(I2S_NUM_0, _sampleRate, I2S_SAMPLE_RESOLUTION, I2S_CHANNEL_MONO);
+        err = i2s_set_clk(I2S_NUM_0, _sampleRate, I2S_SAMPLE_RESOLUTION, I2S_CHANNEL_MONO);  // set bit clocks. Also takes care of MCLK routing if needed.
         if (err != ESP_OK) {
           DEBUGSR_PRINTF("AR: Failed to configure i2s clocks: %d\n", err);
-          i2s_driver_uninstall(I2S_NUM_0);
+          i2s_driver_uninstall(I2S_NUM_0);  // uninstall already-installed driver
           return;
         }
-      } else {
-        DEBUGSR_PRINTLN(F("AR: PDM mode — skipping i2s_set_clk (IDF 5.x compat)."));
       }
 #endif
       _initialized = true;


### PR DESCRIPTION
i2s_set_clk() after i2s_driver_install() kills PDM mode on ESP-IDF 5.x, producing all-zero samples from the microphone. The PDM clock is configured during driver install; calling i2s_set_clk() afterwards resets it to I2S standard mode.

Fix: guard i2s_set_clk() with if (!(_config.mode & I2S_MODE_PDM)) so PDM microphones (SPM1423, INMP441 in PDM mode) work correctly on IDF 5.x.

Also fixes PDM channel format: uses I2S_CHANNEL_FMT_ALL_LEFT/ALL_RIGHT instead of ONLY_LEFT/ONLY_RIGHT, which is required for PDM compatibility on IDF 5.x (ONLY_* variants produce silence in PDM mode).

Tested on M5StickC with SPM1423 PDM microphone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDM microphone channel configuration for left and right channel modes.
  * Prevented unnecessary clock configuration during PDM audio initialization.
  * Preserved error handling when clock setup fails for non-PDM audio modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->