### PR TITLE
Per-segment realtime eligibility mask

### DIFF
--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -75,7 +75,7 @@ private:
     
     uint8_t lineBuffer[w * 2];
 
-    if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) strip.service();
+    if (!realtimeMode || realtimeOverride || (realtimeMode && rtFrozenSegs)) strip.service();
 
     // 0,0 coordinates are top left
     for (row = 0; row < h; row++) {
@@ -169,7 +169,7 @@ private:
     uint32_t lineSize = ((bitDepth * w +31) >> 5) * 4;
     uint8_t lineBuffer[lineSize];
     
-    uint8_t serviceStrip = (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) ? 7 : 0;
+    uint8_t serviceStrip = (!realtimeMode || realtimeOverride || (realtimeMode && rtFrozenSegs)) ? 7 : 0;
     // row is decremented as the BMP image is drawn bottom up
     for (row = h-1; row >= 0; row--) {
       if ((row & 0b00000111) == serviceStrip) strip.service(); //still refresh backlight to mitigate stutter every few rows
@@ -250,7 +250,7 @@ private:
     
     uint8_t lineBuffer[w * 2];
     
-    if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) strip.service();
+    if (!realtimeMode || realtimeOverride || (realtimeMode && rtFrozenSegs)) strip.service();
 
     // 0,0 coordinates are top left
     for (row = 0; row < h; row++) {

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1579,8 +1579,8 @@ class AudioReactive : public Usermod {
       if (strip.isUpdating() && (millis() - lastUMRun < 2)) return;   // be nice, but not too nice
 
       // suspend local sound processing when "real time mode" is active (E131, UDP, ADALIGHT, ARTNET, DDP, DMX)
-      //  exception: sound input is still needed when useMainSegmentOnly - other segments are still running with local input.
-      if (realtimeMode && !realtimeOverride && !useMainSegmentOnly) {
+      //  exception: sound input is still needed when only some segments are frozen - other segments are still running with local input.
+      if (realtimeMode && !realtimeOverride && !rtFrozenSegs) {
         #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DEBUG)
         if ((disableSoundProcessing == false) && (audioSyncEnabled == 0)) {  // we just switched to "disabled"
           DEBUG_PRINTLN(F("[AR userLoop]  realtime mode active - audio processing suspended."));

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -890,6 +890,7 @@ class WS2812FX {
       fixInvalidSegments(),                       // fixes incorrect segment configuration
       blendSegment(const Segment &topSegment) const,    // blends topSegment into pixels
       show(),                                     // initiates LED output
+      showFrozenSegs(),                           // fast-path show for DDP realtime: bypasses full _pixels[] pipeline when rtFrozenSegs is set
       setTargetFps(unsigned fps),
       setupEffectData(),                          // add default effects to the list; defined in FX.cpp
       waitForIt();                                // wait until frame is over (service() has finished or time for 1 frame has passed)

--- a/wled00/FX_2Dfcn.cpp
+++ b/wled00/FX_2Dfcn.cpp
@@ -478,13 +478,13 @@ void Segment::drawCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
         setPixelColorXY(cx + dx, cy + dy, col);
         setPixelColorXY(cx + dy, cy + dx, col);
     }
-      x++;
       if (d > 0) {
-        y--;
         d += 4 * (x - y) + 10;
+        y--;
       } else {
         d += 4 * x + 6;
       }
+      x++;
     }
   }
 }
@@ -497,9 +497,10 @@ void Segment::fillCircle(uint16_t cx, uint16_t cy, uint8_t radius, uint32_t col,
   // draw soft bounding circle
   if (soft) drawCircle(cx, cy, radius, col, soft);
   // fill it
+  int radius2 = soft ? radius * radius : radius * radius + radius;  // (r+0.5)^2 = r*r + r + 0.25; use exact radius for "soft" circle to stay compatible with Wu’s algorithm
   for (int y = -radius; y <= radius; y++) {
     for (int x = -radius; x <= radius; x++) {
-      if (x * x + y * y <= radius * radius &&
+      if (x * x + y * y < radius2 &&
           int(cx)+x >= 0 && int(cy)+y >= 0 &&
           int(cx)+x < vW && int(cy)+y < vH)
         setPixelColorXY(cx + x, cy + y, col);

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1871,8 +1871,21 @@ void WS2812FX::showFrozenSegs() {
 
 void WS2812FX::setRealtimePixelColor(unsigned i, uint32_t c) {
   if (rtFrozenSegs) {
-    const Segment &seg = getMainSegment();
-    if (seg.isActive() && i < seg.length()) seg.setPixelColorRaw(i, c);
+    if (ddpSlotCount > 0) {
+      // route through slot table so non-main eligible segments get pixels
+      for (uint8_t s = 0; s < ddpSlotCount; s++) {
+        const DdpSegSlot &slot = ddpSlots[s];
+        if (i < slot.globalStart + slot.length) {
+          Segment &seg = getSegment(slot.segId);
+          if (seg.isActive()) seg.setPixelColorRaw(i - slot.globalStart, c);
+          return;
+        }
+      }
+    } else {
+      // legacy: no slot table, write to main segment
+      const Segment &seg = getMainSegment();
+      if (seg.isActive() && i < seg.length()) seg.setPixelColorRaw(i, c);
+    }
   } else {
     setPixelColor(i, c);
   }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1821,19 +1821,28 @@ void WS2812FX::showFrozenSegs() {
   const bool is2D = (Segment::maxHeight > 1);
   const uint16_t mw = Segment::maxWidth;
 
+  // row-stride aware paint: flat segPixStart+i is wrong when seg.width() < maxWidth
+  const auto paintSeg = [&](const Segment &seg, unsigned maxLen) {
+    const unsigned w = seg.stop  - seg.start;
+    const unsigned h = seg.stopY - seg.startY;
+    unsigned i = 0;
+    for (unsigned r = 0; r < h && i < maxLen; r++) {
+      const unsigned rowStart = is2D ? (unsigned)(seg.startY + r) * mw + seg.start : seg.start;
+      for (unsigned x = 0; x < w && i < maxLen; x++, i++) {
+        uint32_t c = seg.pixels[i];
+        if (c && useGamma) c = gamma32(c);
+        BusManager::setPixelColor(getMappedPixelIndex(rowStart + x), c);
+      }
+    }
+  };
+
   if (__builtin_popcount(rtFrozenSegs) == 1) {
     // Case B: single frozen segment -- walk seg.pixels[] directly
     unsigned segIdx = __builtin_ctz(rtFrozenSegs);
     if (segIdx < _segments.size()) {
       const Segment &seg = _segments[segIdx];
       if (seg.isActive() && seg.pixels) {
-        uint16_t segPixStart = is2D ? (uint16_t)seg.startY * mw + seg.start : seg.start;
-        unsigned segLen = seg.length();
-        for (unsigned i = 0; i < segLen; i++) {
-          uint32_t c = seg.pixels[i];
-          if (c && useGamma) c = gamma32(c);
-          BusManager::setPixelColor(getMappedPixelIndex(segPixStart + i), c);
-        }
+        paintSeg(seg, seg.length());
       }
     }
   } else {
@@ -1844,13 +1853,7 @@ void WS2812FX::showFrozenSegs() {
       if (slot.segId >= _segments.size()) continue;
       const Segment &seg = _segments[slot.segId];
       if (!seg.isActive() || !seg.pixels) continue;
-      uint16_t segPixStart = is2D ? (uint16_t)seg.startY * mw + seg.start : seg.start;
-      unsigned len = min((unsigned)slot.length, (unsigned)seg.length());
-      for (unsigned i = 0; i < len; i++) {
-        uint32_t c = seg.pixels[i];
-        if (c && useGamma) c = gamma32(c);
-        BusManager::setPixelColor(getMappedPixelIndex(segPixStart + i), c);
-      }
+      paintSeg(seg, min((unsigned)slot.length, (unsigned)seg.length()));
     }
   }
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1801,12 +1801,12 @@ void WS2812FX::showFrozenSegs() {
   if (!_pixels || !rtFrozenSegs) { show(); return; }
 
   uint32_t allActiveMask = 0;
-  for (unsigned i = 0; i < _segments.size(); i++)
+  for (unsigned i = 0; i < _segments.size() && i < 32; i++)
     if (_segments[i].isActive()) allActiveMask |= (1u << i);
 
   // Case D: effect segments running -- service() calls show(); calling it here too
   // would double-show per iteration, hanging TFT SPI DMA.
-  for (unsigned i = 0; i < _segments.size(); i++) {
+  for (unsigned i = 0; i < _segments.size() && i < 32; i++) {
     if (!(allActiveMask & (1u << i))) continue;
     if (rtFrozenSegs & (1u << i)) continue;
     if (_segments[i].on && !_segments[i].freeze) { show(); return; }

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -632,10 +632,14 @@ Segment &Segment::setName(const char *newName) {
   if (newName) {
     const int newLen = min(strlen(newName), (size_t)WLED_MAX_SEGNAME_LEN);
     if (newLen) {
-      if (name) p_free(name); // free old name
-      name = static_cast<char*>(allocate_buffer(newLen+1, BFRALLOC_PREFER_PSRAM));
-      if (mode == FX_MODE_2DSCROLLTEXT) startTransition(strip.getTransition(), true); // if the name changes in scrolling text mode, we need to copy the segment for blending
-      if (name) strlcpy(name, newName, newLen+1);
+      char *newBuf = static_cast<char*>(allocate_buffer(newLen+1, BFRALLOC_PREFER_PSRAM));
+      if (newBuf) {
+        strlcpy(newBuf, newName, newLen+1);
+        if (mode == FX_MODE_2DSCROLLTEXT) startTransition(strip.getTransition(), true); // if the name changes in scrolling text mode, we need to copy the segment for blending
+        char *oldName = name;
+        name = newBuf;
+        if (oldName) p_free(oldName);
+      }
       return *this;
     }
   }
@@ -1359,7 +1363,7 @@ void WS2812FX::service() {
   #ifdef WLED_DEBUG
   if ((_targetFps != FPS_UNLIMITED) && (millis() - nowUp > _frametime)) DEBUG_PRINTF_P(PSTR("Slow effects %u/%d.\n"), (unsigned)(millis()-nowUp), (int)_frametime);
   #endif
-  if (doShow && !_suspend) {
+  if (doShow && !_suspend && !rtFrozenSegs) {
     yield();
     Segment::handleRandomPalette(); // slowly transition random palette; move it into for loop when each segment has individual random palette
     _lastServiceShow = nowUp; // update timestamp, for precise FPS control
@@ -1741,7 +1745,7 @@ void WS2812FX::show() {
     _pixelCCT = static_cast<uint8_t*>(allocate_buffer(totalLen * sizeof(uint8_t), BFRALLOC_PREFER_PSRAM)); // allocate CCT buffer if necessary, prefer PSRAM
   if (_pixelCCT) memset(_pixelCCT, 127, totalLen); // set neutral (50:50) CCT
 
-  if (realtimeMode == REALTIME_MODE_INACTIVE || useMainSegmentOnly || realtimeOverride > REALTIME_OVERRIDE_NONE) {
+  if (realtimeMode == REALTIME_MODE_INACTIVE || rtFrozenSegs || realtimeOverride > REALTIME_OVERRIDE_NONE) {
     // clear frame buffer
     memset(_pixels, 0, sizeof(uint32_t) * totalLen);
     // blend all segments into (cleared) buffer
@@ -1790,8 +1794,80 @@ void WS2812FX::show() {
   }
 }
 
+// Fast-path show for DDP realtime: walks frozen segment pixel buffers directly into
+// BusManager::setPixelColor(), bypassing the full _pixels[] pipeline.
+// Cases: B=single frozen seg, C=multi-slot sparse paint via ddpSlots[], D=effects running.
+void WS2812FX::showFrozenSegs() {
+  if (!_pixels || !rtFrozenSegs) { show(); return; }
+
+  uint32_t allActiveMask = 0;
+  for (unsigned i = 0; i < _segments.size(); i++)
+    if (_segments[i].isActive()) allActiveMask |= (1u << i);
+
+  // Case D: effect segments running -- service() calls show(); calling it here too
+  // would double-show per iteration, hanging TFT SPI DMA.
+  for (unsigned i = 0; i < _segments.size(); i++) {
+    if (!(allActiveMask & (1u << i))) continue;
+    if (rtFrozenSegs & (1u << i)) continue;
+    if (_segments[i].on && !_segments[i].freeze) { show(); return; }
+  }
+
+  // Cases B and C: only frozen segments are active -- fast path
+  unsigned long showNow = millis();
+  size_t diff = showNow - _lastShow;
+
+  bool useGamma = gammaCorrectCol && !(realtimeMode && arlsDisableGammaCorrection && !realtimeOverride);
+
+  const bool is2D = (Segment::maxHeight > 1);
+  const uint16_t mw = Segment::maxWidth;
+
+  if (__builtin_popcount(rtFrozenSegs) == 1) {
+    // Case B: single frozen segment -- walk seg.pixels[] directly
+    unsigned segIdx = __builtin_ctz(rtFrozenSegs);
+    if (segIdx < _segments.size()) {
+      const Segment &seg = _segments[segIdx];
+      if (seg.isActive() && seg.pixels) {
+        uint16_t segPixStart = is2D ? (uint16_t)seg.startY * mw + seg.start : seg.start;
+        unsigned segLen = seg.length();
+        for (unsigned i = 0; i < segLen; i++) {
+          uint32_t c = seg.pixels[i];
+          if (c && useGamma) c = gamma32(c);
+          BusManager::setPixelColor(getMappedPixelIndex(segPixStart + i), c);
+        }
+      }
+    }
+  } else {
+    // Case C: multiple frozen segments -- sparse paint via ddpSlots[]
+    for (uint8_t s = 0; s < ddpSlotCount; s++) {
+      const DdpSegSlot &slot = ddpSlots[s];
+      if (!(rtFrozenSegs & (1u << slot.segId))) continue;
+      if (slot.segId >= _segments.size()) continue;
+      const Segment &seg = _segments[slot.segId];
+      if (!seg.isActive() || !seg.pixels) continue;
+      uint16_t segPixStart = is2D ? (uint16_t)seg.startY * mw + seg.start : seg.start;
+      unsigned len = min((unsigned)slot.length, (unsigned)seg.length());
+      for (unsigned i = 0; i < len; i++) {
+        uint32_t c = seg.pixels[i];
+        if (c && useGamma) c = gamma32(c);
+        BusManager::setPixelColor(getMappedPixelIndex(segPixStart + i), c);
+      }
+    }
+  }
+
+  // _pixels[] zeroed -- fast path writes bus buffers directly, not _pixels[].
+  if (_pixels) memset(_pixels, 0, sizeof(uint32_t) * getLengthTotal());
+
+  BusManager::show();
+
+  if (diff > 0) {
+    size_t fpsCurr = (1000 << FPS_CALC_SHIFT) / diff;
+    _cumulativeFps = (FPS_CALC_AVG * _cumulativeFps + fpsCurr + FPS_CALC_AVG / 2) / (FPS_CALC_AVG + 1);
+    _lastShow = showNow;
+  }
+}
+
 void WS2812FX::setRealtimePixelColor(unsigned i, uint32_t c) {
-  if (useMainSegmentOnly) {
+  if (rtFrozenSegs) {
     const Segment &seg = getMainSegment();
     if (seg.isActive() && i < seg.length()) seg.setPixelColorRaw(i, c);
   } else {

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -597,7 +597,13 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   JsonObject if_live = interfaces["live"];
   CJSON(receiveDirect, if_live["en"]);  // UDP/Hyperion realtime
-  CJSON(useMainSegmentOnly, if_live[F("mso")]);
+  {
+    bool mso = false;
+    CJSON(mso, if_live[F("mso")]);
+    if (mso) ddpEligibleMask = (1UL << strip.getMainSegmentId()); // backwards compat
+  }
+  CJSON(ddpEligibleMask, if_live[F("ddpelig")]);
+  rebuildDdpSlots();
   CJSON(realtimeRespectLedMaps, if_live[F("rlm")]);
   CJSON(e131Port, if_live["port"]); // 5568
   if (e131Port == DDP_DEFAULT_PORT) e131Port = E131_DEFAULT_PORT; // prevent double DDP port allocation
@@ -1135,7 +1141,8 @@ void serializeConfig(JsonObject root) {
 
   JsonObject if_live = interfaces.createNestedObject("live");
   if_live["en"] = receiveDirect; // UDP/Hyperion realtime
-  if_live[F("mso")] = useMainSegmentOnly;
+  if_live[F("mso")] = (ddpEligibleMask != 0); // backwards compat
+  if_live[F("ddpelig")] = ddpEligibleMask;
   if_live[F("rlm")] = realtimeRespectLedMaps;
   if_live["port"] = e131Port;
   if_live[F("mc")] = e131Multicast;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -92,6 +92,7 @@ static void handleDDPPacket(e131_packet_t* p, size_t packetLen) {
       // Mode B: distribute flat stream across eligible segments via slot table
       for (uint8_t s = 0; s < ddpSlotCount; s++) {
         DdpSegSlot &slot = ddpSlots[s];
+        if (slot.segId >= strip.getSegmentsNum()) continue; // stale slot after segment removal
         if (start >= slot.globalStart + slot.length) continue;
         if (stop <= slot.globalStart) break;
         unsigned oStart = (start > slot.globalStart) ? start : slot.globalStart;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -81,22 +81,15 @@ static void handleDDPPacket(e131_packet_t* p, size_t packetLen) {
   }
 
   if (realtimeMode != REALTIME_MODE_DDP) ddpSeenPush = false; // just starting, no push yet
-  // Freeze eligible segments BEFORE realtimeLock() so rtFrozenSegs is set
+  // Hoist routing decision before freeze+lock so rtFrozenSegs is set
   // when realtimeLock() checks whether to do legacy strip.fill(BLACK)
-  {
-    uint8_t dest = p->destination;
-    if (ddpSlotCount > 0 && dest == 0) {
-      freezeEligibleSegs();
-    }
-  }
+  const bool useSlotRouting = (ddpSlotCount > 0 && p->destination == 0);
+  if (useSlotRouting) freezeEligibleSegs();
   realtimeLock(realtimeTimeoutMs, REALTIME_MODE_DDP);
 
   if (!realtimeOverride) {
-    uint8_t dest = p->destination;
-
-    if (ddpSlotCount > 0 && dest == 0) {
+    if (useSlotRouting) {
       // Mode B: distribute flat stream across eligible segments via slot table
-      freezeEligibleSegs();
       for (uint8_t s = 0; s < ddpSlotCount; s++) {
         DdpSegSlot &slot = ddpSlots[s];
         if (start >= slot.globalStart + slot.length) continue;

--- a/wled00/e131.cpp
+++ b/wled00/e131.cpp
@@ -81,11 +81,41 @@ static void handleDDPPacket(e131_packet_t* p, size_t packetLen) {
   }
 
   if (realtimeMode != REALTIME_MODE_DDP) ddpSeenPush = false; // just starting, no push yet
+  // Freeze eligible segments BEFORE realtimeLock() so rtFrozenSegs is set
+  // when realtimeLock() checks whether to do legacy strip.fill(BLACK)
+  {
+    uint8_t dest = p->destination;
+    if (ddpSlotCount > 0 && dest == 0) {
+      freezeEligibleSegs();
+    }
+  }
   realtimeLock(realtimeTimeoutMs, REALTIME_MODE_DDP);
 
   if (!realtimeOverride) {
-    for (unsigned i = start; i < stop; i++, c += ddpChannelsPerLed) {
-      setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed >3 ? data[c+3] : 0);
+    uint8_t dest = p->destination;
+
+    if (ddpSlotCount > 0 && dest == 0) {
+      // Mode B: distribute flat stream across eligible segments via slot table
+      freezeEligibleSegs();
+      for (uint8_t s = 0; s < ddpSlotCount; s++) {
+        DdpSegSlot &slot = ddpSlots[s];
+        if (start >= slot.globalStart + slot.length) continue;
+        if (stop <= slot.globalStart) break;
+        unsigned oStart = (start > slot.globalStart) ? start : slot.globalStart;
+        unsigned oEnd = (stop < (unsigned)(slot.globalStart + slot.length)) ? stop : (slot.globalStart + slot.length);
+        Segment &seg = strip.getSegment(slot.segId);
+        unsigned di = c + (oStart - start) * ddpChannelsPerLed;
+        for (unsigned g = oStart; g < oEnd; g++, di += ddpChannelsPerLed) {
+          unsigned local = g - slot.globalStart;
+          uint32_t col = RGBW32(data[di], data[di+1], data[di+2], ddpChannelsPerLed > 3 ? data[di+3] : 0);
+          seg.setRawPixelColor(local, col);
+        }
+      }
+    } else {
+      // Legacy: full-strip absolute pixel indexing (backwards compatible)
+      for (unsigned i = start; i < stop; i++, c += ddpChannelsPerLed) {
+        setRealtimePixel(i, data[c], data[c+1], data[c+2], ddpChannelsPerLed > 3 ? data[c+3] : 0);
+      }
     }
   }
 

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -390,8 +390,10 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     for (size_t s=0; s < strip.getSegmentsNum(); s++) {
       strip.getSegment(s).freeze = false;
     }
-    if (realtimeMode && !realtimeOverride && useMainSegmentOnly) { // keep live segment frozen if live
-      strip.getMainSegment().freeze = true;
+    if (realtimeMode && !realtimeOverride && rtFrozenSegs) { // keep frozen segments frozen if live
+      for (uint8_t i = 0; i < strip.getSegmentsNum() && i < 32; i++) {
+        if (rtFrozenSegs & (1UL << i)) strip.getSegment(i).freeze = true;
+      }
     }
   }
 
@@ -443,9 +445,11 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 
   realtimeOverride = root[F("lor")] | realtimeOverride;
   if (realtimeOverride > 2) realtimeOverride = REALTIME_OVERRIDE_ALWAYS;
-  if (realtimeMode && useMainSegmentOnly) {
-    strip.getMainSegment().freeze = !realtimeOverride;
-    realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using main segment only
+  if (realtimeMode && rtFrozenSegs) {
+    for (uint8_t i = 0; i < strip.getSegmentsNum() && i < 32; i++) {
+      if (rtFrozenSegs & (1UL << i)) strip.getSegment(i).freeze = !realtimeOverride;
+    }
+    realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if frozen segments active
   }
 
   if (root.containsKey("live")) {
@@ -487,6 +491,7 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
       if (strip.getSegmentsNum() > 3 && deleted >= strip.getSegmentsNum()/2U) strip.purgeSegments(); // batch deleting more than half segments
     }
     strip.resume();
+    rebuildDdpSlots(); // segment geometry changed; update Mode B offset table
   }
   // reset segment request
   if (root[F("rSeg")] | false) {
@@ -769,7 +774,7 @@ void serializeInfo(JsonObject root)
   root[F("udpport")] = udpPort;
   root[F("simplifiedui")] = simplifiedUI;
   root["live"] = (bool)realtimeMode;
-  root[F("liveseg")] = useMainSegmentOnly ? strip.getMainSegmentId() : -1;  // if using main segment only for live
+  root[F("liveseg")] = rtFrozenSegs ? (int)__builtin_ctz(rtFrozenSegs) : -1;  // first frozen segment, or -1 if none
 
   switch (realtimeMode) {
     case REALTIME_MODE_INACTIVE: root["lm"] = ""; break;
@@ -785,6 +790,9 @@ void serializeInfo(JsonObject root)
   }
 
   root[F("lip")] = realtimeIP[0] == 0 ? "" : realtimeIP.toString();
+  root[F("ddpelig")] = ddpEligibleMask;
+  root[F("ddpslots")] = ddpSlotCount;
+  root[F("frozensegs")] = rtFrozenSegs;
 
   #ifdef WLED_ENABLE_WEBSOCKETS
   root[F("ws")] = ws.count();

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -472,7 +472,12 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     nodeBroadcastEnabled = request->hasArg(F("NB"));
 
     receiveDirect = request->hasArg(F("RD")); // UDP realtime
-    ddpEligibleMask = request->hasArg(F("MO")) ? (1UL << strip.getMainSegmentId()) : 0; rebuildDdpSlots();
+    if (request->hasArg(F("MO"))) {
+      if (!ddpEligibleMask) ddpEligibleMask = (1UL << strip.getMainSegmentId());
+    } else {
+      ddpEligibleMask &= ~(1UL << strip.getMainSegmentId());
+    }
+    rebuildDdpSlots();
     realtimeRespectLedMaps = request->hasArg(F("RLM"));
     e131SkipOutOfSequence = request->hasArg(F("ES"));
     e131Multicast = request->hasArg(F("EM"));

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -472,7 +472,7 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     nodeBroadcastEnabled = request->hasArg(F("NB"));
 
     receiveDirect = request->hasArg(F("RD")); // UDP realtime
-    useMainSegmentOnly = request->hasArg(F("MO"));
+    ddpEligibleMask = request->hasArg(F("MO")) ? (1UL << strip.getMainSegmentId()) : 0; rebuildDdpSlots();
     realtimeRespectLedMaps = request->hasArg(F("RLM"));
     e131SkipOutOfSequence = request->hasArg(F("ES"));
     e131Multicast = request->hasArg(F("EM"));
@@ -1265,9 +1265,9 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   if (pos > 0) {
     realtimeOverride = getNumVal(req, pos);
     if (realtimeOverride > 2) realtimeOverride = REALTIME_OVERRIDE_ALWAYS;
-    if (realtimeMode && useMainSegmentOnly) {
+    if (realtimeMode && ddpEligibleMask) {
       strip.getMainSegment().freeze = !realtimeOverride;
-      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using main segment only
+      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if eligible segments are frozen
     }
   }
 

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -1270,9 +1270,11 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   if (pos > 0) {
     realtimeOverride = getNumVal(req, pos);
     if (realtimeOverride > 2) realtimeOverride = REALTIME_OVERRIDE_ALWAYS;
-    if (realtimeMode && ddpEligibleMask) {
-      strip.getMainSegment().freeze = !realtimeOverride;
-      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if eligible segments are frozen
+    if (realtimeMode && rtFrozenSegs) {
+      for (unsigned i = 0; i < strip.getSegmentsNum() && i < 32; i++) {
+        if (rtFrozenSegs & (1UL << i)) strip.getSegment(i).freeze = !realtimeOverride;
+      }
+      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if frozen segments active
     }
   }
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -475,7 +475,7 @@ void exitRealtime() {
   realtimeIP[0] = 0;
   if (rtFrozenSegs) { // unfreeze live segment(s) again
     for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
-      strip.getSegment(s).freeze = false;
+      if (rtFrozenSegs & (1UL << s)) strip.getSegment(s).freeze = false;
     }
     rtFrozenSegs = 0;
     strip.trigger();

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -443,8 +443,8 @@ void realtimeLock(uint32_t timeoutMs, byte md)
       freezeEligibleSegs();
       // if WLED is off, freeze non-eligible segments too so they stay dark
       if (bri == 0) {
-        for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
-          if (!(rtFrozenSegs & (1UL << s))) { strip.getSegment(s).freeze = true; if (s < 32) rtFrozenSegs |= (1UL << s); }
+        for (size_t s = 0; s < strip.getSegmentsNum() && s < 32; s++) {
+          if (!(rtFrozenSegs & (1UL << s))) freezeSegForRealtime(s); // clear + freeze + track
         }
       }
     } else {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -404,21 +404,51 @@ static void parseNotifyPacket(const uint8_t *udpIn) {
   stateUpdated(CALL_MODE_NOTIFICATION);
 }
 
+void rebuildDdpSlots() {
+  ddpSlotCount = 0;
+  ddpTotalEligible = 0;
+  for (uint8_t i = 0; i < strip.getSegmentsNum() && i < 32; i++) {
+    if (!(ddpEligibleMask & (1UL << i))) continue;
+    Segment &seg = strip.getSegment(i);
+    if (seg.stop <= seg.start) continue; // skip degenerate/unset segments
+    DdpSegSlot &slot = ddpSlots[ddpSlotCount++];
+    slot.segId = i;
+    slot.globalStart = ddpTotalEligible;
+    slot.length = seg.length();
+    ddpTotalEligible += slot.length;
+  }
+}
+
+void freezeSegForRealtime(uint8_t segId) {
+  if (segId >= strip.getSegmentsNum()) return;
+  if (rtFrozenSegs & (1UL << segId)) return; // already frozen
+  Segment &seg = strip.getSegment(segId);
+  if (!seg.isActive()) return;
+  seg.clear();
+  seg.freeze = true;
+  rtFrozenSegs |= (1UL << segId);
+}
+
+void freezeEligibleSegs() {
+  for (uint8_t s = 0; s < ddpSlotCount; s++)
+    freezeSegForRealtime(ddpSlots[s].segId);
+}
+
 // realtimeLock() is called from UDP notifications, JSON API or serial Ada
 void realtimeLock(uint32_t timeoutMs, byte md)
 {
   if (!realtimeMode && !realtimeOverride) {
-    if (useMainSegmentOnly) {
-      Segment& mainseg = strip.getMainSegment();
-      mainseg.clear(); // clear entire segment (in case sender transmits less pixels)
-      mainseg.freeze = true;
-      // if WLED was off and using main segment only, freeze non-main segments so they stay off
+    if (ddpSlotCount > 0) {
+      // per-segment mode: freeze eligible segments immediately
+      freezeEligibleSegs();
+      // if WLED is off, freeze non-eligible segments too so they stay dark
       if (bri == 0) {
-        for (size_t s = 0; s < strip.getSegmentsNum(); s++) strip.getSegment(s).freeze = true;
+        for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+          if (!(rtFrozenSegs & (1UL << s))) strip.getSegment(s).freeze = true;
+        }
       }
     } else {
-      // clear entire strip
-      strip.fill(BLACK);
+      strip.fill(BLACK); // clear entire strip
     }
     // if strip is off (bri==0) and not already in RTM
     if (briT == 0) {
@@ -443,8 +473,11 @@ void exitRealtime() {
   realtimeTimeout = 0; // cancel realtime mode immediately
   realtimeMode = REALTIME_MODE_INACTIVE; // inform UI immediately
   realtimeIP[0] = 0;
-  if (useMainSegmentOnly) { // unfreeze live segment again
-    strip.getMainSegment().freeze = false;
+  if (rtFrozenSegs) { // unfreeze live segment(s) again
+    for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+      strip.getSegment(s).freeze = false;
+    }
+    rtFrozenSegs = 0;
     strip.trigger();
   } else {
     strip.show(); // possible fix for #3589
@@ -475,7 +508,7 @@ void handleNotifications()
   if (e131NewData && millis() - strip.getLastShow() > 15)
   {
     e131NewData = false;
-    if (useMainSegmentOnly) strip.trigger();
+    if (rtFrozenSegs) strip.showFrozenSegs();
     else                    strip.show();
   }
 
@@ -508,7 +541,7 @@ void handleNotifications()
       for (size_t i = 0, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++) {
         setRealtimePixel(id, lbuf[i], lbuf[i+1], lbuf[i+2], 0);
       }
-      if (useMainSegmentOnly) strip.trigger();
+      if (rtFrozenSegs) strip.showFrozenSegs();
       else                    strip.show();
       return;
     }
@@ -592,7 +625,7 @@ void handleNotifications()
       }
       if (tpmPacketCount == numPackets) { //reset packet count and show if all packets were received
         tpmPacketCount = 0;
-        if (useMainSegmentOnly) strip.trigger();
+        if (rtFrozenSegs) strip.showFrozenSegs();
         else                    strip.show();
       }
       return;
@@ -637,7 +670,7 @@ void handleNotifications()
           setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
         }
       }
-      if (useMainSegmentOnly) strip.trigger();
+      if (rtFrozenSegs) strip.showFrozenSegs();
       else                    strip.show();
       return;
     }

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -444,7 +444,7 @@ void realtimeLock(uint32_t timeoutMs, byte md)
       // if WLED is off, freeze non-eligible segments too so they stay dark
       if (bri == 0) {
         for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
-          if (!(rtFrozenSegs & (1UL << s))) strip.getSegment(s).freeze = true;
+          if (!(rtFrozenSegs & (1UL << s))) { strip.getSegment(s).freeze = true; if (s < 32) rtFrozenSegs |= (1UL << s); }
         }
       }
     } else {

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -462,7 +462,7 @@ void realtimeLock(uint32_t timeoutMs, byte md)
   realtimeMode = md;
 
   if (realtimeOverride) return;
-  if (arlsForceMaxBri) strip.setBrightness(255, true);
+  if (arlsForceMaxBri) strip.setBrightness(255, true); // global -- affects non-frozen effect segments in Mode B
   if (briT > 0 && md == REALTIME_MODE_GENERIC) strip.show();
 }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -128,7 +128,7 @@ void WLED::loop()
   #ifdef WLED_DEBUG
   stripMillis = millis();
   #endif
-  if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly))  // block stuff if WARLS/Adalight is enabled
+  if (!realtimeMode || realtimeOverride || (realtimeMode && rtFrozenSegs))  // block stuff if WARLS/Adalight is enabled
   {
     if (apActive) dnsServer.processNextRequest();
     #ifdef WLED_ENABLE_AOTA
@@ -149,13 +149,27 @@ void WLED::loop()
     handlePresets();
     yield();
 
-    if (!offMode || strip.isOffRefreshRequired() || strip.needsUpdate())
+    // Skip strip.service() when all active segments are DDP-frozen:
+    // showFrozenSegs() in handleNotifications() drives the show at full speed.
+    bool allSegsFrozenByDDP = false;
+    if (realtimeMode && rtFrozenSegs) {
+      uint32_t activeMask = 0;
+      for (unsigned _i = 0; _i < strip.getSegmentsNum(); _i++) {
+        const Segment &_seg = strip.getSegment(_i);
+      if (_seg.isActive() && _seg.on) activeMask |= (1u << _i);
+      }
+      allSegsFrozenByDDP = activeMask && ((rtFrozenSegs & activeMask) == activeMask);
+    }
+    if (!allSegsFrozenByDDP && (!offMode || strip.isOffRefreshRequired() || strip.needsUpdate()))
       strip.service();
     #ifdef ESP8266
-    else if (!noWifiSleep)
+    else if (!noWifiSleep && !allSegsFrozenByDDP)
       delay(1); //required to make sure ESP enters modem sleep (see #1184)
     #endif
   }
+  // Safety net: exit realtime if timeout expired (backup for handleNotifications check)
+  if (realtimeMode && millis() > realtimeTimeout) exitRealtime();
+
   #ifdef WLED_DEBUG
   stripMillis = millis() - stripMillis;
   avgStripMillis += stripMillis;
@@ -539,6 +553,7 @@ void WLED::setup()
 
   DEBUG_PRINTLN(F("Initializing strip"));
   beginStrip();
+  rebuildDdpSlots(); // refresh after strip init in case segment count changed
   DEBUG_PRINTF_P(PSTR("heap %u\n"), getFreeHeapSize());
 
   DEBUG_PRINTLN(F("Usermods setup"));

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -154,9 +154,9 @@ void WLED::loop()
     bool allSegsFrozenByDDP = false;
     if (realtimeMode && rtFrozenSegs) {
       uint32_t activeMask = 0;
-      for (unsigned _i = 0; _i < strip.getSegmentsNum(); _i++) {
+      for (unsigned _i = 0; _i < strip.getSegmentsNum() && _i < 32; _i++) {
         const Segment &_seg = strip.getSegment(_i);
-      if (_seg.isActive() && _seg.on) activeMask |= (1u << _i);
+        if (_seg.isActive() && _seg.on) activeMask |= (1u << _i);
       }
       allSegsFrozenByDDP = activeMask && ((rtFrozenSegs & activeMask) == activeMask);
     }

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -725,7 +725,23 @@ WLED_GLOBAL IPAddress realtimeIP _INIT_N(((0, 0, 0, 0)));
 WLED_GLOBAL unsigned long realtimeTimeout _INIT(0);
 WLED_GLOBAL uint8_t tpmPacketCount _INIT(0);
 WLED_GLOBAL uint16_t tpmPayloadFrameSize _INIT(0);
-WLED_GLOBAL bool useMainSegmentOnly _INIT(false);
+// DDP per-segment targeting (replaces useMainSegmentOnly)
+WLED_GLOBAL uint32_t ddpEligibleMask _INIT(0);                           // bitmask of segments accepting concatenated DDP
+WLED_GLOBAL uint32_t rtFrozenSegs    _INIT(0);                           // which segments are currently frozen by realtime
+
+struct DdpSegSlot {
+  uint8_t  segId;        // segment index
+  uint16_t globalStart;  // cumulative pixel offset in flat DDP stream
+  uint16_t length;       // seg.length() at build time
+};
+WLED_GLOBAL DdpSegSlot ddpSlots[32];                                     // pre-computed offset table
+WLED_GLOBAL uint8_t    ddpSlotCount _INIT(0);                            // valid entries in ddpSlots[]
+WLED_GLOBAL uint16_t   ddpTotalEligible _INIT(0);                        // sum of eligible segment lengths
+
+void rebuildDdpSlots();                                                  // rebuild offset table from ddpEligibleMask
+void freezeSegForRealtime(uint8_t segId);                                // freeze one segment for realtime
+void freezeEligibleSegs();                                               // freeze all eligible segments
+
 WLED_GLOBAL bool realtimeRespectLedMaps _INIT(true);                     // Respect LED maps when receiving realtime data
 
 WLED_GLOBAL unsigned long lastInterfaceUpdate _INIT(0);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -503,7 +503,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormCheckbox(settingsScript,PSTR("NB"),nodeBroadcastEnabled);
 
     printSetFormCheckbox(settingsScript,PSTR("RD"),receiveDirect);
-    printSetFormCheckbox(settingsScript,PSTR("MO"),useMainSegmentOnly);
+    printSetFormCheckbox(settingsScript,PSTR("MO"),(ddpEligibleMask != 0));
     printSetFormCheckbox(settingsScript,PSTR("RLM"),realtimeRespectLedMaps);
     printSetFormValue(settingsScript,PSTR("EP"),e131Port);
     printSetFormCheckbox(settingsScript,PSTR("ES"),e131SkipOutOfSequence);


### PR DESCRIPTION
# Per-segment realtime eligibility mask

Replaces `useMainSegmentOnly` with a `ddpEligibleMask` bitmask. Segments marked
eligible accept DDP/E1.31/Art-Net realtime data; the rest keep running effects.

## Motivation

Multi-segment setups (PC ARGB with fans + matrix, retail video panel + accent
lighting, DJ booth with hub75 + LED strips) need some segments on realtime while
others run local effects. The old boolean was main-segment-only or the entire strip.

Some additional comments from separate DDP Compression conversation #5810.

## Changes

- `ddpEligibleMask` (uint32): per-segment eligibility, cfg key `ddpelig`
- `ddpSlots[]`: pre-computed offset table for flat-stream-to-segment routing
- `rtFrozenSegs` (uint32): tracks which segments are frozen by realtime
- `showFrozenSegs()`: renders frozen segment pixels to bus without re-running effects
- `service()` show gate: skips `show()` when frozen segs exist, prevents race
- `realtimeLock()`/`exitRealtime()`: freeze/unfreeze lifecycle
- `rebuildDdpSlots()` called from config load, segment API changes, and strip init

Files: wled.h, udp.cpp, FX.h, FX_fcn.cpp, e131.cpp, cfg.cpp, json.cpp, wled.cpp,
set.cpp, xml.cpp + audioreactive and EleksTube_IPS usermods (replaced references).

## Backwards compatibility

- `mso=true` in cfg.json migrates to `ddpEligibleMask = (1 << mainSegId)`
- `ddpelig=0` (default) preserves legacy full-strip pixel indexing
- `MO` settings checkbox maps to single-segment mask, same UI behaviour
- cfg.json writes both `mso` (bool) and `ddpelig` (bitmask)
- `liveseg` in `/json/info` now reports the first frozen segment index (via
  `__builtin_ctz(rtFrozenSegs)`) rather than always the main segment ID. When
  `ddpelig` matches the main segment (the common case), the value is identical.
  When `ddpelig` targets a different segment, the reported value reflects the
  actual realtime target -- more useful for diagnostics but a visible change.
- No change for existing senders (OpenRGB, xLights, LedFX, HyperHDR)

## Overhead

- **RAM**: +164B static (ddpSlots[32] = 160B, masks + counters = 4B). Not heap-allocated
  because rebuildDdpSlots() runs from packet handlers.
- **Flash**: ~750B (showFrozenSegs ~70 lines, slot functions ~30 lines)
- **CPU when ddpelig=0**: zero -- all paths gated on ddpSlotCount/rtFrozenSegs

## Testing

Tested on ESP32-PICO-D4 (M5StickC), vanilla esp32dev build, WS2812B 8x32 panel:
- 3 segments: seg0 Rainbow, seg1 DDP-eligible, seg2 Ghost Rider
- During DDP to seg1: `frozensegs=2`, seg0+seg2 effects undisturbed
- Realtime enter/exit cycling: heap stable
- Legacy mode (ddpelig=0): unchanged behaviour
- Audioreactive: audio continues for non-frozen segments

Build: esp32dev SUCCESS, Flash 85.0%, RAM 26.6%.

## Future direction

The slot table and frozen-segment rendering enable a follow-up: per-packet segment
targeting via the DDP destination byte, for video wall compositors that need to route
different content to different segments within a single frame.

Assisted-by: OpenCode/OhMyOpenCode agentic harness with multiple LLM providers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for routing DDP streams across multiple eligible LED segments.
  * Improved realtime rendering with per-segment freezing and optimized output.
  * Added DDP eligibility tracking and expanded status reporting.
* **Bug Fixes**
  * Preserved compatibility with existing “main segment only” configurations.
  * Kept local audio processing active when only selected segments are frozen.
  * Improved realtime timeout handling and restoration of segment states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->