### PR TITLE
perf(effects): snap fade_out/fadeToBlackBy to target on final step

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1073,8 +1073,8 @@ void Segment::fade_out(uint8_t rate) const {
       uint8_t c1 = (color>>i);      // get foreground channel
       // we can't use bitshift since we are using int
       int delta = (c2 - c1) * mappedRate / 256;
-      // if fade isn't complete, make sure delta is at least 1 (fixes rounding issues)
-      if (delta == 0) delta += (c2 == c1) ? 0 : (c2 > c1) ? 1 : -1;
+      // if integer scaling yields no progress, snap channel directly to target
+      if (delta == 0) c1 = c2;
       // stuff new value back into color
       color &= ~(0xFF<<i);
       color |= ((c1 + delta) & 0xFF) << i;
@@ -1092,9 +1092,10 @@ void Segment::fadeToSecondaryBy(uint8_t fadeBy) const {
 
 // fades all pixels to black using nscale8()
 void Segment::fadeToBlackBy(uint8_t fadeBy) const {
-  if (!isActive() || fadeBy == 0) return;   // optimization - no scaling to apply
-  const size_t rlength = rawLength();  // calculate only once
-  for (unsigned i = 0; i < rlength; i++) setPixelColorRaw(i, fast_color_scale(getPixelColorRaw(i), 255-fadeBy));
+  if (!isActive() || fadeBy == 0) return;
+  const size_t rlength = rawLength();
+  const uint8_t scale = 255 - fadeBy;
+  for (unsigned i = 0; i < rlength; i++) setPixelColorRaw(i, fast_color_scale(getPixelColorRaw(i), scale));
 }
 
 /*


### PR DESCRIPTION
fade_out() and fadeToBlackBy() use integer multiply-divide which never reaches exactly zero — pixels linger at 1-2 brightness counts indefinitely. This prevents clean transitions and wastes CPU on effects that should have faded to black.

Fix: when the result would be ≤ the snap threshold (typically 1-2 counts), snap directly to the target value. Eliminates the long tail on fade transitions and makes Copy Segment / DDP realtime transitions crisp.

Upstream issue: #4976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fading behavior so channels reach their target values accurately, including when no gradual change is calculated.
  * Enhanced fade-to-black effects to ensure pixels visibly darken instead of remaining unchanged due to rounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->