### PR TITLE
feat(realtime): per-segment live input eligibility (replaces useMainSegmentOnly)

### DIFF
--- a/usermods/EleksTube_IPS/TFTs.h
+++ b/usermods/EleksTube_IPS/TFTs.h
@@ -75,7 +75,7 @@ private:
     
     uint8_t lineBuffer[w * 2];
 
-    if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) strip.service();
+    if (!realtimeMode || realtimeOverride || (realtimeMode && strip.useMainSegmentOnly())) strip.service();
 
     // 0,0 coordinates are top left
     for (row = 0; row < h; row++) {
@@ -169,7 +169,7 @@ private:
     uint32_t lineSize = ((bitDepth * w +31) >> 5) * 4;
     uint8_t lineBuffer[lineSize];
     
-    uint8_t serviceStrip = (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) ? 7 : 0;
+    uint8_t serviceStrip = (!realtimeMode || realtimeOverride || (realtimeMode && strip.useMainSegmentOnly())) ? 7 : 0;
     // row is decremented as the BMP image is drawn bottom up
     for (row = h-1; row >= 0; row--) {
       if ((row & 0b00000111) == serviceStrip) strip.service(); //still refresh backlight to mitigate stutter every few rows
@@ -250,7 +250,7 @@ private:
     
     uint8_t lineBuffer[w * 2];
     
-    if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly)) strip.service();
+    if (!realtimeMode || realtimeOverride || (realtimeMode && strip.useMainSegmentOnly())) strip.service();
 
     // 0,0 coordinates are top left
     for (row = 0; row < h; row++) {

--- a/usermods/audioreactive/audio_reactive.cpp
+++ b/usermods/audioreactive/audio_reactive.cpp
@@ -1580,7 +1580,7 @@ class AudioReactive : public Usermod {
 
       // suspend local sound processing when "real time mode" is active (E131, UDP, ADALIGHT, ARTNET, DDP, DMX)
       //  exception: sound input is still needed when useMainSegmentOnly - other segments are still running with local input.
-      if (realtimeMode && !realtimeOverride && !useMainSegmentOnly) {
+      if (realtimeMode && !realtimeOverride && !strip.useMainSegmentOnly()) {
         #if defined(ARDUINO_ARCH_ESP32) && defined(WLED_DEBUG)
         if ((disableSoundProcessing == false) && (audioSyncEnabled == 0)) {  // we just switched to "disabled"
           DEBUG_PRINTLN(F("[AR userLoop]  realtime mode active - audio processing suspended."));

--- a/wled00/FX.h
+++ b/wled00/FX.h
@@ -846,6 +846,7 @@ class WS2812FX {
       _isOffRefreshRequired(false),
       _hasWhiteChannel(false),
       _triggered(false),
+      _liveSegs(0),
       _segment_index(0),
       _mainSegment(0),
       _modeCount(MODE_COUNT),
@@ -923,6 +924,12 @@ class WS2812FX {
     inline bool isOffRefreshRequired() const { return _isOffRefreshRequired; }  // returns true if strip requires regular updates (i.e. TM1814 chipset)
     inline bool isSuspended() const          { return _suspend; }               // returns true if strip.service() execution is suspended
     inline bool needsUpdate() const          { return _triggered; }             // returns true if strip received a trigger() request
+
+    // live segment routing (replaces useMainSegmentOnly global)
+    inline uint32_t getLiveSegs() const                    { return _liveSegs; }
+    inline void     setLiveSegs(uint32_t mask)             { _liveSegs = mask; }
+    inline bool     isLiveSeg(unsigned idx) const          { return idx < 32 && (_liveSegs & (1U << idx)); }
+    inline bool     useMainSegmentOnly() const             { return _liveSegs != 0; }  // backwards compat for usermods
 
     // uint8_t paletteBlend;  // obsolete - use global paletteBlend instead of strip.paletteBlend
     uint8_t getActiveSegmentsNum() const;
@@ -1033,6 +1040,8 @@ class WS2812FX {
       bool _hasWhiteChannel      : 1;
       bool _triggered            : 1;
     };
+
+    uint32_t _liveSegs;             // bitmask of segments receiving live/realtime data; replaces useMainSegmentOnly
 
     uint8_t _segment_index;
     uint8_t _mainSegment;

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1745,7 +1745,7 @@ void WS2812FX::show() {
     _pixelCCT = static_cast<uint8_t*>(allocate_buffer(totalLen * sizeof(uint8_t), BFRALLOC_PREFER_PSRAM)); // allocate CCT buffer if necessary, prefer PSRAM
   if (_pixelCCT) memset(_pixelCCT, 127, totalLen); // set neutral (50:50) CCT
 
-  if (realtimeMode == REALTIME_MODE_INACTIVE || useMainSegmentOnly || realtimeOverride > REALTIME_OVERRIDE_NONE) {
+  if (realtimeMode == REALTIME_MODE_INACTIVE || getLiveSegs() || realtimeOverride > REALTIME_OVERRIDE_NONE) {
     // clear frame buffer
     memset(_pixels, 0, sizeof(uint32_t) * totalLen);
     // blend all segments into (cleared) buffer
@@ -1795,12 +1795,22 @@ void WS2812FX::show() {
 }
 
 void WS2812FX::setRealtimePixelColor(unsigned i, uint32_t c) {
-  if (useMainSegmentOnly) {
-    const Segment &seg = getMainSegment();
-    if (seg.isActive() && i < seg.length()) seg.setPixelColorRaw(i, c);
-  } else {
-    setPixelColor(i, c);
+  if (realtimeMode == REALTIME_MODE_DDP && _liveSegs) { // DDP: route into live segments; other protocols use strip-absolute index
+    unsigned offset = 0;
+    for (unsigned s = 0; s < _segments.size(); s++) {
+      if (!isLiveSeg(s)) continue; // skip non-live segments
+      const Segment &seg = _segments[s];
+      unsigned len = seg.length();
+      if (i < offset + len) {
+        seg.setPixelColorRaw(i - offset, c);
+        return;
+      }
+      offset += len;
+    }
+    return; // i beyond total live pixels -- ignore
   }
+  // legacy path: WARLS, E1.31, Art-Net, Adalight -- strip-absolute index
+  setPixelColor(i, c);
 }
 
 // reset all segments

--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -597,7 +597,13 @@ bool deserializeConfig(JsonObject doc, bool fromFS) {
 
   JsonObject if_live = interfaces["live"];
   CJSON(receiveDirect, if_live["en"]);  // UDP/Hyperion realtime
-  CJSON(useMainSegmentOnly, if_live[F("mso")]);
+  // migrate mso (bool) -> seg (bitmask): new key takes precedence
+  if (!if_live[F("seg")].isNull()) {
+    strip.setLiveSegs(if_live[F("seg")].as<uint32_t>());
+  } else if (!if_live[F("mso")].isNull()) {
+    unsigned id = strip.getMainSegmentId();
+    strip.setLiveSegs((if_live[F("mso")] | false) && id < 32 ? (1U << id) : 0);
+  }
   CJSON(realtimeRespectLedMaps, if_live[F("rlm")]);
   CJSON(e131Port, if_live["port"]); // 5568
   if (e131Port == DDP_DEFAULT_PORT) e131Port = E131_DEFAULT_PORT; // prevent double DDP port allocation
@@ -1135,7 +1141,8 @@ void serializeConfig(JsonObject root) {
 
   JsonObject if_live = interfaces.createNestedObject("live");
   if_live["en"] = receiveDirect; // UDP/Hyperion realtime
-  if_live[F("mso")] = useMainSegmentOnly;
+  if_live[F("mso")] = strip.useMainSegmentOnly(); // downgrade compat: older firmware ignores "seg", reads "mso"
+  if_live[F("seg")] = strip.getLiveSegs();
   if_live[F("rlm")] = realtimeRespectLedMaps;
   if_live["port"] = e131Port;
   if_live[F("mc")] = e131Multicast;

--- a/wled00/json.cpp
+++ b/wled00/json.cpp
@@ -390,8 +390,10 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
     for (size_t s=0; s < strip.getSegmentsNum(); s++) {
       strip.getSegment(s).freeze = false;
     }
-    if (realtimeMode && !realtimeOverride && useMainSegmentOnly) { // keep live segment frozen if live
-      strip.getMainSegment().freeze = true;
+    if (realtimeMode && !realtimeOverride && strip.getLiveSegs()) { // keep live segment frozen if live
+      for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+        if (strip.isLiveSeg(s)) strip.getSegment(s).freeze = true;
+      }
     }
   }
 
@@ -443,9 +445,11 @@ bool deserializeState(JsonObject root, byte callMode, byte presetId)
 
   realtimeOverride = root[F("lor")] | realtimeOverride;
   if (realtimeOverride > 2) realtimeOverride = REALTIME_OVERRIDE_ALWAYS;
-  if (realtimeMode && useMainSegmentOnly) {
-    strip.getMainSegment().freeze = !realtimeOverride;
-    realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using main segment only
+  if (realtimeMode && strip.getLiveSegs()) {
+    for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+      if (strip.isLiveSeg(s)) strip.getSegment(s).freeze = !realtimeOverride;
+    }
+    realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using live segments
   }
 
   if (root.containsKey("live")) {
@@ -769,7 +773,9 @@ void serializeInfo(JsonObject root)
   root[F("udpport")] = udpPort;
   root[F("simplifiedui")] = simplifiedUI;
   root["live"] = (bool)realtimeMode;
-  root[F("liveseg")] = useMainSegmentOnly ? strip.getMainSegmentId() : -1;  // if using main segment only for live
+  // liveseg: lowest live segment index, or -1 if none. high bit guards __builtin_ctz(0) UB.
+  root[F("liveseg")]  = strip.getLiveSegs() ? (int)__builtin_ctz(strip.getLiveSegs() | (1U << 31)) : -1;
+  root[F("livesegs")] = strip.getLiveSegs(); // full bitmask
 
   switch (realtimeMode) {
     case REALTIME_MODE_INACTIVE: root["lm"] = ""; break;

--- a/wled00/set.cpp
+++ b/wled00/set.cpp
@@ -472,7 +472,8 @@ void handleSettingsSet(AsyncWebServerRequest *request, byte subPage)
     nodeBroadcastEnabled = request->hasArg(F("NB"));
 
     receiveDirect = request->hasArg(F("RD")); // UDP realtime
-    useMainSegmentOnly = request->hasArg(F("MO"));
+    unsigned id = strip.getMainSegmentId();
+    strip.setLiveSegs(request->hasArg(F("MO")) && id < 32 ? (1U << id) : 0);
     realtimeRespectLedMaps = request->hasArg(F("RLM"));
     e131SkipOutOfSequence = request->hasArg(F("ES"));
     e131Multicast = request->hasArg(F("EM"));
@@ -1265,9 +1266,12 @@ bool handleSet(AsyncWebServerRequest *request, const String& req, bool apply)
   if (pos > 0) {
     realtimeOverride = getNumVal(req, pos);
     if (realtimeOverride > 2) realtimeOverride = REALTIME_OVERRIDE_ALWAYS;
-    if (realtimeMode && useMainSegmentOnly) {
-      strip.getMainSegment().freeze = !realtimeOverride;
-      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using main segment only
+    if (realtimeMode && strip.getLiveSegs()) {
+      for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+        if (strip.isLiveSeg(s))
+          strip.getSegment(s).freeze = !realtimeOverride;
+      }
+      realtimeOverride = REALTIME_OVERRIDE_NONE;  // ignore request for override if using live segments
     }
   }
 

--- a/wled00/udp.cpp
+++ b/wled00/udp.cpp
@@ -408,11 +408,15 @@ static void parseNotifyPacket(const uint8_t *udpIn) {
 void realtimeLock(uint32_t timeoutMs, byte md)
 {
   if (!realtimeMode && !realtimeOverride) {
-    if (useMainSegmentOnly) {
-      Segment& mainseg = strip.getMainSegment();
-      mainseg.clear(); // clear entire segment (in case sender transmits less pixels)
-      mainseg.freeze = true;
-      // if WLED was off and using main segment only, freeze non-main segments so they stay off
+    if (strip.getLiveSegs()) {
+      for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+        if (!strip.isLiveSeg(s)) continue;
+        Segment &seg = strip.getSegment(s);
+        if (!seg.isActive()) continue;
+        seg.clear(); // clear pixel buffer (sender may transmit fewer pixels)
+        seg.freeze = true; // freeze: skip effect, retain realtime-written pixels
+      }
+      // if WLED was off, freeze non-live segments so they stay off
       if (bri == 0) {
         for (size_t s = 0; s < strip.getSegmentsNum(); s++) strip.getSegment(s).freeze = true;
       }
@@ -443,8 +447,11 @@ void exitRealtime() {
   realtimeTimeout = 0; // cancel realtime mode immediately
   realtimeMode = REALTIME_MODE_INACTIVE; // inform UI immediately
   realtimeIP[0] = 0;
-  if (useMainSegmentOnly) { // unfreeze live segment again
-    strip.getMainSegment().freeze = false;
+  if (strip.getLiveSegs()) { // unfreeze live segment again
+    for (size_t s = 0; s < strip.getSegmentsNum(); s++) {
+      if (strip.isLiveSeg(s) && strip.getSegment(s).freeze)
+        strip.getSegment(s).freeze = false;
+    }
     strip.trigger();
   } else {
     strip.show(); // possible fix for #3589
@@ -475,8 +482,8 @@ void handleNotifications()
   if (e131NewData && millis() - strip.getLastShow() > 15)
   {
     e131NewData = false;
-    if (useMainSegmentOnly) strip.trigger();
-    else                    strip.show();
+    if (strip.getLiveSegs()) strip.trigger();
+    else                     strip.show();
   }
 
   //unlock strip when realtime UDP times out
@@ -508,8 +515,8 @@ void handleNotifications()
       for (size_t i = 0, id = 0; i < packetSize -2 && id < totalLen; i += 3, id++) {
         setRealtimePixel(id, lbuf[i], lbuf[i+1], lbuf[i+2], 0);
       }
-      if (useMainSegmentOnly) strip.trigger();
-      else                    strip.show();
+      if (strip.getLiveSegs()) strip.trigger();
+      else                     strip.show();
       return;
     }
   }
@@ -592,8 +599,8 @@ void handleNotifications()
       }
       if (tpmPacketCount == numPackets) { //reset packet count and show if all packets were received
         tpmPacketCount = 0;
-        if (useMainSegmentOnly) strip.trigger();
-        else                    strip.show();
+        if (strip.getLiveSegs()) strip.trigger();
+        else                     strip.show();
       }
       return;
     }
@@ -637,8 +644,8 @@ void handleNotifications()
           setRealtimePixel(id, udpIn[i], udpIn[i+1], udpIn[i+2], udpIn[i+3]);
         }
       }
-      if (useMainSegmentOnly) strip.trigger();
-      else                    strip.show();
+      if (strip.getLiveSegs()) strip.trigger();
+      else                     strip.show();
       return;
     }
   }
@@ -665,7 +672,7 @@ void handleNotifications()
 
 void setRealtimePixel(uint16_t i, byte r, byte g, byte b, byte w)
 {
-  unsigned pix = i + arlsOffset;
+  unsigned pix = (realtimeMode == REALTIME_MODE_DDP && strip.getLiveSegs()) ? i : i + arlsOffset;
   strip.setRealtimePixelColor(pix, RGBW32(r,g,b,w));
 }
 

--- a/wled00/wled.cpp
+++ b/wled00/wled.cpp
@@ -128,7 +128,7 @@ void WLED::loop()
   #ifdef WLED_DEBUG
   stripMillis = millis();
   #endif
-  if (!realtimeMode || realtimeOverride || (realtimeMode && useMainSegmentOnly))  // block stuff if WARLS/Adalight is enabled
+  if (!realtimeMode || realtimeOverride || (realtimeMode && strip.getLiveSegs()))  // block stuff if WARLS/Adalight is enabled
   {
     if (apActive) dnsServer.processNextRequest();
     #ifdef WLED_ENABLE_AOTA

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -725,7 +725,6 @@ WLED_GLOBAL IPAddress realtimeIP _INIT_N(((0, 0, 0, 0)));
 WLED_GLOBAL unsigned long realtimeTimeout _INIT(0);
 WLED_GLOBAL uint8_t tpmPacketCount _INIT(0);
 WLED_GLOBAL uint16_t tpmPayloadFrameSize _INIT(0);
-WLED_GLOBAL bool useMainSegmentOnly _INIT(false);
 WLED_GLOBAL bool realtimeRespectLedMaps _INIT(true);                     // Respect LED maps when receiving realtime data
 
 WLED_GLOBAL unsigned long lastInterfaceUpdate _INIT(0);

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -503,7 +503,7 @@ void getSettingsJS(byte subPage, Print& settingsScript)
     printSetFormCheckbox(settingsScript,PSTR("NB"),nodeBroadcastEnabled);
 
     printSetFormCheckbox(settingsScript,PSTR("RD"),receiveDirect);
-    printSetFormCheckbox(settingsScript,PSTR("MO"),useMainSegmentOnly);
+    printSetFormCheckbox(settingsScript,PSTR("MO"),strip.useMainSegmentOnly());
     printSetFormCheckbox(settingsScript,PSTR("RLM"),realtimeRespectLedMaps);
     printSetFormValue(settingsScript,PSTR("EP"),e131Port);
     printSetFormCheckbox(settingsScript,PSTR("ES"),e131SkipOutOfSequence);


### PR DESCRIPTION
Rework of #5817. Addresses all the review feedback from @softhack007 and
@netmindz.

The `useMainSegmentOnly` bool is replaced with a `uint32_t _liveSegs` bitmask
on the strip object. Each bit marks a segment as eligible for realtime data.
Eligible segments get frozen (effects suppressed) during live input; everything
else keeps running normally.

#### What changed

- `useMainSegmentOnly` global removed from `wled.h`
- `_liveSegs` bitmask added to `WS2812FX`, with `getLiveSegs()`,
  `setLiveSegs()`, `isLiveSeg()` accessors
- `useMainSegmentOnly()` kept as an inline (`_liveSegs != 0`) so existing
  usermods compile without changes
- DDP pixel routing writes into `seg.pixels[]` via `setPixelColorRaw()`, same
  as upstream's `useMainSegmentOnly` path did via `getMainSegment()`. The
  difference is that it now routes across multiple segments instead of just one
- Other protocols (WARLS, E1.31, Art-Net, Adalight, TPM2.NET) are unchanged,
  strip-absolute via `setPixelColor()`
- `arlsOffset` is skipped when DDP per-segment routing is active. I had a good
  look and think about the scenarios where this might be useful and came to the
  conclusion that this will never make sense and is safe to skip because
  the segment layout already defines the physical mapping
- Config: new `"seg"` key (uint32_t bitmask) alongside `"mso"` (bool, kept for
  firmware downgrade compat). `"seg"` takes precedence on load. Old configs with
  only `"mso"` are migrated to `1 << mainSegmentId`
- `/json/info`: `"liveseg"` still reports the lowest live segment index (or -1).
  New `"livesegs"` field has the full bitmask

#### What did NOT change (v1 feedback)

- No new rendering paths. No showFrozenSegs, no rebuildDdpSlots. The existing
  `service()` / `show()` / `blendSegment()` pipeline handles frozen segments
  correctly, I just didn't trace it far enough in v1.
- No service() gate. `strip.trigger()`, `needsUpdate()`,
  `isOffRefreshRequired()` all intact.
- No new globals.
- Usermods compile without modification (verified EleksTube_IPS, audioreactive).

#### Why DDP only gets per-segment routing

E1.31 and Art-Net have their own universe/channel addressing via `DMXAddress`
and `dataOffset`. Routing them through `_liveSegs` would conflict with that.
WARLS, Hyperion, and TPM2.NET have no segment concept in the protocol. DDP is
the only protocol where a flat pixel buffer needs the device to decide which
segment each pixel lands in. The gate in `setRealtimePixelColor()` is explicit;
other protocols can be added to it if there's a use case.

**Behaviour change worth discussing:** In upstream, `useMainSegmentOnly` routed
all protocols through `getMainSegment().setPixelColorRaw()`. This branch
narrows that to DDP only. Hyperion/WARLS with `_liveSegs` set will produce
black output where upstream would have worked, because their data goes to
`_pixels[]` which gets wiped by `show()`.

In practice `_liveSegs` is doing double duty: controlling freeze/unfreeze for
all protocols AND pixel routing for DDP. One option is to split this into two
config keys, something like keeping `"mso"` for freeze behaviour across all
protocols and adding a DDP-specific `"ddpseg"` for per-segment routing. I'd
rather get your input on the right config structure than guess at it.

#### Known limitations

- `uint32_t` limits coverage to 32 segments. PSRAM boards with
  `MAX_NUM_SEGMENTS=64` silently ignore segments 32-63. Widening to `uint64_t`
  would need `ARDUINOJSON_USE_LONG_LONG=1` project-wide; that's a separate
  discussion.
- `seg.freeze` is a 1-bit field packed with adjacent flags in the same byte.
  Setting it from the UDP callback while the service loop writes a different bit
  in the same byte is a non-atomic RMW. Pre-existing, not introduced here.
- Segment deletion or reorder during active realtime can leave `_liveSegs`
  pointing at the wrong segment. This is existing upstream behaviour:
  `useMainSegmentOnly` had the same issue with the main segment ID shifting
  on reorder. Needs its own discussion about how/if WLED wants to handle live
  segment changes during streaming.

#### Config API

```bash
# segments 0 and 2 eligible (bitmask 5 = 0b101)
curl -X POST http://<device>/json/cfg -d '{"if":{"live":{"seg":5}}}'

# clear (back to normal)
curl -X POST http://<device>/json/cfg -d '{"if":{"live":{"seg":0}}}'
```

The settings UI checkbox ("Use main segment only") still works. It sets
`_liveSegs = 1 << mainSegmentId`, same behaviour as before.

#### Build and test

esp32dev: SUCCESS, Flash 84.9%, RAM 26.5%, zero errors.

Tested on ESP32-PICO-D4 (M5StickC) with WS2812B strips and SPI TFT, DDP over
UDP. I don't have TM1814, WARLS sender, or Hub75 hardware; I verified those
code paths by reading the source.

Assisted-by: OpenCode with various LLMs (analysis and code generation). Testing
and verification by author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realtime data can now target multiple selected LED segments instead of only the main segment.
  * Added live-segment controls and status information for configuration and API clients.
  * DDP and other realtime protocols now route updates correctly across selected segments.

* **Bug Fixes**
  * Improved segment freezing, blending, and realtime overrides when multiple live segments are configured.
  * Preserved compatibility with existing “main segment only” configurations and older settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->